### PR TITLE
Load window size/position

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -199,6 +199,9 @@ void vcMain_LoadSettings(vcState *pProgramState, bool forceDefaults)
     case 1: ImGui::StyleColorsDark(); break;
     case 2: ImGui::StyleColorsLight(); break;
     }
+
+    SDL_SetWindowSize(pProgramState->pWindow, pProgramState->settings.window.width, pProgramState->settings.window.height);
+    SDL_SetWindowPosition(pProgramState->pWindow, pProgramState->settings.window.xpos, pProgramState->settings.window.ypos);
   }
 }
 

--- a/src/vcSettings.cpp
+++ b/src/vcSettings.cpp
@@ -261,15 +261,12 @@ bool vcSettings_Load(vcSettings *pSettings, bool forceReset /*= false*/, vcSetti
 
   if (group == vcSC_All)
   {
-    if (pSettings->docksLoaded != vcSettings::vcDockLoaded::vcDL_True)
-    {
-      // Windows
-      pSettings->window.xpos = data.Get("window.position.x").AsInt(SDL_WINDOWPOS_CENTERED);
-      pSettings->window.ypos = data.Get("window.position.y").AsInt(SDL_WINDOWPOS_CENTERED);
-      pSettings->window.width = data.Get("window.width").AsInt(1280);
-      pSettings->window.height = data.Get("window.height").AsInt(720);
-      pSettings->window.maximized = data.Get("window.maximized").AsBool(false);
-    }
+    // Windows
+    pSettings->window.xpos = data.Get("window.position.x").AsInt(SDL_WINDOWPOS_CENTERED);
+    pSettings->window.ypos = data.Get("window.position.y").AsInt(SDL_WINDOWPOS_CENTERED);
+    pSettings->window.width = data.Get("window.width").AsInt(1280);
+    pSettings->window.height = data.Get("window.height").AsInt(720);
+    pSettings->window.maximized = data.Get("window.maximized").AsBool(false);
 
     udStrcpy(pSettings->window.languageCode, data.Get("window.language").AsString("enAU"));
 


### PR DESCRIPTION
Applies loaded window size/position to the window, removed limitation on dock loaded state because loading defaults is now on the login screen