### PR TITLE
Rectify mistype preventing shift bindings from working properly

### DIFF
--- a/src/vcHotkey.cpp
+++ b/src/vcHotkey.cpp
@@ -100,7 +100,7 @@ namespace vcHotkey
 
     if (keyNum > vcMOD_Mask)
     {
-      if (((keyNum & vcMOD_Shift) == vcMOD_Shift) != io.KeyCtrl)
+      if (((keyNum & vcMOD_Shift) == vcMOD_Shift) != io.KeyShift)
         return false;
       if (((keyNum & vcMOD_Ctrl) == vcMOD_Ctrl) != io.KeyCtrl)
         return false;


### PR DESCRIPTION
Resolves [AB#809](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/809)