### PR TITLE
Improvements to internal handling of texture formats

### DIFF
--- a/src/gl/directx11/vcFramebuffer.cpp
+++ b/src/gl/directx11/vcFramebuffer.cpp
@@ -1,12 +1,17 @@
 #include "gl/vcFramebuffer.h"
 #include "vcD3D11.h"
 
-bool vcFramebuffer_Create(vcFramebuffer **ppFramebuffer, vcTexture *pTexture, vcTexture *pDepth /*= nullptr*/, int level /*= 0*/)
+bool vcFramebuffer_Create(vcFramebuffer **ppFramebuffer, vcTexture *pTexture, vcTexture *pDepth /*= nullptr*/, uint32_t level /*= 0*/)
 {
-  vcFramebuffer *pFramebuffer = udAllocType(vcFramebuffer, 1, udAF_Zero);
+  if (ppFramebuffer == nullptr || pTexture == nullptr)
+    return false;
 
+  udResult result = udR_Success;
   D3D11_RENDER_TARGET_VIEW_DESC renderTargetViewDesc;
   memset(&renderTargetViewDesc, 0, sizeof(renderTargetViewDesc));
+
+  vcFramebuffer *pFramebuffer = udAllocType(vcFramebuffer, 1, udAF_Zero);
+  UD_ERROR_NULL(pFramebuffer, udR_MemoryAllocationFailure);
 
   renderTargetViewDesc.Format = pTexture->d3dFormat;
   renderTargetViewDesc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2D;
@@ -27,7 +32,13 @@ bool vcFramebuffer_Create(vcFramebuffer **ppFramebuffer, vcTexture *pTexture, vc
   }
 
   *ppFramebuffer = pFramebuffer;
-  return true;
+  pFramebuffer = nullptr;
+
+epilogue:
+  if (pFramebuffer != nullptr)
+    vcFramebuffer_Destroy(&pFramebuffer);
+
+  return result == udR_Success;
 }
 
 void vcFramebuffer_Destroy(vcFramebuffer **ppFramebuffer)

--- a/src/gl/metal/vcFramebuffer.mm
+++ b/src/gl/metal/vcFramebuffer.mm
@@ -1,13 +1,17 @@
 #import "gl/vcFramebuffer.h"
 #import "vcMetal.h"
 
