### PR TITLE
Fixed issue with point-triangle distance test

### DIFF
--- a/vcTesting/src/vcMathTests.cpp
+++ b/vcTesting/src/vcMathTests.cpp
@@ -1,13 +1,13 @@
 #include "vcMath.h"
 #include "vcTesting.h"
 
-#define EPSILON 0.0000001
+#define EPSILON_DOUBLE 0.0000000001
 #define TRI_DIST udDistanceToTriangle(p0, p1, p2, testPoint, &out)
-#define EXPECT_VEC_NEAR(v0, v1) EXPECT_NEAR(v0.x, v1.x, EPSILON);\
-EXPECT_NEAR(v0.y, v1.y, EPSILON);\
-EXPECT_NEAR(v0.z, v1.z, EPSILON)
+#define EXPECT_VEC_NEAR(v0, v1) EXPECT_NEAR(v0.x, v1.x, EPSILON_DOUBLE);\
+EXPECT_NEAR(v0.y, v1.y, EPSILON_DOUBLE);\
+EXPECT_NEAR(v0.z, v1.z, EPSILON_DOUBLE)
 
-TEST(vcMath, TriangleTest)
+TEST(vcMath, TriangleTest_PointOnTrianglePlane)
 {
   udDouble3 p0{ 0.0, 1.0, 0.0 };
   udDouble3 p1{ -1.0, 0.0, 0.0 };
@@ -15,7 +15,6 @@ TEST(vcMath, TriangleTest)
   udDouble3 out;
   udDouble3 testPoint = {};
   double rt2on2 = 0.70710678118654752440084436210485;
-  double rt2 = 1.4142135623730950488016887242097;
 
   //------------------------------------------------------------------------
   // Point inside triangle
@@ -46,11 +45,11 @@ TEST(vcMath, TriangleTest)
   //------------------------------------------------------------------------
 
   testPoint = udDouble3::create(1.0, 1.0, 0.0);
-  EXPECT_NEAR(TRI_DIST, rt2on2, EPSILON);
+  EXPECT_NEAR(TRI_DIST, rt2on2, EPSILON_DOUBLE);
   EXPECT_VEC_NEAR(out, udDouble3::create(0.5, 0.5, 0.0));
 
   testPoint = udDouble3::create(-1.0, 1.0, 0.0);
-  EXPECT_NEAR(TRI_DIST, rt2on2, EPSILON);
+  EXPECT_NEAR(TRI_DIST, rt2on2, EPSILON_DOUBLE);
   EXPECT_VEC_NEAR(out, udDouble3::create(-0.5, 0.5, 0.0));
 
   testPoint = udDouble3::create(0.0, -1.0, 0.0);
@@ -79,31 +78,184 @@ TEST(vcMath, TriangleTest)
   //------------------------------------------------------------------------
 
   testPoint = udDouble3::create(0.5, 0.5, 0.0);
-  EXPECT_NEAR(TRI_DIST, 0.0, EPSILON);
+  EXPECT_NEAR(TRI_DIST, 0.0, EPSILON_DOUBLE);
   EXPECT_VEC_NEAR(out, udDouble3::create(0.5, 0.5, 0.0));
 
   testPoint = udDouble3::create(-0.5, 0.5, 0.0);
-  EXPECT_NEAR(TRI_DIST, 0.0, EPSILON);
+  EXPECT_NEAR(TRI_DIST, 0.0, EPSILON_DOUBLE);
   EXPECT_VEC_NEAR(out, udDouble3::create(-0.5, 0.5, 0.0));
 
   testPoint = udDouble3::create(0.0, 0.0, 0.0);
-  EXPECT_NEAR(TRI_DIST, 0.0, EPSILON);
+  EXPECT_NEAR(TRI_DIST, 0.0, EPSILON_DOUBLE);
   EXPECT_VEC_NEAR(out, udDouble3::create(0.0, 0.0, 0.0));
+}
 
