### PR TITLE
SLPK conversions now properly use the destroy callback

### DIFF
--- a/src/vcSceneLayer.cpp
+++ b/src/vcSceneLayer.cpp
@@ -665,6 +665,7 @@ udResult vcSceneLayer_LoadNodeInternals(const vcSceneLayer *pSceneLayer, vcScene
   udResult result;
 
   UD_ERROR_NULL(pNode, udR_InvalidParameter_);
+  UD_ERROR_IF(pNode->internalsLoadState != vcSceneLayerNode::vcILS_BasicNodeData, udR_Success);
 
   UD_ERROR_CHECK(vcSceneLayer_LoadFeatureData(pSceneLayer, pNode));
   UD_ERROR_CHECK(vcSceneLayer_LoadGeometryData(pSceneLayer, pNode));
@@ -687,6 +688,8 @@ udResult vcSceneLayer_LoadNode(const vcSceneLayer *pSceneLayer, vcSceneLayerNode
   udJSON nodeJSON;
   const char *pPathBuffer = nullptr;
   char *pFileData = nullptr;
+
+  UD_ERROR_IF(pNode->internalsLoadState != vcSceneLayerNode::vcILS_None, udR_Success);
 
   pNode->loadState = vcSceneLayerNode::vcLS_Loading;
 


### PR DESCRIPTION
[AB#570](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/570)