-bool vcFramebuffer_Create(vcFramebuffer **ppFramebuffer, vcTexture *pTexture, vcTexture *pDepth /*= nullptr*/, int level /*= 0*/)
+bool vcFramebuffer_Create(vcFramebuffer **ppFramebuffer, vcTexture *pTexture, vcTexture *pDepth /*= nullptr*/, uint32_t level /*= 0*/)
 {
-  if (ppFramebuffer == nullptr)
+  udUnused(level);
+
+  if (ppFramebuffer == nullptr || pTexture == nullptr)
     return false;
 
-  udUnused(level);
+  udResult result = udR_Success;
+
   vcFramebuffer *pFramebuffer = udAllocType(vcFramebuffer, 1, udAF_Zero);
+  UD_ERROR_NULL(pFramebuffer, udR_MemoryAllocationFailure);
 
   pFramebuffer->pColor = pTexture;
   pFramebuffer->pDepth = pDepth;
@@ -21,7 +25,11 @@ bool vcFramebuffer_Create(vcFramebuffer **ppFramebuffer, vcTexture *pTexture, vc
   *ppFramebuffer = pFramebuffer;
   pFramebuffer = nullptr;
 
-  return true;
+epilogue:
+  if (pFramebuffer != nullptr)
+    vcFramebuffer_Destroy(&pFramebuffer);
+
+  return result == udR_Success;
 }
 
 void vcFramebuffer_Destroy(vcFramebuffer **ppFramebuffer)

--- a/src/gl/opengl/vcFramebuffer.cpp
+++ b/src/gl/opengl/vcFramebuffer.cpp
@@ -1,10 +1,16 @@
 #include "gl/vcFramebuffer.h"
 #include "vcOpenGL.h"
 
-bool vcFramebuffer_Create(vcFramebuffer **ppFramebuffer, vcTexture *pTexture, vcTexture *pDepth /*= nullptr*/, int level /*= 0*/)
+bool vcFramebuffer_Create(vcFramebuffer **ppFramebuffer, vcTexture *pTexture, vcTexture *pDepth /*= nullptr*/, uint32_t level /*= 0*/)
 {
+  if (ppFramebuffer == nullptr || pTexture == nullptr)
+    return false;
+
+  udResult result = udR_Success;
+  static const GLenum DrawBuffers[] = { GL_COLOR_ATTACHMENT0 };
+
   vcFramebuffer *pFramebuffer = udAllocType(vcFramebuffer, 1, udAF_Zero);
-  GLenum DrawBuffers[] = { GL_COLOR_ATTACHMENT0 };
+  UD_ERROR_NULL(pFramebuffer, udR_MemoryAllocationFailure);
 
   glGenFramebuffers(1, &pFramebuffer->id);
   glBindFramebuffer(GL_DRAW_FRAMEBUFFER, pFramebuffer->id);
@@ -27,7 +33,14 @@ bool vcFramebuffer_Create(vcFramebuffer **ppFramebuffer, vcTexture *pTexture, vc
   pFramebuffer->pDepth = pDepth;
 
   *ppFramebuffer = pFramebuffer;
-  return true;
+  pFramebuffer = nullptr;
+
+epilogue:
+  if (pFramebuffer != nullptr)
+    vcFramebuffer_Destroy(&pFramebuffer);
+
+  VERIFY_GL();
+  return result == udR_Success;
 }
 
 void vcFramebuffer_Destroy(vcFramebuffer **ppFramebuffer)
@@ -37,6 +50,8 @@ void vcFramebuffer_Destroy(vcFramebuffer **ppFramebuffer)
 
   glDeleteFramebuffers(1, &(*ppFramebuffer)->id);
   udFree(*ppFramebuffer);
+
+  VERIFY_GL();
 }
 
 bool vcFramebuffer_Bind(vcFramebuffer *pFramebuffer)
@@ -46,11 +61,15 @@ bool vcFramebuffer_Bind(vcFramebuffer *pFramebuffer)
   else
     glBindFramebuffer(GL_FRAMEBUFFER, pFramebuffer->id);
 
+  VERIFY_GL();
   return true;
 }
 
 bool vcFramebuffer_Clear(vcFramebuffer *pFramebuffer, uint32_t colour)
 {
+  if (pFramebuffer == nullptr)
+    return false;
+
   GLbitfield clearMask = GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT;
   if (pFramebuffer->pDepth && pFramebuffer->pDepth->format == vcTextureFormat_D24S8)
     clearMask |= GL_STENCIL_BUFFER_BIT;
@@ -58,5 +77,6 @@ bool vcFramebuffer_Clear(vcFramebuffer *pFramebuffer, uint32_t colour)
   glClearColor(((colour >> 16) & 0xFF) / 255.f, ((colour >> 8) & 0xFF) / 255.f, (colour & 0xFF) / 255.f, ((colour >> 24) & 0xFF) / 255.f);
   glClear(clearMask);
 
+  VERIFY_GL();
   return true;
 }

--- a/src/gl/opengl/vcTexture.cpp
+++ b/src/gl/opengl/vcTexture.cpp
@@ -10,16 +10,74 @@
 
 #include "stb_image.h"
 
