### PR TITLE
ImageRenderer now uses appropriate shaders

### DIFF
--- a/src/gl/directx11/vcRenderShaders.cpp
+++ b/src/gl/directx11/vcRenderShaders.cpp
@@ -712,7 +712,7 @@ const char* const g_PolygonP1N1UV1VertexShader = R"shader(
   }
 )shader";
 
-const char* const g_PolygonP1UV1FragmentShader = R"shader(
+const char *const g_ImageRendererFragmentShader = R"shader(
   struct PS_INPUT
   {
     float4 pos : SV_POSITION;
@@ -730,10 +730,11 @@ const char* const g_PolygonP1UV1FragmentShader = R"shader(
   }
 )shader";
 
-const char* const g_PolygonP1UV1VertexShader = R"shader(
+const char *const g_ImageRendererMeshVertexShader = R"shader(
   struct VS_INPUT
   {
     float3 pos : POSITION;
+    float3 normal : NORMAL; // unused
     float2 uv  : TEXCOORD0;
   };
 
@@ -756,32 +757,14 @@ const char* const g_PolygonP1UV1VertexShader = R"shader(
     PS_INPUT output;
 
     output.pos = mul(u_modelViewProjectionMatrix, float4(input.pos, 1.0));
-    output.uv = float2(input.uv.x, 1.0 - input.uv.y);
+    output.uv = input.uv;
     output.colour = u_colour;
 
     return output;
   }
 )shader";
 
-const char* const g_BillboardFragmentShader = R"shader(
-  struct PS_INPUT
-  {
-    float4 pos : SV_POSITION;
-    float2 uv : TEXCOORD0;
-    float4 colour : COLOR0;
-  };
-
-  sampler sampler0;
-  Texture2D texture0;
-
-  float4 main(PS_INPUT input) : SV_Target
-  {
-    float4 col = texture0.Sample(sampler0, input.uv);
-    return col * input.colour;
-  }
-)shader";
-
-const char* const g_BillboardVertexShader = R"shader(
+const char *const g_ImageRendererBillboardVertexShader = R"shader(
   struct VS_INPUT
   {
     float3 pos : POSITION;
@@ -808,13 +791,13 @@ const char* const g_BillboardVertexShader = R"shader(
 
     output.pos = mul(u_modelViewProjectionMatrix, float4(input.pos, 1.0));
     output.pos.xy += u_screenSize.z * output.pos.w * u_screenSize.xy * float2(input.uv.x * 2.0 - 1.0, input.uv.y * 2.0 - 1.0); // expand billboard
+
     output.uv = float2(input.uv.x, 1.0 - input.uv.y);
     output.colour = u_colour;
 
     return output;
   }
 )shader";
-
 
 const char* const g_FlatColour_FragmentShader = R"shader(
   struct PS_INPUT

--- a/src/gl/metal/Shaders.metal
+++ b/src/gl/metal/Shaders.metal
@@ -518,7 +518,7 @@ PNUVFragmentShader(PNUVSOutput in [[stage_in]], texture2d<float, access::sample>
 }
 
 
-// g_PolygonP1UV1FragmentShader
+// g_ImageRendererFragmentShader
 struct PUC
 {
     float4 pos [[position]];
@@ -527,20 +527,21 @@ struct PUC
 };
 
 fragment float4
-PUVFragmentShader(PUC in [[stage_in]], texture2d<float, access::sample> PUFSimg [[texture(0)]], sampler PUFSsampler [[sampler(0)]])
+imageRendererFragmentShader(PUC in [[stage_in]], texture2d<float, access::sample> IRFSimg [[texture(0)]], sampler IRFSsampler [[sampler(0)]])
 {
-    float4 col = PUFSimg.sample(PUFSsampler, in.uv);
+    float4 col = IRFSimg.sample(PUFSsampler, in.uv);
     return col * in.color;
 }
 
