### PR TITLE
Fix scene explorer selection to work with scene tab closed

### DIFF
--- a/src/scene/vcFolder.cpp
+++ b/src/scene/vcFolder.cpp
@@ -231,7 +231,20 @@ void vcFolder::HandleImGui(vcState *pProgramState, size_t *pItemID)
       bool sceneExplorerItemClicked = ((ImGui::IsMouseReleased(0) && ImGui::IsItemHovered() && !ImGui::IsItemActive()) || (!pSceneItem->m_selected && ImGui::IsItemActive()));
       if (sceneExplorerItemClicked)
       {
-        udStrcpy(pProgramState->sceneExplorer.selectUUIDWhenPossible, pNode->UUID);
+        if (!ImGui::GetIO().KeyCtrl)
+          vcProject_ClearSelection(pProgramState);
+
+        if (pSceneItem->m_selected)
+        {
+          vcProject_UnselectItem(pProgramState, m_pNode, pNode);
+          pProgramState->sceneExplorer.clickedItem = { nullptr, nullptr };
+        }
+        else
+        {
+          vcProject_SelectItem(pProgramState, m_pNode, pNode);
+          pProgramState->sceneExplorer.clickedItem = { m_pNode, pNode };
+        }
+
         pSceneItem->SelectSubitem(0);
       }
 


### PR DESCRIPTION
Resolves [AB#336](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/336)