+void vcTexture_GetFormatAndPixelSize(const vcTextureFormat format, int *pPixelSize = nullptr, GLint *pTextureFormat = nullptr, GLenum *pPixelType = nullptr, GLint *pPixelFormat = nullptr)
+{
+  GLint textureFormat = GL_INVALID_ENUM;
+  GLenum pixelType = GL_INVALID_ENUM;
+  GLint pixelFormat = GL_INVALID_ENUM;
+  int pixelSize = 0; // in bytes
+
+  switch (format)
+  {
+  case vcTextureFormat_RGBA8:
+    textureFormat = GL_RGBA8;
+    pixelType = GL_UNSIGNED_BYTE;
+    pixelFormat = GL_RGBA;
+    pixelSize = 4;
+    break;
+  case vcTextureFormat_BGRA8:
+    textureFormat = GL_RGBA8;
+    pixelType = GL_UNSIGNED_BYTE;
+#if UDPLATFORM_EMSCRIPTEN
+    glFormat = GL_RGBA; // TODO: Fix this
+#else
+    pixelFormat = GL_BGRA;
+#endif
+    pixelSize = 4;
+    break;
+  case vcTextureFormat_D32F:
+    textureFormat = GL_DEPTH_COMPONENT32F;
+    pixelType = GL_FLOAT;
+    pixelFormat = GL_DEPTH_COMPONENT;
+    pixelSize = 4;
+    break;
+  case vcTextureFormat_D24S8:
+    textureFormat = GL_DEPTH24_STENCIL8;
+    pixelType = GL_UNSIGNED_INT_24_8;
+    pixelFormat = GL_DEPTH_STENCIL;
+    pixelSize = 4;
+    break;
+
+  case vcTextureFormat_Unknown: // fall through
+  case vcTextureFormat_Cubemap: // fall through
+  case vcTextureFormat_Count:
+    break;
+  }
+
+  if (pPixelSize != nullptr)
+    *pPixelSize = pixelSize;
+
+  if (pTextureFormat != nullptr)
+    *pTextureFormat = textureFormat;
+
+  if (pPixelType != nullptr)
+    *pPixelType = pixelType;
+
+  if (pPixelFormat != nullptr)
+    *pPixelFormat = pixelFormat;
+}
+
 udResult vcTexture_Create(vcTexture **ppTexture, uint32_t width, uint32_t height, const void *pPixels, vcTextureFormat format /*= vcTextureFormat_RGBA8*/, vcTextureFilterMode filterMode /*= vcTFM_Nearest*/, bool hasMipmaps /*= false*/, vcTextureWrapMode wrapMode /*= vcTWM_Repeat*/, vcTextureCreationFlags flags /*= vcTCF_None*/, int32_t aniFilter /* = 0 */)
 {
-  if (ppTexture == nullptr || width == 0 || height == 0)
+  if (ppTexture == nullptr || width == 0 || height == 0 || format == vcTextureFormat_Unknown || format == vcTextureFormat_Count || format == vcTextureFormat_Cubemap)
     return udR_InvalidParameter_;
 
   udResult result = udR_Success;
-  GLint internalFormat = GL_INVALID_ENUM;
-  GLenum type = GL_INVALID_ENUM;
-  GLint glFormat = GL_INVALID_ENUM;
-  int pixelBytes = 4;
+  GLint textureFormat = GL_INVALID_ENUM;
+  GLenum pixelType = GL_INVALID_ENUM;
+  GLint pixelFormat = GL_INVALID_ENUM;
+  int pixelBytes = 0;
+  vcTexture_GetFormatAndPixelSize(format, &pixelBytes, &textureFormat, &pixelType, &pixelFormat);
 
   vcTexture *pTexture = udAllocType(vcTexture, 1, udAF_Zero);
   UD_ERROR_NULL(pTexture, udR_MemoryAllocationFailure);
@@ -38,47 +96,10 @@ udResult vcTexture_Create(vcTexture **ppTexture, uint32_t width, uint32_t height
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, realAniso);
   }
 
-  switch (format)
-  {
-  case vcTextureFormat_RGBA8:
-    internalFormat = GL_RGBA8;
-    type = GL_UNSIGNED_BYTE;
-    glFormat = GL_RGBA;
-    pixelBytes = 4;
-    break;
-  case vcTextureFormat_BGRA8:
-    internalFormat = GL_RGBA8;
-    type = GL_UNSIGNED_BYTE;
-#if UDPLATFORM_EMSCRIPTEN
-    glFormat = GL_RGBA; // TODO: Fix this
-#else
-    glFormat = GL_BGRA;
-#endif
-    pixelBytes = 4;
-    break;
-  case vcTextureFormat_D32F:
-    internalFormat = GL_DEPTH_COMPONENT32F;
-    type = GL_FLOAT;
-    glFormat = GL_DEPTH_COMPONENT;
-    pixelBytes = 4;
-    break;
-  case vcTextureFormat_D24S8:
-    internalFormat = GL_DEPTH24_STENCIL8;
-    type = GL_UNSIGNED_INT_24_8;
-    glFormat = GL_DEPTH_STENCIL;
-    pixelBytes = 4;
-    break;
-  default:
-    UD_ERROR_SET(udR_InvalidParameter_);
-  }
-
-  glTexImage2D(GL_TEXTURE_2D, 0, internalFormat, width, height, 0, glFormat, type, pPixels);
+  glTexImage2D(GL_TEXTURE_2D, 0, textureFormat, width, height, 0, pixelFormat, pixelType, pPixels);
 
   if (hasMipmaps)
     glGenerateMipmap(GL_TEXTURE_2D);
