### PR TITLE
creating VSM poly meshes back on main thread

### DIFF
--- a/src/rendering/vcPolygonModel.cpp
+++ b/src/rendering/vcPolygonModel.cpp
@@ -84,9 +84,9 @@ struct AsyncPolygonModelLoadMeshInfo
   vcPolygonModel *pPolygonModel;
   vcPolygonModelMesh *pMesh;
   vcP3N3UV2Vertex *pVerts;
-  const vcVertexLayoutTypes* pMeshLayout;
+  const vcVertexLayoutTypes *pMeshLayout;
   int totalTypes;
-  void* pIndices;
+  void *pIndices;
   uint32_t currentIndices;
   vcMeshFlags flags;
 };
@@ -162,7 +162,7 @@ epilogue:
   return result;
 }
 
-udResult vcPolygonModel_CreateFromVSMFInMemory(vcPolygonModel **ppModel, char *pData, int dataLength, udWorkerPool* pWorkerPool)
+udResult vcPolygonModel_CreateFromVSMFInMemory(vcPolygonModel **ppModel, char *pData, int dataLength, udWorkerPool *pWorkerPool)
 {
   if (pData == nullptr || (size_t)dataLength < sizeof(VSMFHeader))
     return udR_InvalidParameter_;
@@ -228,9 +228,9 @@ udResult vcPolygonModel_CreateFromVSMFInMemory(vcPolygonModel **ppModel, char *p
 
     // override material id for now
     pNewModel->pMeshes[i].materialID = vcPMST_P3N3UV2_Opaque;
-
+    
     size_t vertArraySize = sizeof(vcP3N3UV2Vertex) * pNewModel->pMeshes[i].numVertices;
-    vcP3N3UV2Vertex* pVerts = (vcP3N3UV2Vertex*)pFilePos;
+    vcP3N3UV2Vertex *pVerts = (vcP3N3UV2Vertex*)pFilePos;
     pFilePos += vertArraySize;
 
     // TODO: Assume these all need flipping
@@ -241,7 +241,7 @@ udResult vcPolygonModel_CreateFromVSMFInMemory(vcPolygonModel **ppModel, char *p
     }
 
     size_t indexArraySize = sizeof(uint16_t) * pNewModel->pMeshes[i].numElements;
-    uint16_t *pIndices = (uint16_t *)pFilePos;
+    uint16_t *pIndices = (uint16_t*)pFilePos;
     pFilePos += indexArraySize;
 
     for (int t = 0; t < header.numTextures; ++t)
@@ -261,17 +261,15 @@ udResult vcPolygonModel_CreateFromVSMFInMemory(vcPolygonModel **ppModel, char *p
       pFilePos += textureFileSize;
     }
 
-    AsyncPolygonModelLoadMeshInfo* pLoadInfo = udAllocType(AsyncPolygonModelLoadMeshInfo, 1, udAF_Zero);
+    AsyncPolygonModelLoadMeshInfo *pLoadInfo = udAllocType(AsyncPolygonModelLoadMeshInfo, 1, udAF_Zero);
     UD_ERROR_NULL(pLoadInfo, udR_MemoryAllocationFailure);
 
     pLoadInfo->pPolygonModel = pNewModel;
     pLoadInfo->pMesh = &pNewModel->pMeshes[i];
-    pLoadInfo->pVerts = (vcP3N3UV2Vertex*)udAlloc(vertArraySize);
-    memcpy(pLoadInfo->pVerts, pVerts, vertArraySize);
+    pLoadInfo->pVerts = (vcP3N3UV2Vertex*)udMemDup(pVerts, vertArraySize, 0, udAF_None);
     pLoadInfo->pMeshLayout = vcP3N3UV2VertexLayout;
     pLoadInfo->totalTypes = (int)udLengthOf(vcP3N3UV2VertexLayout);
-    pLoadInfo->pIndices = (uint16_t*)udAlloc(indexArraySize);
-    memcpy(pLoadInfo->pIndices, pIndices, indexArraySize);
+    pLoadInfo->pIndices = (uint16_t*)udMemDup(pIndices, indexArraySize, 0, udAF_None);
     pLoadInfo->currentIndices = pNewModel->pMeshes[i].numElements;
     pLoadInfo->flags = vcMF_IndexShort;
 
@@ -471,7 +469,7 @@ udResult vcPolygonModel_CreateFromURL(vcPolygonModel **ppModel, const char *pURL
     int64_t fileLength = 0;
 
     UD_ERROR_CHECK(udFile_Load(pURL, &pMemory, &fileLength));
-    UD_ERROR_CHECK(vcPolygonModel_CreateFromVSMFInMemory(ppModel, (char *)pMemory, (int)fileLength, pWorkerPool));
+    UD_ERROR_CHECK(vcPolygonModel_CreateFromVSMFInMemory(ppModel, (char*)pMemory, (int)fileLength, pWorkerPool));
 
     udFree(pMemory);
   }

--- a/src/rendering/vcPolygonModel.cpp
+++ b/src/rendering/vcPolygonModel.cpp
@@ -84,6 +84,11 @@ struct AsyncPolygonModelLoadMeshInfo
   vcPolygonModel *pPolygonModel;
   vcPolygonModelMesh *pMesh;
   vcP3N3UV2Vertex *pVerts;
+  const vcVertexLayoutTypes* pMeshLayout;
+  int totalTypes;
+  void* pIndices;
+  uint32_t currentIndices;
+  vcMeshFlags flags;
 };
 
 void vcPolygonModel_MainThreadCreateMesh(void *pData)
@@ -92,9 +97,10 @@ void vcPolygonModel_MainThreadCreateMesh(void *pData)
   if (!pLoadInfo->pPolygonModel->keepLoading)
     return;
 
-  vcMesh_Create(&pLoadInfo->pMesh->pMesh, pDefaultMeshLayout, DefaultTotalTypes, pLoadInfo->pVerts, pLoadInfo->pMesh->numVertices, nullptr, 0, vcMF_NoIndexBuffer);
+  vcMesh_Create(&pLoadInfo->pMesh->pMesh, pLoadInfo->pMeshLayout, pLoadInfo->totalTypes, pLoadInfo->pVerts, pLoadInfo->pMesh->numVertices, pLoadInfo->pIndices, pLoadInfo->currentIndices, pLoadInfo->flags);
 
   udFree(pLoadInfo->pVerts);
+  udFree(pLoadInfo->pIndices);
 }
 
 vcPolygonModelShaderType vcPolygonModel_GetShaderType(const vcVertexLayoutTypes *pMeshLayout, int totalTypes)
