### PR TITLE
Retain world anchor point while smoothing

### DIFF
--- a/src/vcCamera.cpp
+++ b/src/vcCamera.cpp
@@ -842,7 +842,7 @@ void vcCamera_HandleSceneInput(vcState *pProgramState, udDouble3 oscMove, udFloa
 
   vcCamera_Apply(pProgramState, pProgramState->pCamera, &pProgramState->settings.camera, &pProgramState->cameraInput, pProgramState->deltaTime, speedModifier);
 
-  if (pProgramState->cameraInput.inputState == vcCIS_None)
+  if (pProgramState->cameraInput.inputState == vcCIS_None && pProgramState->cameraInput.smoothOrthographicChange == 0.0)
     pProgramState->isUsingAnchorPoint = false;
 
   vcCamera_UpdateMatrices(pProgramState->pCamera, pProgramState->settings.camera, windowSize, &mousePos);


### PR DESCRIPTION
Retain world anchor point while smoothing is nonzero

Resolves [AB#148](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/148)