### PR TITLE
Fix vcHotkey button borders

### DIFF
--- a/src/vcHotkey.cpp
+++ b/src/vcHotkey.cpp
@@ -258,7 +258,17 @@ namespace vcHotkey
 
     for (int i = 0; i < vcB_Count; ++i)
     {
-      if (ImGui::Button(bindNames[i], ImVec2(-1, 0)))
+      ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 2);
+      if (target == i)
+        ImGui::PushStyleColor(ImGuiCol_Border, vcSettingsUI_GetErrorColour(vcSE_Select));
+
+      bool pressed = ImGui::Button(bindNames[i], ImVec2(-1, 0));
+
+      if (target == i)
+        ImGui::PopStyleColor();
+      ImGui::PopStyleVar();
+
+      if (pressed)
       {
         vcSettingsUI_UnsetError(pProgramState, vcSE_Bound);
         if (target == i)
@@ -273,9 +283,6 @@ namespace vcHotkey
           target = i;
         }
       }
-
-      if (target == i)
-        ImGui::GetForegroundDrawList()->AddRect(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), ImGui::ColorConvertFloat4ToU32(vcSettingsUI_GetErrorColour(vcSE_Select)), 0.0f, ImDrawCornerFlags_All, 2.0f);
 
       ImGui::NextColumn();
 

--- a/src/vcHotkey.cpp
+++ b/src/vcHotkey.cpp
@@ -262,9 +262,13 @@ namespace vcHotkey
       if (target == i)
         ImGui::PushStyleColor(ImGuiCol_Border, vcSettingsUI_GetErrorColour(vcSE_Select));
 
+      bool bound = vcSettingsUI_CheckError(pProgramState, vcSE_Bound) && (vcHotkey::Get((vcBind)i) == pProgramState->currentKey);
+      if (bound)
+        ImGui::PushStyleColor(ImGuiCol_Border, vcSettingsUI_GetErrorColour(vcSE_Bound));
+
       bool pressed = ImGui::Button(bindNames[i], ImVec2(-1, 0));
 
-      if (target == i)
+      if (target == i || bound)
         ImGui::PopStyleColor();
       ImGui::PopStyleVar();
 


### PR DESCRIPTION
Use ImGui variables/color enum values instead of draw calls for button borders
Resolves [AB#865](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/865)