### PR TITLE
Unsupported attributes now fully ignored in vertex processing.

### DIFF
--- a/src/rendering/vcSceneLayerRenderer.cpp
+++ b/src/rendering/vcSceneLayerRenderer.cpp
@@ -77,7 +77,7 @@ double vcSceneLayerRenderer_CalculateNodeScreenSize(vcSceneLayerNode *pNode, con
   double r1 = udMag(center.toVector3() - p1.toVector3());
   double r2 = udMag(center.toVector3() - p2.toVector3());
   udDouble2 screenSize = udDouble2::create(screenResolution.x * r1, screenResolution.y * r2);
-  return udMax(screenSize.x, screenSize.y);
+  return 2.0 * udMax(screenSize.x, screenSize.y);
 }
 
 void vcSceneLayerRenderer_RenderNode(vcSceneLayerRenderer *pSceneLayerRenderer, vcSceneLayerNode *pNode, const udFloat4 *pColourOverride)

--- a/src/vcSceneLayer.cpp
+++ b/src/vcSceneLayer.cpp
@@ -376,7 +376,7 @@ udResult vcSceneLayer_LoadFeatureData(const vcSceneLayer *pSceneLayer, vcSceneLa
         pNode->pFeatureData[i].pGeometryLayout[a] = vcVLT_ColourBGRA;
       else
       {
-        // the renderer will ignore anything else
+        // attribute gets ignored
         pNode->pFeatureData[i].pGeometryLayout[a] = vcVLT_Unsupported;
         attributeSize = 0;
       }
@@ -451,6 +451,9 @@ udResult vcSceneLayer_LoadGeometryData(const vcSceneLayer *pSceneLayer, vcSceneL
       uint32_t attributeSize = vcLayout_GetSize(pNode->pFeatureData[i].pGeometryLayout[attributeIndex]);
       vcVertexLayoutTypes attributeType = pNode->pFeatureData[i].pGeometryLayout[attributeIndex];
       pCurrentFile = pFileData + pNode->pFeatureData[i].pAttributeOffset[attributeIndex];
+
+      if (attributeType == vcVLT_Unsupported)
+        continue;
 
       // positions require additional pre-processing
       if (attributeType == vcVLT_Position3)


### PR DESCRIPTION
Node screen size calculation is now correct.
[AB#421](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/421)