### PR TITLE
VSM focus issue fix

### DIFF
--- a/src/scene/vcFolder.cpp
+++ b/src/scene/vcFolder.cpp
@@ -315,7 +315,7 @@ void vcFolder::HandleImGui(vcState *pProgramState, size_t *pItemID)
         ImGui::EndPopup();
       }
 
-      if (pNode->itemtype != vdkPNT_Folder /*&& pSceneItem->GetWorldSpacePivot() != udDouble3::zero()*/ && ImGui::IsMouseDoubleClicked(0) && ImGui::IsItemHovered())
+      if (pSceneItem->Is3DSceneObject() && ImGui::IsMouseDoubleClicked(0) && ImGui::IsItemHovered())
       {
         if (pSceneItem->m_pPreferredProjection != nullptr)
           vcProject_UseProjectionFromItem(pProgramState, pSceneItem);

--- a/src/scene/vcFolder.cpp
+++ b/src/scene/vcFolder.cpp
@@ -315,7 +315,7 @@ void vcFolder::HandleImGui(vcState *pProgramState, size_t *pItemID)
         ImGui::EndPopup();
       }
 
-      if (pNode->itemtype != vdkPNT_Folder && pSceneItem->GetWorldSpacePivot() != udDouble3::zero() && ImGui::IsMouseDoubleClicked(0) && ImGui::IsItemHovered())
+      if (pNode->itemtype != vdkPNT_Folder /*&& pSceneItem->GetWorldSpacePivot() != udDouble3::zero()*/ && ImGui::IsMouseDoubleClicked(0) && ImGui::IsItemHovered())
       {
         if (pSceneItem->m_pPreferredProjection != nullptr)
           vcProject_UseProjectionFromItem(pProgramState, pSceneItem);

--- a/src/scene/vcFolder.h
+++ b/src/scene/vcFolder.h
@@ -11,14 +11,14 @@ public:
   vcFolder(vdkProject *pProject, vdkProjectNode *pNode, vcState *pProgramState);
   ~vcFolder() {};
 
-  void OnNodeUpdate(vcState *pProgramState);
+  void OnNodeUpdate(vcState *pProgramState) override;
 
-  void ChangeProjection(const udGeoZone &newZone);
+  void ChangeProjection(const udGeoZone &newZone) override;
 
   bool Is3DSceneObject() const override { return false; }
-  void AddToScene(vcState *pProgramState, vcRenderData *pRenderData);
-  void ApplyDelta(vcState *pProgramState, const udDouble4x4 &delta);
-  void HandleImGui(vcState *pProgramState, size_t *pItemID);
+  void AddToScene(vcState *pProgramState, vcRenderData *pRenderData) override;
+  void ApplyDelta(vcState *pProgramState, const udDouble4x4 &delta) override;
+  void HandleImGui(vcState *pProgramState, size_t *pItemID) override;
   void Cleanup(vcState *pProgramState);
 };
 

--- a/src/scene/vcFolder.h
+++ b/src/scene/vcFolder.h
@@ -19,7 +19,7 @@ public:
   void AddToScene(vcState *pProgramState, vcRenderData *pRenderData) override;
   void ApplyDelta(vcState *pProgramState, const udDouble4x4 &delta) override;
   void HandleImGui(vcState *pProgramState, size_t *pItemID) override;
-  void Cleanup(vcState *pProgramState);
+  void Cleanup(vcState *pProgramState) override;
 };
 
 #endif //vcFolder_h__

--- a/src/scene/vcFolder.h
+++ b/src/scene/vcFolder.h
@@ -15,6 +15,7 @@ public:
 
   void ChangeProjection(const udGeoZone &newZone);
 
+  bool Is3DSceneObject() const override { return false; }
   void AddToScene(vcState *pProgramState, vcRenderData *pRenderData);
   void ApplyDelta(vcState *pProgramState, const udDouble4x4 &delta);
   void HandleImGui(vcState *pProgramState, size_t *pItemID);

--- a/src/scene/vcSceneItem.h
+++ b/src/scene/vcSceneItem.h
@@ -50,6 +50,8 @@ public:
   vcSceneItem(vcState *pProgramState, const char *pType, const char *pName);
   virtual ~vcSceneItem();
 
+  virtual bool Is3DSceneObject() const { return true; }
+
   // This lets SceneItems know that their vdkProjectNode has changed
   virtual void OnNodeUpdate(vcState *pProgramState) = 0;
 


### PR DESCRIPTION
[AB#515](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/515)

Previously it seemed we required scene items to have a non-zero `WorldSpacePivot()` in order to be brought into focus. I'm not sure why this is. The world space pivot is built off the item's local space pivot, which can indeed be it's origin - the zero-vector. And if the the item's world space matrix has zero translation, the world space pivot will again remain at the origin.

I believe this check exists for the case where it does not make sense to focus on that item, such as a folder. If this check is important, we might need a `Is3DSceneItem()` method to determine this explicitly. 