@@ -156,7 +162,7 @@ epilogue:
   return result;
 }
 
-udResult vcPolygonModel_CreateFromVSMFInMemory(vcPolygonModel **ppModel, char *pData, int dataLength)
+udResult vcPolygonModel_CreateFromVSMFInMemory(vcPolygonModel **ppModel, char *pData, int dataLength, udWorkerPool* pWorkerPool)
 {
   if (pData == nullptr || (size_t)dataLength < sizeof(VSMFHeader))
     return udR_InvalidParameter_;
@@ -223,8 +229,9 @@ udResult vcPolygonModel_CreateFromVSMFInMemory(vcPolygonModel **ppModel, char *p
     // override material id for now
     pNewModel->pMeshes[i].materialID = vcPMST_P3N3UV2_Opaque;
 
-    vcP3N3UV2Vertex *pVerts = (vcP3N3UV2Vertex *)pFilePos;
-    pFilePos += sizeof(*pVerts) * pNewModel->pMeshes[i].numVertices;
+    size_t vertArraySize = sizeof(vcP3N3UV2Vertex) * pNewModel->pMeshes[i].numVertices;
+    vcP3N3UV2Vertex* pVerts = (vcP3N3UV2Vertex*)pFilePos;
+    pFilePos += vertArraySize;
 
     // TODO: Assume these all need flipping
     for (uint32_t v = 0; v < pNewModel->pMeshes[i].numVertices; ++v)
@@ -233,8 +240,9 @@ udResult vcPolygonModel_CreateFromVSMFInMemory(vcPolygonModel **ppModel, char *p
       pVert->uv.y = 1.0f - pVert->uv.y;
     }
 
+    size_t indexArraySize = sizeof(uint16_t) * pNewModel->pMeshes[i].numElements;
     uint16_t *pIndices = (uint16_t *)pFilePos;
-    pFilePos += sizeof(*pIndices) * pNewModel->pMeshes[i].numElements;
+    pFilePos += indexArraySize;
 
     for (int t = 0; t < header.numTextures; ++t)
     {
@@ -245,7 +253,7 @@ udResult vcPolygonModel_CreateFromVSMFInMemory(vcPolygonModel **ppModel, char *p
       if (t == 0)
       {
         void *pTextureData = pFilePos;
-        if (!vcTexture_CreateFromMemory(&pNewModel->pMeshes[i].material.pTexture, pTextureData, textureFileSize))
+        if (!vcTexture_AsyncCreateFromMemory(&pNewModel->pMeshes[i].material.pTexture, pWorkerPool, pTextureData, textureFileSize))
         {
           // TODO: (EVC-570)
         }
@@ -253,7 +261,26 @@ udResult vcPolygonModel_CreateFromVSMFInMemory(vcPolygonModel **ppModel, char *p
       pFilePos += textureFileSize;
     }
 
-    UD_ERROR_CHECK(vcMesh_Create(&pNewModel->pMeshes[i].pMesh, vcP3N3UV2VertexLayout, (int)udLengthOf(vcP3N3UV2VertexLayout), pVerts, pNewModel->pMeshes[i].numVertices, pIndices, pNewModel->pMeshes[i].numElements, vcMF_IndexShort));
+    AsyncPolygonModelLoadMeshInfo* pLoadInfo = udAllocType(AsyncPolygonModelLoadMeshInfo, 1, udAF_Zero);
+    UD_ERROR_NULL(pLoadInfo, udR_MemoryAllocationFailure);
+
+    pLoadInfo->pPolygonModel = pNewModel;
+    pLoadInfo->pMesh = &pNewModel->pMeshes[i];
+    pLoadInfo->pVerts = (vcP3N3UV2Vertex*)udAlloc(vertArraySize);
+    memcpy(pLoadInfo->pVerts, pVerts, vertArraySize);
+    pLoadInfo->pMeshLayout = vcP3N3UV2VertexLayout;
+    pLoadInfo->totalTypes = (int)udLengthOf(vcP3N3UV2VertexLayout);
+    pLoadInfo->pIndices = (uint16_t*)udAlloc(indexArraySize);
+    memcpy(pLoadInfo->pIndices, pIndices, indexArraySize);
+    pLoadInfo->currentIndices = pNewModel->pMeshes[i].numElements;
+    pLoadInfo->flags = vcMF_IndexShort;
+
+    if (udWorkerPool_AddTask(pWorkerPool, nullptr, pLoadInfo, true, vcPolygonModel_MainThreadCreateMesh) != udR_Success)
+    {
+      udFree(pLoadInfo->pVerts);
+      udFree(pLoadInfo->pIndices);
+      udFree(pLoadInfo);
+    }
   }
 
   *ppModel = pNewModel;
@@ -390,6 +417,11 @@ udResult vcPolygonModel_CreateFromOBJ(vcPolygonModel **ppPolygonModel, const cha
     pLoadInfo->pPolygonModel = pPolygonModel;
     pLoadInfo->pMesh = pMesh;
     pLoadInfo->pVerts = pVerts;
+    pLoadInfo->pMeshLayout = pDefaultMeshLayout;
+    pLoadInfo->totalTypes = DefaultTotalTypes;
+    pLoadInfo->pIndices = nullptr;
+    pLoadInfo->currentIndices = 0;
+    pLoadInfo->flags = vcMF_NoIndexBuffer;
 
     if (udWorkerPool_AddTask(pWorkerPool, nullptr, pLoadInfo, true, vcPolygonModel_MainThreadCreateMesh) != udR_Success)
     {
@@ -439,7 +471,7 @@ udResult vcPolygonModel_CreateFromURL(vcPolygonModel **ppModel, const char *pURL
     int64_t fileLength = 0;
 
     UD_ERROR_CHECK(udFile_Load(pURL, &pMemory, &fileLength));
-    UD_ERROR_CHECK(vcPolygonModel_CreateFromVSMFInMemory(ppModel, (char *)pMemory, (int)fileLength));
+    UD_ERROR_CHECK(vcPolygonModel_CreateFromVSMFInMemory(ppModel, (char *)pMemory, (int)fileLength, pWorkerPool));
 
     udFree(pMemory);
   }

--- a/src/rendering/vcPolygonModel.h
+++ b/src/rendering/vcPolygonModel.h
@@ -59,6 +59,6 @@ udResult vcPolygonModel_Destroy(vcPolygonModel **ppModel);
 udResult vcPolygonModel_Render(vcPolygonModel *pModel, const udDouble4x4 &modelMatrix, const udDouble4x4 &viewProjectionMatrix, const vcPolyModelPass &passType = vcPMP_Standard, vcTexture *pDiffuseOverride = nullptr, const udFloat4 *pColourOverride = nullptr);
 
 // TODO: (EVC-570) Parsing formats should be in their own module, not here
-udResult vcPolygonModel_CreateFromVSMFInMemory(vcPolygonModel **ppModel, char *pData, int dataLength, udWorkerPool* pWorkerPool);
+udResult vcPolygonModel_CreateFromVSMFInMemory(vcPolygonModel **ppModel, char *pData, int dataLength, udWorkerPool *pWorkerPool);
 
 #endif // vcPolygonModel_h__

--- a/src/rendering/vcPolygonModel.h
+++ b/src/rendering/vcPolygonModel.h
@@ -59,6 +59,6 @@ udResult vcPolygonModel_Destroy(vcPolygonModel **ppModel);
 udResult vcPolygonModel_Render(vcPolygonModel *pModel, const udDouble4x4 &modelMatrix, const udDouble4x4 &viewProjectionMatrix, const vcPolyModelPass &passType = vcPMP_Standard, vcTexture *pDiffuseOverride = nullptr, const udFloat4 *pColourOverride = nullptr);
 
 // TODO: (EVC-570) Parsing formats should be in their own module, not here
-udResult vcPolygonModel_CreateFromVSMFInMemory(vcPolygonModel **ppModel, char *pData, int dataLength);
+udResult vcPolygonModel_CreateFromVSMFInMemory(vcPolygonModel **ppModel, char *pData, int dataLength, udWorkerPool* pWorkerPool);
 
 #endif // vcPolygonModel_h__

--- a/src/scene/vcLiveFeed.cpp
+++ b/src/scene/vcLiveFeed.cpp
@@ -420,7 +420,7 @@ void vcLiveFeed::AddToScene(vcState *pProgramState, vcRenderData *pRenderData)
             if (pItem->loadStatus == vcLiveFeedPolyCache::LS_Downloaded)
             {
               pItem->loadStatus = vcLiveFeedPolyCache::LS_Loaded;
-              if (vcPolygonModel_CreateFromVSMFInMemory(&pItem->pModel, (char*)pItem->pModelData, (int)pItem->modelDataLength) != udR_Success)
+              if (vcPolygonModel_CreateFromVSMFInMemory(&pItem->pModel, (char*)pItem->pModelData, (int)pItem->modelDataLength, pProgramState->pWorkerPool) != udR_Success)
               {
                 // TODO: (EVC-570) retry? draw some error mesh?
                 pItem->loadStatus = vcLiveFeedPolyCache::LS_Failed;

--- a/src/scene/vcPolyModelNode.cpp
+++ b/src/scene/vcPolyModelNode.cpp
@@ -46,8 +46,7 @@ vcPolyModelNode::vcPolyModelNode(vdkProject *pProject, vdkProjectNode *pNode, vc
     pLoadInfo->pNode = this;
     pLoadInfo->pProgramState = pProgramState;
 
-    // Queue for load
-    udWorkerPool_AddTask(pProgramState->pWorkerPool, vcPolyModelNode_LoadModel, pLoadInfo, true);
+    vcPolyModelNode_LoadModel(pLoadInfo);
   }
   else
   {

--- a/src/scene/vcPolyModelNode.cpp
+++ b/src/scene/vcPolyModelNode.cpp
@@ -46,7 +46,7 @@ vcPolyModelNode::vcPolyModelNode(vdkProject *pProject, vdkProjectNode *pNode, vc
     pLoadInfo->pNode = this;
     pLoadInfo->pProgramState = pProgramState;
 
-    vcPolyModelNode_LoadModel(pLoadInfo);
+    udWorkerPool_AddTask(pProgramState->pWorkerPool, vcPolyModelNode_LoadModel, pLoadInfo, true);
   }
   else
   {


### PR DESCRIPTION
[AB#1079](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1079)

While fixing another another bug I came across this crash. When loading a VSM, we were trying to create the mesh on a worker thread. This caused a crash in (at least) OpenGL as we are making OpenGL calls on a thread that does not own the OpenGL context. One possible solution would be to transfer ownership of the context to the thread before we make our gl calls. I decided against this however as we create all other meshes on the main thread. I am not sure why VSMs are treated differently.