-
-  glBindTexture(GL_TEXTURE_2D, 0);
-  VERIFY_GL();
 
   if ((flags & vcTCF_AsynchronousRead) == vcTCF_AsynchronousRead)
   {
@@ -91,10 +112,13 @@ udResult vcTexture_Create(vcTexture **ppTexture, uint32_t width, uint32_t height
     glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
   }
 
+  glBindTexture(GL_TEXTURE_2D, 0);
+
   pTexture->flags = flags;
   pTexture->format = format;
   pTexture->width = width;
   pTexture->height = height;
+
   vcGLState_ReportGPUWork(0, 0, pTexture->width * pTexture->height * pixelBytes);
 
   *ppTexture = pTexture;
@@ -104,6 +128,7 @@ epilogue:
   if (pTexture != nullptr)
     vcTexture_Destroy(&pTexture);
 
+  VERIFY_GL();
   return result;
 
 }
@@ -116,7 +141,7 @@ bool vcTexture_CreateFromMemory(vcTexture **ppTexture, void *pFileData, size_t f
   uint32_t width, height, channelCount;
   vcTexture *pTexture = nullptr;
 
-  uint8_t *pData = stbi_load_from_memory((stbi_uc*)pFileData, (int)fileLength, (int*)&width, (int*)&height, (int*)&channelCount, 4);
+  uint8_t *pData = stbi_load_from_memory((stbi_uc *)pFileData, (int)fileLength, (int *)& width, (int *)& height, (int *)& channelCount, 4);
 
   if (pData)
     vcTexture_Create(&pTexture, width, height, pData, vcTextureFormat_RGBA8, filterMode, hasMipmaps, wrapMode, flags, aniFilter);
@@ -156,58 +181,27 @@ udResult vcTexture_UploadPixels(vcTexture *pTexture, const void *pPixels, int wi
   if (pTexture == nullptr || pPixels == nullptr || width == 0 || height == 0)
     return udR_InvalidParameter_;
 
+  if (pTexture->format == vcTextureFormat_Unknown || pTexture->format == vcTextureFormat_Cubemap || pTexture->format == vcTextureFormat_Count)
+    return udR_InvalidParameter_;
+
   udResult result = udR_Success;
 
+  GLint textureFormat = GL_INVALID_ENUM;
+  GLenum pixelType = GL_INVALID_ENUM;
+  GLint pixelFormat = GL_INVALID_ENUM;
+  int pixelBytes = 0;
+  vcTexture_GetFormatAndPixelSize(pTexture->format, &pixelBytes, &textureFormat, &pixelType, &pixelFormat);
 
-  GLint internalFormat = GL_INVALID_ENUM;
-  GLenum type = GL_INVALID_ENUM;
-  GLint glFormat = GL_INVALID_ENUM;
-  int pixelBytes = 4;
-
-  switch (pTexture->format)
-  {
-  case vcTextureFormat_RGBA8:
-    internalFormat = GL_RGBA8;
-    type = GL_UNSIGNED_BYTE;
-    glFormat = GL_RGBA;
-    pixelBytes = 4;
-    break;
-  case vcTextureFormat_BGRA8:
-    internalFormat = GL_RGBA8;
-    type = GL_UNSIGNED_BYTE;
-#if UDPLATFORM_EMSCRIPTEN
-    glFormat = GL_RGBA; // TODO: Fix this
-#else
-    glFormat = GL_BGRA;
-#endif
-    pixelBytes = 4;
-    break;
-  case vcTextureFormat_D32F:
-    internalFormat = GL_DEPTH_COMPONENT32F;
-    type = GL_FLOAT;
-    glFormat = GL_DEPTH_COMPONENT;
-    pixelBytes = 4;
-    break;
-  case vcTextureFormat_D24S8:
-    internalFormat = GL_DEPTH24_STENCIL8;
-    type = GL_UNSIGNED_INT_24_8;
-    glFormat = GL_DEPTH_STENCIL;
-    pixelBytes = 4;
-    break;
-  default:
-    UD_ERROR_SET(udR_InvalidParameter_);
-  }
+  glBindTexture(GL_TEXTURE_2D, pTexture->id);
+  glTexImage2D(GL_TEXTURE_2D, 0, textureFormat, pTexture->width, pTexture->height, 0, pixelFormat, pixelType, pPixels);
+  glBindTexture(GL_TEXTURE_2D, 0);
 
   pTexture->width = width;
   pTexture->height = height;
-
-  glBindTexture(GL_TEXTURE_2D, pTexture->id);
-  glTexImage2D(GL_TEXTURE_2D, 0, internalFormat, pTexture->width, pTexture->height, 0, glFormat, type, pPixels);
-  glBindTexture(GL_TEXTURE_2D, 0);
-
   vcGLState_ReportGPUWork(0, 0, pTexture->width * pTexture->height * pixelBytes);
 
-epilogue:
+//epilogue:
+  VERIFY_GL();
   return result;
 }
 
@@ -220,6 +214,8 @@ void vcTexture_Destroy(vcTexture **ppTexture)
   glDeleteBuffers(2, (*ppTexture)->pbos);
   udFree(*ppTexture);
   *ppTexture = nullptr;
+
+  VERIFY_GL();
 }
 
 bool vcTexture_LoadCubemap(vcTexture **ppTexture, const char *pFilename)
