### PR TITLE
Metal full size indexes

### DIFF
--- a/src/imgui_ex/imgui_impl_metal.mm
+++ b/src/imgui_ex/imgui_impl_metal.mm
@@ -202,7 +202,7 @@ void ImGui_ImplMetal_DestroyDeviceObjects()
     vcShader_GetSamplerIndex(&pMetalSampler, pMetalShader, "Texture");
 
     if (drawData->CmdListsCount != 0 && pMetalMesh == nullptr)
-        vcMesh_Create(&pMetalMesh, vcImGuiVertexLayout, 3, drawData->CmdLists[0]->VtxBuffer.Data, drawData->CmdLists[0]->VtxBuffer.Size, drawData->CmdLists[0]->IdxBuffer.Data, drawData->CmdLists[0]->IdxBuffer.Size, vcMF_Dynamic | vcMF_IndexShort);
+        vcMesh_Create(&pMetalMesh, vcImGuiVertexLayout, 3, drawData->CmdLists[0]->VtxBuffer.Data, drawData->CmdLists[0]->VtxBuffer.Size, drawData->CmdLists[0]->IdxBuffer.Data, drawData->CmdLists[0]->IdxBuffer.Size, vcMF_Dynamic);
 
     // Draw
     ImVec2 pos = drawData->DisplayPos;


### PR DESCRIPTION
Change metal imgui mesh creation to use full size indexes
Resolves [AB#470](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/470)