### PR TITLE
Translate menu window name

### DIFF
--- a/builds/assets/lang/enAU.json
+++ b/builds/assets/lang/enAU.json
@@ -253,6 +253,7 @@
   "convertWatermark": "Watermark",
   "convertNoJobSelected": "No job is selected. Please select one on the left or create a new job.",
 
+  "menuName": "Main Menu Bar",
   "menuSystem": "System",
   "menuQuit": "Quit",
   "menuLanguage": "Language",

--- a/docs/TranslationGuide.md
+++ b/docs/TranslationGuide.md
@@ -4,7 +4,7 @@
 
 - Version 0.4.0
   - Added:
-    - `settingsVisContoursRainbowRepeatRate`, `settingsVisContoursRainbowIntensity`
+    - `settingsVisContoursRainbowRepeatRate`, `settingsVisContoursRainbowIntensity`, `menuName`
   - Changed:
     - ?
   - Removed:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2065,7 +2065,14 @@ void vcRenderWindow(vcState *pProgramState)
     int margin = vcMainMenuGui(pProgramState);
 
     if (pProgramState->settings.docksLoaded != vcSettings::vcDockLoaded::vcDL_True)
+    {
+      ImGuiWindow *pWindow = ImGui::FindWindowByName("##MainMenuBar");
+      delete pWindow->Name;
+      pWindow->Name = new char[80];
+      vcStringFormat(pWindow->Name, 80, "{0}##MainMenuBar", vcString::Get("menuName"));
+
       pProgramState->settings.rootDock = ImGui::GetID("MyDockspace");
+    }
 
     ImGui::SetNextWindowSize(ImVec2(size.x, size.y));
     ImGui::SetNextWindowPos(ImVec2(0, 0));


### PR DESCRIPTION
Probably the only way to do this, ImGui was filling a backup name for it (in english) since the window had no name, also no built in way to give it a name
Resolves [AB#2](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2)