### PR TITLE
Correct spelling mistake, filter rotation

### DIFF
--- a/src/scene/vcQueryNode.cpp
+++ b/src/scene/vcQueryNode.cpp
@@ -115,9 +115,9 @@ void vcQueryNode::ApplyDelta(vcState *pProgramState, const udDouble4x4 &delta)
   vdkProjectNode_SetMetadataDouble(m_pNode, "size.y", m_extents.y);
   vdkProjectNode_SetMetadataDouble(m_pNode, "size.z", m_extents.z);
 
-  vdkProjectNode_SetMetadataDouble(m_pNode, "tranform.rotation.y", m_ypr.x);
-  vdkProjectNode_SetMetadataDouble(m_pNode, "tranform.rotation.p", m_ypr.y);
-  vdkProjectNode_SetMetadataDouble(m_pNode, "tranform.rotation.r", m_ypr.z);
+  vdkProjectNode_SetMetadataDouble(m_pNode, "transform.rotation.y", m_ypr.x);
+  vdkProjectNode_SetMetadataDouble(m_pNode, "transform.rotation.p", m_ypr.y);
+  vdkProjectNode_SetMetadataDouble(m_pNode, "transform.rotation.r", m_ypr.z);
 }
 
 void vcQueryNode::HandleImGui(vcState *pProgramState, size_t *pItemID)


### PR DESCRIPTION
Resolves [AB#496](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/496)