### PR TITLE
OBJ vert positions are now stored relative to a model origin.

### DIFF
--- a/src/rendering/vcPolygonModel.h
+++ b/src/rendering/vcPolygonModel.h
@@ -40,6 +40,8 @@ struct vcPolygonModel
 {
   int meshCount;
   vcPolygonModelMesh *pMeshes;
+
+  udDouble4x4 modelOffset;
 };
 
 udResult vcPolygonModel_CreateShaders();


### PR DESCRIPTION
OBJ will no longer fail to load if a texture is missing.
[AB#444](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/444)