### PR TITLE
Compare models now uses the Convert UI and system

### DIFF
--- a/src/scene/vcModel.cpp
+++ b/src/scene/vcModel.cpp
@@ -389,14 +389,14 @@ void vcModel::ContextMenuListModels(vcState *pProgramState, vdkProjectNode *pPar
       //udTempStr("%s###SXIName%zu", pNode->pName, *pItemID)
       if (ImGui::Selectable(pChildNode->pName))
       {
-        this->m_compareData.pContext = pProgramState->pVDKContext;
+        this->m_compareData.pProgramState = pProgramState;
         this->m_compareData.pOldModel = (vcModel *)pChildNode->pUserData;
         this->m_compareData.pNewModel = this;
         this->m_compareData.ballRadius = 0.15; // TODO: Expose this to the user
         udWorkerPoolCallback *pCallback = [](void *pUserData) {
           vcModelCompareData *pCompareData = (vcModelCompareData *)pUserData;
-          vcBPA_CompareExport(pCompareData->pContext, pCompareData->pOldModel->m_pPointCloud, pCompareData->pNewModel->m_pPointCloud, pCompareData->ballRadius);
-          pCompareData->pContext = nullptr;
+          vcBPA_CompareExport(pCompareData->pProgramState, pCompareData->pOldModel->m_pPointCloud, pCompareData->pNewModel->m_pPointCloud, pCompareData->ballRadius);
+          pCompareData->pProgramState = nullptr;
           pCompareData->pOldModel = nullptr;
           pCompareData->pNewModel = nullptr;
           pCompareData->ballRadius = 0.0;

--- a/src/scene/vcModel.h
+++ b/src/scene/vcModel.h
@@ -31,7 +31,7 @@ public:
 
   struct vcModelCompareData
   {
-    vdkContext *pContext;
+    vcState *pProgramState;
     vcModel *pOldModel;
     vcModel *pNewModel;
     double ballRadius;

--- a/src/vcBPA.h
+++ b/src/vcBPA.h
@@ -6,7 +6,8 @@
 // https://lidarwidgets.com/samples/bpa_tvcg.pdf
 
 #include "vdkPointCloud.h"
+struct vcState;
 
-void vcBPA_CompareExport(vdkContext *pContext, vdkPointCloud *pOldModel, vdkPointCloud *pNewModel, double ballRadius);
+void vcBPA_CompareExport(vcState *pProgramState, vdkPointCloud *pOldModel, vdkPointCloud *pNewModel, double ballRadius);
 
 #endif //vcBPA_h__

--- a/src/vcConvert.h
+++ b/src/vcConvert.h
@@ -75,6 +75,7 @@ void vcConvert_Deinit(vcState *pProgramState);
 
 void vcConvert_ShowUI(vcState *pProgramState);
 
+void vcConvert_AddEmptyJob(vcState *pProgramState, vcConvertItem **ppNextItem);
 void vcConvert_QueueFile(vcState *pProgramState, const char *pFilename);
 void vcConvert_RemoveJob(vcState *pProgramState, size_t index);
 


### PR DESCRIPTION
- Replaced temporary convert reset functionality with proper vdkConvert reset functionality
- Fixed memory leaks in compare models functionality and made modifications to allow for cancelling and restarting

Resolves [AB#520](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/520)