### PR TITLE
Fix crash

### DIFF
--- a/src/vcFBX.cpp
+++ b/src/vcFBX.cpp
@@ -275,7 +275,7 @@ void vcFBX_CleanMaterials(udChunkedArray<vcFBXMaterial> *pMats)
         void *pPtr = (*pMats)[i].textures[j].pPixels;
         for (uint32_t k = i; k < pMats->length; ++k)
         {
-          for (uint32_t l = j + 1; l < (*pMats)[k].textures.length; ++l)
+          for (uint32_t l = j; l < (*pMats)[k].textures.length; ++l)
           {
             if (pPtr == (*pMats)[k].textures[l].pPixels)
               (*pMats)[k].textures[l].pPixels = nullptr;


### PR DESCRIPTION
Resolves [AB#516](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/516)

No idea why but assigning nullptr to the very same address here instead of winding back j by 1 still crashes