### PR TITLE
Fixed object file loading.

### DIFF
--- a/src/parsers/vcOBJ.cpp
+++ b/src/parsers/vcOBJ.cpp
@@ -404,7 +404,10 @@ udResult vcOBJ_Load(vcOBJ **ppOBJ, const char *pFilename)
       pTextBuffer[bufferPos + charCount] = temp;
       pOBJ->basePath.SetFilenameWithExt(f.GetFilenameWithExt());
 
-      UD_ERROR_CHECK(vcOBJ_LoadMtlLib(pOBJ, pOBJ->basePath.GetPath()));
+      //Allow to load an object file without a material file.
+      result = vcOBJ_LoadMtlLib(pOBJ, pOBJ->basePath.GetPath());
+      if (result != udR_OpenFailure || result != udR_Success)
+        UD_ERROR_SET(result);
     }
     else
     {

--- a/src/parsers/vcOBJ.cpp
+++ b/src/parsers/vcOBJ.cpp
@@ -406,7 +406,7 @@ udResult vcOBJ_Load(vcOBJ **ppOBJ, const char *pFilename)
 
       //Allow to load an object file without a material file.
       result = vcOBJ_LoadMtlLib(pOBJ, pOBJ->basePath.GetPath());
-      if (result != udR_OpenFailure || result != udR_Success)
+      if (result != udR_OpenFailure && result != udR_Success)
         UD_ERROR_SET(result);
     }
     else

--- a/src/rendering/vcPolygonModel.cpp
+++ b/src/rendering/vcPolygonModel.cpp
@@ -308,7 +308,7 @@ udResult vcPolygonModel_CreateFromOBJ(vcPolygonModel **ppPolygonModel, const cha
   {
     vcOBJ::Face *pFace = &pOBJReader->faces[f];
     if (pFace->mat == -1)
-      continue;
+      pFace->mat = 0;
 
     pMaterialVerticesMap[pFace->mat].PushBack(pFace->verts[0]);
     pMaterialVerticesMap[pFace->mat].PushBack(pFace->verts[1]);


### PR DESCRIPTION
Resolved [AB#784](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/784)

Allow to load the object file without a material file.
Allow to create meshes without face matrix.