@@ -232,7 +228,7 @@ bool vcTexture_LoadCubemap(vcTexture **ppTexture, const char *pFilename)
   glGenTextures(1, &pTexture->id);
   glBindTexture(GL_TEXTURE_CUBE_MAP, pTexture->id);
 
-  const char* names[] = { "_LF", "_RT", "_FR", "_BK", "_UP", "_DN" };
+  const char *names[] = { "_LF", "_RT", "_FR", "_BK", "_UP", "_DN" };
   const GLenum types[] = { GL_TEXTURE_CUBE_MAP_POSITIVE_X, GL_TEXTURE_CUBE_MAP_NEGATIVE_X, GL_TEXTURE_CUBE_MAP_POSITIVE_Y, GL_TEXTURE_CUBE_MAP_NEGATIVE_Y, GL_TEXTURE_CUBE_MAP_POSITIVE_Z, GL_TEXTURE_CUBE_MAP_NEGATIVE_Z };
   int pixelBytes = 4;
 
@@ -242,7 +238,7 @@ bool vcTexture_LoadCubemap(vcTexture **ppTexture, const char *pFilename)
 
     char fileNameNoExt[256] = "";
     fileName.ExtractFilenameOnly(fileNameNoExt, (int)udLengthOf(fileNameNoExt));
-    uint8_t* data = stbi_load(vcSettings_GetAssetPath(udTempStr("assets/skyboxes/%s%s%s", fileNameNoExt, names[i], fileName.GetExt())), &width, &height, &depth, 0);
+    uint8_t *data = stbi_load(vcSettings_GetAssetPath(udTempStr("assets/skyboxes/%s%s%s", fileNameNoExt, names[i], fileName.GetExt())), &width, &height, &depth, 0);
 
     pTexture->height = height;
     pTexture->width = width;
@@ -258,7 +254,6 @@ bool vcTexture_LoadCubemap(vcTexture **ppTexture, const char *pFilename)
     }
 
     pixelBytes = depth; // assume they all have the same depth
-    VERIFY_GL();
   }
 
   glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
@@ -266,8 +261,6 @@ bool vcTexture_LoadCubemap(vcTexture **ppTexture, const char *pFilename)
   glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
   glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
   glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