-// g_PolygonP1UV1VertexShader
-struct PUVVSInput
+// g_ImageRendererMeshVertexShader
+struct PNUVVSInput
 {
     float3 pos [[attribute(0)]];
-    float2 uv [[attribute(1)]];
+    float3 normal [[attribute(1)]]; // unused
+    float2 uv [[attribute(2)]];
 };
 
-struct PUVVSUniforms
+struct IRMVSUniforms
 {
     float4x4 u_modelViewProjectionMatrix;
     float4 u_color;
@@ -548,7 +549,7 @@ struct PUVVSUniforms
 };
 
 vertex PUC
-PUVVertexShader(PUVVSInput in [[stage_in]], constant PUVVSUniforms& uniforms [[buffer(1)]])
+imageRendererMeshVertexShader(PNUVVSInput in [[stage_in]], constant IRMVSUniforms& uniforms [[buffer(1)]])
 {
     PUC out;
     
@@ -559,22 +560,14 @@ PUVVertexShader(PUVVSInput in [[stage_in]], constant PUVVSUniforms& uniforms [[b
     return out;
 }
 
-// g_BillboardFragmentShader
-fragment float4
-billboardFragmentShader(PUC in [[stage_in]], texture2d<float, access::sample> BFSimg [[texture(0)]], sampler BFSsampler [[sampler(0)]])
-{
-    float4 col = BFSimg.sample(BFSsampler, in.uv);
-    return col * in.color;
-}
-
-// g_BillboardVertexShader
-struct BVSInput
+// g_ImageRendererBillboardVertexShader
+struct IRBVSInput
 {
     float3 pos [[attribute(0)]];
     float2 uv [[attribute(1)]];
 };
 
-struct BVSUniforms
+struct IRBVSUniforms
 {
     float4x4 u_modelViewProjectionMatrix;
     float4 u_color;
@@ -582,7 +575,7 @@ struct BVSUniforms
 };
 
 vertex PUC
-billboardVertexShader(BVSInput in [[stage_in]], constant BVSUniforms& uniforms [[buffer(1)]])
+imageRendererBillboardVertexShader(IRBVSInput in [[stage_in]], constant IRBVSUniforms& uniforms [[buffer(1)]])
 {
     PUC out;
     

--- a/src/gl/metal/Shaders.metal
+++ b/src/gl/metal/Shaders.metal
@@ -529,7 +529,7 @@ struct PUC
 fragment float4
 imageRendererFragmentShader(PUC in [[stage_in]], texture2d<float, access::sample> IRFSimg [[texture(0)]], sampler IRFSsampler [[sampler(0)]])
 {
-    float4 col = IRFSimg.sample(PUFSsampler, in.uv);
+    float4 col = IRFSimg.sample(IRFSsampler, in.uv);
     return col * in.color;
 }
 

--- a/src/gl/metal/vcRenderShaders.cpp
+++ b/src/gl/metal/vcRenderShaders.cpp
@@ -26,13 +26,11 @@ const char* const g_WaterVertexShader = "waterVertexShader";
 const char* const g_PolygonP1N1UV1FragmentShader = "PNUVFragmentShader";
 const char* const g_PolygonP1N1UV1VertexShader = "PNUVVertexShader";
 
-const char* const g_PolygonP1UV1VertexShader = "PUVVertexShader";
-const char* const g_PolygonP1UV1FragmentShader = "PUVFragmentShader";
-
 const char* const g_FlatColour_FragmentShader = "flatColourFragmentShader";
 
-const char* const g_BillboardVertexShader = "billboardVertexShader";
-const char* const g_BillboardFragmentShader = "billboardFragmentShader";
+const char *const g_ImageRendererFragmentShader = "imageRendererFragmentShader";
+const char *const g_ImageRendererMeshVertexShader = "imageRendererMeshVertexShader";
+const char *const g_ImageRendererBillboardVertexShader = "imageRendererBillboardVertexShader";
 
 const char *const g_BlurVertexShader = "blurVertexShader";
 const char *const g_BlurFragmentShader = "blurFragmentShader";

--- a/src/gl/opengl/vcRenderShaders.cpp
+++ b/src/gl/opengl/vcRenderShaders.cpp
@@ -629,7 +629,7 @@ const char* const g_PolygonP1N1UV1VertexShader = VERT_HEADER R"shader(
   }
 )shader";
 
-const char* const g_PolygonP1UV1FragmentShader = FRAG_HEADER R"shader(
+const char *const g_ImageRendererFragmentShader = FRAG_HEADER R"shader(
   //Input Format
   in vec2 v_uv;
   in vec4 v_colour;
@@ -646,10 +646,11 @@ const char* const g_PolygonP1UV1FragmentShader = FRAG_HEADER R"shader(
   }
 )shader";
 
