### PR TITLE
Allowing child nodes to render after a parent node renders

### DIFF
--- a/src/rendering/vcSceneLayerRenderer.cpp
+++ b/src/rendering/vcSceneLayerRenderer.cpp
@@ -120,12 +120,13 @@ bool vcSceneLayerRenderer_RecursiveRender(vcSceneLayerRenderer *pSceneLayerRende
   bool shouldRender = (pNode->childrenCount == 0 || nodeScreenSize < pNode->lodSelectionValue);
   bool canRender = (pNode->internalsLoadState >= vcSceneLayerNode::vcILS_NodeInternals);
 
+  bool hasNodeRendered = false;
   if (shouldRender)
   {
     if (vcSceneLayer_ExpandNodeForRendering(pSceneLayerRenderer->pSceneLayer, pNode))
     {
       vcSceneLayerRenderer_RenderNode(pSceneLayerRenderer, pNode, pColourOverride, shadowsPass);
-      return true;
+      hasNodeRendered = true;
     }
 
     // continue, as child may be able to draw
@@ -137,6 +138,9 @@ bool vcSceneLayerRenderer_RecursiveRender(vcSceneLayerRenderer *pSceneLayerRende
     vcSceneLayerNode *pChildNode = &pNode->pChildren[i];
     allChildrenWereRendered = vcSceneLayerRenderer_RecursiveRender(pSceneLayerRenderer, pChildNode, screenResolution, pColourOverride, shadowsPass) && allChildrenWereRendered;
   }
+
+  if (hasNodeRendered)
+    return hasNodeRendered;
 
   // If any children can't render, draw this node
   // This *may* cause some occlusion sometimes with partial children loaded, but its


### PR DESCRIPTION
[AB#421](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/421)

For reference, each node in the tree contained geometry data (exactly one item to be exact). When we determine we need to render a node, we need to render that node as well as continue to test all children. I had a look at some other .slpk files and this seems to be a common way of setting up the tree. However the [specification](http://docs.opengeospatial.org/cs/17-014r7/17-014r7.html#_persistence) suggests you can have an arbitrary of geometry attached to each node. I imagine one could set up the tree such that each node will link all encapsulating geometry. In this case, rendering a node _and_ its children would be a waste.