### PR TITLE
DX11 Pixel read block / input improvement

### DIFF
--- a/src/gl/directx11/vcTexture.cpp
+++ b/src/gl/directx11/vcTexture.cpp
@@ -411,7 +411,11 @@ bool vcTexture_EndReadPixels(vcTexture *pTexture, uint32_t x, uint32_t y, uint32
   UD_ERROR_IF(g_pd3dDeviceContext->Map(pStagingTexture, 0, D3D11_MAP_READ, 0, &msr) != S_OK, udR_InternalError);
 
   pPixelData = ((uint32_t *)msr.pData) + (x + y * pTexture->width);
-  memcpy(pPixels, pPixelData, width * height * pixelBytes);
+  for (int i = 0; i < (int)height; ++i)
+  {
+    memcpy((uint8_t*)pPixels + (i * pTexture->width), pPixelData, width * pixelBytes);
+    pPixelData += pTexture->width;
+  }
 
 epilogue:
   if (pStagingTexture != nullptr)

--- a/src/vcCamera.cpp
+++ b/src/vcCamera.cpp
@@ -369,7 +369,10 @@ void vcCamera_HandleSceneInput(vcState *pProgramState, udDouble3 oscMove, udFloa
 
   // Start hold time
   if (isFocused && (isBtnClicked[0] || isBtnClicked[1] || isBtnClicked[2]))
+  {
     isMouseBtnBeingHeld = true;
+    mouseDelta = { 0, 0 };
+  }
 
   bool forceClearMouseState = !isFocused;
 


### PR DESCRIPTION
Makes directx read a block of pixels instead of a sequence, also prevents applying mouse delta from before an input state was engaged

Resolves [AB#762](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/762)
Resolves [AB#763](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/763)