-const char* const g_PolygonP1UV1VertexShader = VERT_HEADER R"shader(
+const char *const g_ImageRendererMeshVertexShader = VERT_HEADER R"shader(
   //Input Format
   layout(location = 0) in vec3 a_pos;
-  layout(location = 1) in vec2 a_uv;
+  layout(location = 1) in vec3 a_normal; //unused
+  layout(location = 2) in vec2 a_uv;
 
   //Output Format
   out vec2 v_uv;
@@ -666,29 +667,12 @@ const char* const g_PolygonP1UV1VertexShader = VERT_HEADER R"shader(
   {
     gl_Position = u_modelViewProjectionMatrix * vec4(a_pos, 1.0);
 
-    v_uv = vec2(a_uv.x, 1.0 - a_uv.y);
+    v_uv = a_uv;
     v_colour = u_colour;
   }
 )shader";
 
-const char* const g_BillboardFragmentShader = FRAG_HEADER R"shader(
-  //Input Format
-  in vec2 v_uv;
-  in vec4 v_colour;
-
-  //Output Format
-  out vec4 out_Colour;
-
-  uniform sampler2D u_texture;
-
-  void main()
-  {
-    vec4 col = texture(u_texture, v_uv);
-    out_Colour = col * v_colour;
-  }
-)shader";
-
-const char* const g_BillboardVertexShader = VERT_HEADER R"shader(
+const char *const g_ImageRendererBillboardVertexShader = VERT_HEADER R"shader(
   //Input Format
   layout(location = 0) in vec3 a_pos;
   layout(location = 1) in vec2 a_uv;

--- a/src/gl/vcRenderShaders.h
+++ b/src/gl/vcRenderShaders.h
@@ -3,46 +3,46 @@
 
 #include "vcGLState.h"
 
-extern const char* const g_udFragmentShader;
-extern const char* const g_udSplatIdFragmentShader;
-extern const char* const g_udVertexShader;
-extern const char* const g_tileFragmentShader;
-extern const char* const g_tileVertexShader;
-extern const char* const g_vcSkyboxFragmentShaderPanarama;
-extern const char* const g_vcSkyboxFragmentShaderImageColour;
-extern const char* const g_vcSkyboxVertexShader;
-extern const char* const g_FenceVertexShader;
-extern const char* const g_FenceFragmentShader;
-extern const char* const g_WaterVertexShader;
-extern const char* const g_WaterFragmentShader;
+extern const char *const g_udFragmentShader;
+extern const char *const g_udSplatIdFragmentShader;
+extern const char *const g_udVertexShader;
+extern const char *const g_tileFragmentShader;
+extern const char *const g_tileVertexShader;
+extern const char *const g_vcSkyboxFragmentShaderPanarama;
+extern const char *const g_vcSkyboxFragmentShaderImageColour;
+extern const char *const g_vcSkyboxVertexShader;
+extern const char *const g_FenceVertexShader;
+extern const char *const g_FenceFragmentShader;
+extern const char *const g_WaterVertexShader;
+extern const char *const g_WaterFragmentShader;
 
-extern const char* const g_CompassFragmentShader;
-extern const char* const g_CompassVertexShader;
+extern const char *const g_CompassFragmentShader;
+extern const char *const g_CompassVertexShader;
 
