### PR TITLE
Changed command-line app name text from cvConvertCMD to vaultConvertCMD

### DIFF
--- a/vcConvertCMD/src/vcConvertCMD.cpp
+++ b/vcConvertCMD/src/vcConvertCMD.cpp
@@ -20,7 +20,7 @@
 
 void vcConvertCMD_ShowOptions()
 {
-  printf("Usage: vcConvertCMD [vault server] [username] [password] [options] -i inputfile [-i anotherInputFile] -o outputfile.uds\n");
+  printf("Usage: vaultConvertCMD [vault server] [username] [password] [options] -i inputfile [-i anotherInputFile] -o outputfile.uds\n");
   printf("   -resolution <res>           - override the resolution (0.01 = 1cm, 0.001 = 1mm)\n");
   printf("   -srid <sridCode>            - override the srid code for geolocation\n");
   printf("   -globalOffset <x,y,z>       - add an offset to all points, no spaces allowed in the x,y,z value\n");
@@ -167,7 +167,7 @@ int main(int argc, const char **ppArgv)
 
   settings.files.Init(256);
 
-  printf("vcConvertCMD %s\n", CONVERTCMD_VERSION);
+  printf("vaultConvertCMD %s\n", CONVERTCMD_VERSION);
 
   if (argc < 4)
   {


### PR DESCRIPTION
Fixed issue [AB#949](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/949)