-
-  VERIFY_GL();
 
   if (pTexture->id == GL_INVALID_INDEX)
   {
@@ -278,6 +271,7 @@ bool vcTexture_LoadCubemap(vcTexture **ppTexture, const char *pFilename)
   vcGLState_ReportGPUWork(0, 0, pTexture->width * pTexture->height * pixelBytes * 6);
 
   *ppTexture = pTexture;
+  VERIFY_GL();
   return true;
 }
 
@@ -305,6 +299,9 @@ bool vcTexture_BeginReadPixels(vcTexture *pTexture, uint32_t x, uint32_t y, uint
 
   udResult result = udR_Success;
   void *pPixelBuffer = pPixels;
+  GLenum pixelType = GL_INVALID_ENUM;
+  GLint pixelFormat = GL_INVALID_ENUM;
+  vcTexture_GetFormatAndPixelSize(pTexture->format, nullptr, nullptr, &pixelType, &pixelFormat);
 
   UD_ERROR_IF(!vcFramebuffer_Bind(pFramebuffer), udR_InternalError);
 
@@ -316,26 +313,7 @@ bool vcTexture_BeginReadPixels(vcTexture *pTexture, uint32_t x, uint32_t y, uint
     pPixelBuffer = nullptr;
   }
 
-  switch (pTexture->format)
-  {
-  case vcTextureFormat_RGBA8:
-    glReadPixels(x, y, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pPixelBuffer);
-    break;
-  case vcTextureFormat_BGRA8:
-    glReadPixels(x, y, width, height, GL_BGRA, GL_UNSIGNED_BYTE, pPixelBuffer);
-    break;
-  case vcTextureFormat_D24S8:
-    glReadPixels(x, y, width, height, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, pPixelBuffer);
-    break;
-  case vcTextureFormat_D32F:
-    glReadPixels(x, y, width, height, GL_DEPTH_COMPONENT, GL_FLOAT, pPixelBuffer);
-    break;
-
-  case vcTextureFormat_Unknown: // fall through
-  case vcTextureFormat_Cubemap: // fall through
-  case vcTextureFormat_Count:
-    break;
-  }
+  glReadPixels(x, y, width, height, pixelFormat, pixelType, pPixelBuffer);
 
   if ((pTexture->flags & vcTCF_AsynchronousRead) == vcTCF_AsynchronousRead)
     glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
@@ -354,7 +332,8 @@ bool vcTexture_EndReadPixels(vcTexture *pTexture, uint32_t x, uint32_t y, uint32
     return false;
 
   udResult result = udR_Success;
-  int pixelBytes = 4; // assumptions
+  int pixelBytes = 0;
+  vcTexture_GetFormatAndPixelSize(pTexture->format, &pixelBytes);
 
   // Read previous PBO back to CPU
   glBindBuffer(GL_PIXEL_PACK_BUFFER, pTexture->pbos[pTexture->pboIndex]);

--- a/src/gl/vcFramebuffer.h
+++ b/src/gl/vcFramebuffer.h
@@ -6,7 +6,7 @@
 
 struct vcFramebuffer;
 
-bool vcFramebuffer_Create(vcFramebuffer **ppFramebuffer, vcTexture *pTexture, vcTexture *pDepth = nullptr, int level = 0);
+bool vcFramebuffer_Create(vcFramebuffer **ppFramebuffer, vcTexture *pTexture, vcTexture *pDepth = nullptr, uint32_t level = 0);
 void vcFramebuffer_Destroy(vcFramebuffer **ppFramebuffer);
 
 bool vcFramebuffer_Bind(vcFramebuffer *pFramebuffer);

--- a/src/gl/vcTexture.h
+++ b/src/gl/vcTexture.h
@@ -13,7 +13,7 @@ enum vcTextureFormat
   vcTextureFormat_D24S8,
   vcTextureFormat_D32F,
 
-  vcTextureFormat_Cubemap,
+  vcTextureFormat_Cubemap, // Cube Maps are handled differently, and must be loaded through `vcTexture_LoadCubemap()`.
 
   vcTextureFormat_Count
 };
@@ -60,11 +60,12 @@ void vcTexture_Destroy(vcTexture **ppTexture);
 udResult vcTexture_UploadPixels(vcTexture *pTexture, const void *pPixels, int width, int height);
 udResult vcTexture_GetSize(vcTexture *pTexture, int *pWidth, int *pHeight);
 
-// If pTexture is created with `AsynchronousRead` flag, BeginReadPixels() / EndReadPixels() will perform
-// asynchronous transfer. It is recommended to call vcTexture_BeginReadPixels(), then wait an appropriate
-// amount of time (e.g. next frame), then get results later with vcTexture_ReadPreviousPixels().
-// Otherwise if pTexture is created without the `AsynchronousRead` flag, BeginReadPixels() will perform a
+// If 'pTexture' is created with `AsynchronousRead` flag, BeginReadPixels() / EndReadPixels() will perform
+// asynchronous transfer. It is recommended to call  BeginReadPixels(), then wait an appropriate amount of
+// time (e.g. next frame), then get results later with ReadPreviousPixels().
+// Otherwise if 'pTexture' is created without the `AsynchronousRead` flag, BeginReadPixels() will perform a
 // synchronous transfer, and there is no need for a corresponding EndReadPixels() call.
+// In both cases, 'pTexture' must be an attachment of 'pFramebuffer'.
 bool vcTexture_BeginReadPixels(vcTexture *pTexture, uint32_t x, uint32_t y, uint32_t width, uint32_t height, void *pPixels, vcFramebuffer *pFramebuffer);
 bool vcTexture_EndReadPixels(vcTexture *pTexture, uint32_t x, uint32_t y, uint32_t width, uint32_t height, void *pPixels);
 

--- a/src/vcRender.cpp
+++ b/src/vcRender.cpp
@@ -118,7 +118,7 @@ struct vcRenderContext
     vcShaderSampler *uniform_texture;
     vcShaderConstantBuffer *uniform_MatrixBlock;
 
-    vcTexture* pSkyboxTexture;
+    vcTexture *pSkyboxTexture;
   } skyboxShaderPanorama;
 
   struct