-extern const char* const g_ImGuiVertexShader;
-extern const char* const g_ImGuiFragmentShader;
+extern const char *const g_ImGuiVertexShader;
+extern const char *const g_ImGuiFragmentShader;
 
 // Polygon shaders
-extern const char* const g_PolygonP1N1UV1FragmentShader;
-extern const char* const g_PolygonP1N1UV1VertexShader;
-extern const char* const g_PolygonP1UV1FragmentShader;
-extern const char* const g_PolygonP1UV1VertexShader;
-extern const char* const g_FlatColour_FragmentShader;
+extern const char *const g_PolygonP1N1UV1FragmentShader;
+extern const char *const g_PolygonP1N1UV1VertexShader;
+extern const char *const g_FlatColour_FragmentShader;
 
-extern const char* const g_BillboardFragmentShader;
-extern const char* const g_BillboardVertexShader;
+// Image Renderer shaders
+extern const char *const g_ImageRendererFragmentShader;
+extern const char *const g_ImageRendererMeshVertexShader;
+extern const char *const g_ImageRendererBillboardVertexShader;
 
 // Utility Shaders
-extern const char* const g_BlurVertexShader;
-extern const char* const g_BlurFragmentShader;
-extern const char* const g_HighlightVertexShader;
-extern const char* const g_HighlightFragmentShader;
+extern const char *const g_BlurVertexShader;
+extern const char *const g_BlurFragmentShader;
+extern const char *const g_HighlightVertexShader;
+extern const char *const g_HighlightFragmentShader;
 
 // GPU UD Renderer
-extern const char* const g_udGPURenderQuadVertexShader;
-extern const char* const g_udGPURenderQuadFragmentShader;
-extern const char* const g_udGPURenderGeomVertexShader;
-extern const char* const g_udGPURenderGeomFragmentShader;
-extern const char* const g_udGPURenderGeomGeometryShader;
+extern const char *const g_udGPURenderQuadVertexShader;
+extern const char *const g_udGPURenderQuadFragmentShader;
+extern const char *const g_udGPURenderGeomVertexShader;
+extern const char *const g_udGPURenderGeomFragmentShader;
+extern const char *const g_udGPURenderGeomGeometryShader;
 
 #endif//vcRenderShaders_h__

--- a/src/rendering/vcImageRenderer.cpp
+++ b/src/rendering/vcImageRenderer.cpp
@@ -39,9 +39,9 @@ void vcImageRenderer_Init()
   gRefCount++;
   if (gRefCount == 1)
   {
-    vcShader_CreateFromText(&gShaders[vcIT_StandardPhoto].pShader, g_BillboardVertexShader, g_BillboardFragmentShader, vcP3UV2VertexLayout);
-    vcShader_CreateFromText(&gShaders[vcIT_PhotoSphere].pShader, g_PolygonP1N1UV1VertexShader, g_PolygonP1N1UV1FragmentShader, vcP3N3UV2VertexLayout);
-    vcShader_CreateFromText(&gShaders[vcIT_Panorama].pShader, g_PolygonP1N1UV1VertexShader, g_PolygonP1N1UV1FragmentShader, vcP3N3UV2VertexLayout);
+    vcShader_CreateFromText(&gShaders[vcIT_StandardPhoto].pShader, g_ImageRendererBillboardVertexShader, g_ImageRendererFragmentShader, vcP3UV2VertexLayout);
+    vcShader_CreateFromText(&gShaders[vcIT_PhotoSphere].pShader, g_ImageRendererMeshVertexShader, g_ImageRendererFragmentShader, vcP3N3UV2VertexLayout);
+    vcShader_CreateFromText(&gShaders[vcIT_Panorama].pShader, g_ImageRendererMeshVertexShader, g_ImageRendererFragmentShader, vcP3N3UV2VertexLayout);
 
     for (int i = 0; i < vcIT_Count; ++i)
     {


### PR DESCRIPTION
ImageRenderer shaders now matches expected attributes and uniforms.
Renamed some shaders to be more understandable.
Removed duplicated fragment shader.

Fixes [AB#326](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/326)