### PR TITLE
Load maximize setting

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -202,6 +202,8 @@ void vcMain_LoadSettings(vcState *pProgramState, bool forceDefaults)
 
     SDL_SetWindowSize(pProgramState->pWindow, pProgramState->settings.window.width, pProgramState->settings.window.height);
     SDL_SetWindowPosition(pProgramState->pWindow, pProgramState->settings.window.xpos, pProgramState->settings.window.ypos);
+    if (pProgramState->settings.window.maximized)
+      SDL_MaximizeWindow(pProgramState->pWindow);
   }
 }
 

--- a/src/vcSettings.cpp
+++ b/src/vcSettings.cpp
@@ -262,11 +262,21 @@ bool vcSettings_Load(vcSettings *pSettings, bool forceReset /*= false*/, vcSetti
   if (group == vcSC_All)
   {
     // Windows
-    pSettings->window.xpos = data.Get("window.position.x").AsInt(SDL_WINDOWPOS_CENTERED);
-    pSettings->window.ypos = data.Get("window.position.y").AsInt(SDL_WINDOWPOS_CENTERED);
-    pSettings->window.width = data.Get("window.width").AsInt(1280);
-    pSettings->window.height = data.Get("window.height").AsInt(720);
     pSettings->window.maximized = data.Get("window.maximized").AsBool(false);
+    if (pSettings->window.maximized)
+    {
+      pSettings->window.xpos = SDL_WINDOWPOS_CENTERED;
+      pSettings->window.ypos = SDL_WINDOWPOS_CENTERED;
+      pSettings->window.width = 1280;
+      pSettings->window.height = 720;
+    }
+    else
+    {
+      pSettings->window.xpos = data.Get("window.position.x").AsInt(SDL_WINDOWPOS_CENTERED);
+      pSettings->window.ypos = data.Get("window.position.y").AsInt(SDL_WINDOWPOS_CENTERED);
+      pSettings->window.width = data.Get("window.width").AsInt(1280);
+      pSettings->window.height = data.Get("window.height").AsInt(720);
+    }
 
     udStrcpy(pSettings->window.languageCode, data.Get("window.language").AsString("enAU"));
 


### PR DESCRIPTION
Resolves [AB#355](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/355)

I've elected to overwrite the window size and position in the case that the window was maximized because it feels much nicer to be able still to restore it to a normal size, even if the resulting size is likely incorrect