@@ -127,7 +127,7 @@ struct vcRenderContext
     vcShaderConstantBuffer *uniform_params;
     vcShaderSampler *uniform_texture;
 
-    vcTexture* pLogoTexture;
+    vcTexture *pLogoTexture;
 
     struct
     {
@@ -344,8 +344,8 @@ udResult vcRender_ResizeScene(vcState *pProgramState, vcRenderContext *pRenderCo
 {
   udResult result = udR_Success;
 
-  uint32_t widthIncr = width +(width % vcRender_SceneSizeIncrement != 0 ? vcRender_SceneSizeIncrement - width % vcRender_SceneSizeIncrement : 0);
-  uint32_t heightIncr = height +(height % vcRender_SceneSizeIncrement != 0 ? vcRender_SceneSizeIncrement - height % vcRender_SceneSizeIncrement : 0);
+  uint32_t widthIncr = width + (width % vcRender_SceneSizeIncrement != 0 ? vcRender_SceneSizeIncrement - width % vcRender_SceneSizeIncrement : 0);
+  uint32_t heightIncr = height + (height % vcRender_SceneSizeIncrement != 0 ? vcRender_SceneSizeIncrement - height % vcRender_SceneSizeIncrement : 0);
 
   UD_ERROR_NULL(pRenderContext, udR_InvalidParameter_);
   UD_ERROR_IF(width == 0, udR_InvalidParameter_);
@@ -360,10 +360,10 @@ udResult vcRender_ResizeScene(vcState *pProgramState, vcRenderContext *pRenderCo
   udFree(pRenderContext->udRenderContext.pColorBuffer);
   udFree(pRenderContext->udRenderContext.pDepthBuffer);
 
-  pRenderContext->udRenderContext.pColorBuffer = udAllocType(uint32_t, pRenderContext->sceneResolution.x*pRenderContext->sceneResolution.y, udAF_Zero);
+  pRenderContext->udRenderContext.pColorBuffer = udAllocType(uint32_t, pRenderContext->sceneResolution.x * pRenderContext->sceneResolution.y, udAF_Zero);
   UD_ERROR_NULL(pRenderContext->udRenderContext.pColorBuffer, udR_MemoryAllocationFailure);
 
-  pRenderContext->udRenderContext.pDepthBuffer = udAllocType(float, pRenderContext->sceneResolution.x*pRenderContext->sceneResolution.y, udAF_Zero);
+  pRenderContext->udRenderContext.pDepthBuffer = udAllocType(float, pRenderContext->sceneResolution.x * pRenderContext->sceneResolution.y, udAF_Zero);
   UD_ERROR_NULL(pRenderContext->udRenderContext.pDepthBuffer, udR_MemoryAllocationFailure);
 
   //Resize GPU Targets
@@ -999,7 +999,7 @@ udResult vcRender_RenderUD(vcState *pProgramState, vcRenderContext *pRenderConte
     vdkRenderContext_ShowIntensity(pProgramState->pVDKContext, pRenderContext->udRenderContext.pRenderer, pProgramState->settings.visualization.minIntensity, pProgramState->settings.visualization.maxIntensity);
     break;
   case vcVM_Classification:
-    vdkRenderContext_ShowClassification(pProgramState->pVDKContext, pRenderContext->udRenderContext.pRenderer, (int*)pProgramState->settings.visualization.customClassificationColors, (int)udLengthOf(pProgramState->settings.visualization.customClassificationColors));
+    vdkRenderContext_ShowClassification(pProgramState->pVDKContext, pRenderContext->udRenderContext.pRenderer, (int *)pProgramState->settings.visualization.customClassificationColors, (int)udLengthOf(pProgramState->settings.visualization.customClassificationColors));
     break;
   default: //Includes vcVM_Colour
     vdkRenderContext_ShowColor(pProgramState->pVDKContext, pRenderContext->udRenderContext.pRenderer);
@@ -1226,18 +1226,19 @@ vcRenderPickResult vcRender_PolygonPick(vcState *pProgramState, vcRenderContext 
       }
     }
 
+    udUInt2 readLocation = { pRenderContext->picking.location.x, pRenderContext->picking.location.y };
     uint8_t colourBytes[4] = {};
     uint8_t depthBytes[4] = {};
 
-    // Synchronously read back data
 #if GRAPHICS_API_OPENGL
-    // note: we render upside-down
-    vcTexture_BeginReadPixels(pRenderContext->picking.pTexture, pRenderContext->picking.location.x, pRenderContext->effectResolution.y - pRenderContext->picking.location.y - 1, 1, 1, colourBytes, pRenderContext->picking.pFramebuffer);
-    vcTexture_BeginReadPixels(pRenderContext->picking.pDepth, pRenderContext->picking.location.x, pRenderContext->effectResolution.y - pRenderContext->picking.location.y - 1, 1, 1, depthBytes, pRenderContext->picking.pFramebuffer);
-#else // All others are the same direction
-    vcTexture_BeginReadPixels(pRenderContext->picking.pTexture, pRenderContext->picking.location.x, pRenderContext->picking.location.y, 1, 1, colourBytes, pRenderContext->picking.pFramebuffer);
-    vcTexture_BeginReadPixels(pRenderContext->picking.pDepth, pRenderContext->picking.location.x, pRenderContext->picking.location.y, 1, 1, depthBytes, pRenderContext->picking.pFramebuffer);
+    // read upside down
+    readLocation.y = pRenderContext->effectResolution.y - pRenderContext->picking.location.y - 1;
 #endif
+
+    // Synchronously read back data
+    vcTexture_BeginReadPixels(pRenderContext->picking.pTexture, readLocation.x, readLocation.y, 1, 1, colourBytes, pRenderContext->picking.pFramebuffer);
+    vcTexture_BeginReadPixels(pRenderContext->picking.pDepth, readLocation.x, readLocation.y, 1, 1, depthBytes, pRenderContext->picking.pFramebuffer);
+
     vcGLState_SetViewport(0, 0, pRenderContext->sceneResolution.x, pRenderContext->sceneResolution.y);
 
     // 24 bit unsigned int -> float


### PR DESCRIPTION
Removed all assumptions about texture storage in texture functions
Error checking in vcFramebuffer and vcTexture classes is now more thorough and consistent
[AB#327](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/327)