-  //------------------------------------------------------------------------
-  // Point outside triangle - closest point is a vertex, varying z
-  //------------------------------------------------------------------------
-
-  testPoint = udDouble3::create(0.0, -1.0, -1.0);
-  EXPECT_NEAR(TRI_DIST, rt2, EPSILON);
-  EXPECT_VEC_NEAR(out, udDouble3::create(0.0, 0.0, 0.0));
-
+TEST(vcMath, TriangleTest_PointAboveTrianglePlane)
+{
+  udDouble3 p0{ 0.0, 1.0, 0.0 };
+  udDouble3 p1{ -1.0, 0.0, 0.0 };
+  udDouble3 p2{ 1.0, 0.0, 0.0 };
+  udDouble3 out;
+  udDouble3 testPoint = {};
+  double rt2 = 1.4142135623730950488016887242097;
   double rt6on2 = 1.2247448713915890490986420373529;
+
+  //------------------------------------------------------------------------
+  // Point inside triangle
+  //------------------------------------------------------------------------
+
+  testPoint = udDouble3::create(0.0, 0.5, 1.0);
+  EXPECT_DOUBLE_EQ(TRI_DIST, 1.0);
+  EXPECT_VEC_NEAR(out, udDouble3::create(0.0, 0.5, 0.0));
+
+  //------------------------------------------------------------------------
+  // Point outside triangle - closest point is a vertex
+  //------------------------------------------------------------------------
+
+  testPoint = udDouble3::create(0.0, 2.0, 1.0);
+  EXPECT_NEAR(TRI_DIST, rt2, EPSILON_DOUBLE);
+  EXPECT_VEC_NEAR(out, p0);
+
+  testPoint = udDouble3::create(-2.0, 0.0, 1.0);
+  EXPECT_NEAR(TRI_DIST, rt2, EPSILON_DOUBLE);
+  EXPECT_VEC_NEAR(out, p1);
+
+  testPoint = udDouble3::create(2.0, 0.0, 1.0);
+  EXPECT_NEAR(TRI_DIST, rt2, EPSILON_DOUBLE);
+  EXPECT_VEC_NEAR(out, p2);
+
+  //------------------------------------------------------------------------
+  // Point outside triangle - closest point is an edge
+  //------------------------------------------------------------------------
+
   testPoint = udDouble3::create(1.0, 1.0, 1.0);
-  EXPECT_NEAR(TRI_DIST, rt6on2, EPSILON);
+  EXPECT_NEAR(TRI_DIST, rt6on2, EPSILON_DOUBLE);
   EXPECT_VEC_NEAR(out, udDouble3::create(0.5, 0.5, 0.0));
 
-  testPoint = udDouble3::create(-1.0, 1.0, -1.0);
-  EXPECT_NEAR(TRI_DIST, rt6on2, EPSILON);
+  
+  testPoint = udDouble3::create(-1.0, 1.0, 1.0);
+  EXPECT_NEAR(TRI_DIST, rt6on2, EPSILON_DOUBLE);
   EXPECT_VEC_NEAR(out, udDouble3::create(-0.5, 0.5, 0.0));
+
+  testPoint = udDouble3::create(0.0, -1.0, 1.0);
+  EXPECT_NEAR(TRI_DIST, rt2, EPSILON_DOUBLE);
+  EXPECT_VEC_NEAR(out, udDouble3::create(0.0, 0.0, 0.0));
+
+
+  //------------------------------------------------------------------------
+  // Point on vertex
+  //------------------------------------------------------------------------
+
+  testPoint = udDouble3::create(0.0, 1.0, 1.0);
+  EXPECT_DOUBLE_EQ(TRI_DIST, 1.0);
+  EXPECT_VEC_NEAR(out, p0);
+  
+  testPoint = udDouble3::create(-1.0, 0.0, 1.0);
+  EXPECT_DOUBLE_EQ(TRI_DIST, 1.0);
+  EXPECT_VEC_NEAR(out, p1);
+  
+  testPoint = udDouble3::create(1.0, 0.0, 1.0);
+  EXPECT_DOUBLE_EQ(TRI_DIST, 1.0);
+  EXPECT_VEC_NEAR(out, p2);
+
+  //------------------------------------------------------------------------
+  // Point on edge
+  //------------------------------------------------------------------------
+
+  testPoint = udDouble3::create(0.5, 0.5, 1.0);
+  EXPECT_NEAR(TRI_DIST, 1.0, EPSILON_DOUBLE);
+  EXPECT_VEC_NEAR(out, udDouble3::create(0.5, 0.5, 0.0));
+
+  testPoint = udDouble3::create(-0.5, 0.5, 1.0);
+  EXPECT_NEAR(TRI_DIST, 1.0, EPSILON_DOUBLE);
+  EXPECT_VEC_NEAR(out, udDouble3::create(-0.5, 0.5, 0.0));
+
+  testPoint = udDouble3::create(0.0, 0.0, 1.0);
+  EXPECT_NEAR(TRI_DIST, 1.0, EPSILON_DOUBLE);
+  EXPECT_VEC_NEAR(out, udDouble3::create(0.0, 0.0, 0.0));
+}
+
+TEST(vcMath, TriangleTest_PointBelowTrianglePlane)
+{
+  udDouble3 p0{ 0.0, 1.0, 0.0 };
+  udDouble3 p1{ -1.0, 0.0, 0.0 };
+  udDouble3 p2{ 1.0, 0.0, 0.0 };
+  udDouble3 out;
+  udDouble3 testPoint = {};
+  double rt2 = 1.4142135623730950488016887242097;
+  double rt6on2 = 1.2247448713915890490986420373529;
+
+  //------------------------------------------------------------------------
+  // Point inside triangle
+  //------------------------------------------------------------------------
+
+  testPoint = udDouble3::create(0.0, 0.5, -1.0);
+  EXPECT_DOUBLE_EQ(TRI_DIST, 1.0);
+  EXPECT_VEC_NEAR(out, udDouble3::create(0.0, 0.5, 0.0));
+
+  //------------------------------------------------------------------------
+  // Point outside triangle - closest point is a vertex
+  //------------------------------------------------------------------------
+
+  testPoint = udDouble3::create(0.0, 2.0, -1.0);
+  EXPECT_NEAR(TRI_DIST, rt2, EPSILON_DOUBLE);
+  EXPECT_VEC_NEAR(out, p0);
+
+  testPoint = udDouble3::create(-2.0, 0.0, -1.0);
+  EXPECT_NEAR(TRI_DIST, rt2, EPSILON_DOUBLE);
+  EXPECT_VEC_NEAR(out, p1);
+
+  testPoint = udDouble3::create(2.0, 0.0, -1.0);
+  EXPECT_NEAR(TRI_DIST, rt2, EPSILON_DOUBLE);
+  EXPECT_VEC_NEAR(out, p2);
+
+  //------------------------------------------------------------------------
+  // Point outside triangle - closest point is an edge
+  //------------------------------------------------------------------------
+
+  testPoint = udDouble3::create(1.0, 1.0, -1.0);
+  EXPECT_NEAR(TRI_DIST, rt6on2, EPSILON_DOUBLE);
+  EXPECT_VEC_NEAR(out, udDouble3::create(0.5, 0.5, 0.0));
+
+
+  testPoint = udDouble3::create(-1.0, 1.0, -1.0);
+  EXPECT_NEAR(TRI_DIST, rt6on2, EPSILON_DOUBLE);
+  EXPECT_VEC_NEAR(out, udDouble3::create(-0.5, 0.5, 0.0));
+
+  testPoint = udDouble3::create(0.0, -1.0, -1.0);
+  EXPECT_NEAR(TRI_DIST, rt2, EPSILON_DOUBLE);
+  EXPECT_VEC_NEAR(out, udDouble3::create(0.0, 0.0, 0.0));
+
+
+  //------------------------------------------------------------------------
+  // Point on vertex
+  //------------------------------------------------------------------------
+
+  testPoint = udDouble3::create(0.0, 1.0, -1.0);
+  EXPECT_DOUBLE_EQ(TRI_DIST, 1.0);
+  EXPECT_VEC_NEAR(out, p0);
+
+  testPoint = udDouble3::create(-1.0, 0.0, -1.0);
+  EXPECT_DOUBLE_EQ(TRI_DIST, 1.0);
+  EXPECT_VEC_NEAR(out, p1);
+
+  testPoint = udDouble3::create(1.0, 0.0, -1.0);
+  EXPECT_DOUBLE_EQ(TRI_DIST, 1.0);
+  EXPECT_VEC_NEAR(out, p2);
+
+  //------------------------------------------------------------------------
+  // Point on edge
+  //------------------------------------------------------------------------
+
+  testPoint = udDouble3::create(0.5, 0.5, -1.0);
+  EXPECT_NEAR(TRI_DIST, 1.0, EPSILON_DOUBLE);
+  EXPECT_VEC_NEAR(out, udDouble3::create(0.5, 0.5, 0.0));
+
+  testPoint = udDouble3::create(-0.5, 0.5, -1.0);
+  EXPECT_NEAR(TRI_DIST, 1.0, EPSILON_DOUBLE);
+  EXPECT_VEC_NEAR(out, udDouble3::create(-0.5, 0.5, 0.0));
+
+  testPoint = udDouble3::create(0.0, 0.0, -1.0);
+  EXPECT_NEAR(TRI_DIST, 1.0, EPSILON_DOUBLE);
+  EXPECT_VEC_NEAR(out, udDouble3::create(0.0, 0.0, 0.0));
 }


### PR DESCRIPTION
The current function was incorrectly returning the closest point when the projected `point` was within the triangle. Additionally, the current algorithm uses both a barycentric and closest-point-to-edge approach. I wondered if there was a more succinct and efficient approach. Turns out there is as explained in 'Real Time Collision Detection' by Christer Ericson, p.141; we can use the triangle's Voronoi regions to determine which feature of the triangle the point is closest to, and then project the point onto the feature to find the closest point.

Also added more exhaustive range of tests, testing on all triangle features on, above and below the triangle plane.