### PR TITLE
Tile Renderer Changes

### DIFF
--- a/src/gl/directx11/vcRenderShaders.cpp
+++ b/src/gl/directx11/vcRenderShaders.cpp
@@ -483,13 +483,14 @@ const char *const g_tileVertexShader = VERT_HEADER R"shader(
   };
 
   // This should match CPU struct size
-  #define VERTEX_COUNT 2
+  #define VERTEX_COUNT 3
 
   cbuffer u_EveryObject : register(b0)
   {
     float4x4 u_projection;
     float4 u_eyePositions[VERTEX_COUNT * VERTEX_COUNT];
     float4 u_colour;
+    float4 u_uvOffsetScale;
   };
 
   PS_INPUT main(VS_INPUT input)
@@ -499,7 +500,7 @@ const char *const g_tileVertexShader = VERT_HEADER R"shader(
     // note: could have precision issues on some devices
     float4 finalClipPos = mul(u_projection, u_eyePositions[int(input.pos.z)]);
     output.colour = u_colour;
-    output.uv = input.pos.xy;
+    output.uv = u_uvOffsetScale.xy + u_uvOffsetScale.zw * input.pos.xy;
     output.pos = finalClipPos;
 
     output.fLogDepth.x = 1.0 + output.pos.w;

--- a/src/gl/opengl/vcRenderShaders.cpp
+++ b/src/gl/opengl/vcRenderShaders.cpp
@@ -404,13 +404,14 @@ out vec2 v_uv;
 out float v_fLogDepth;
 
 // This should match CPU struct size
-#define VERTEX_COUNT 2
+#define VERTEX_COUNT 3
 
 layout (std140) uniform u_EveryObject
 {
   mat4 u_projection;
   vec4 u_eyePositions[VERTEX_COUNT * VERTEX_COUNT];
   vec4 u_colour;
+  vec4 u_uvOffsetScale;
 };
 
 // this could be used instead instead of writing to depth directly,
@@ -426,7 +427,7 @@ void main()
   // TODO: could have precision issues on some devices
   vec4 finalClipPos = u_projection * u_eyePositions[int(a_uv.z)];
 
-  v_uv = a_uv.xy;
+  v_uv = u_uvOffsetScale.xy + u_uvOffsetScale.zw * a_uv.xy;
   v_colour = u_colour;
   gl_Position = finalClipPos;
   v_fLogDepth = 1.0 + gl_Position.w;

--- a/src/rendering/vcTileRenderer.cpp
+++ b/src/rendering/vcTileRenderer.cpp
@@ -23,13 +23,11 @@
 
 enum
 {
-  TileVertexResolution = 2, // This should match GPU struct size
+  TileVertexResolution = 3, // This should match GPU struct size
   TileIndexResolution = (TileVertexResolution - 1),
 
   MaxTextureUploadsPerFrame = 3,
 };
-
-static const float sTileFadeSpeed = 2.15f;
 
 struct vcTileRenderer
 {
@@ -45,7 +43,6 @@ struct vcTileRenderer
   udDouble3 cameraPosition;
 
   std::vector<std::vector<vcQuadTreeNode*>> *pRenderQueue;
-  std::vector<vcQuadTreeNode*> *pTransparentTiles;
 
   // cache textures
   struct vcTileCache
@@ -69,6 +66,7 @@ struct vcTileRenderer
       udFloat4x4 projectionMatrix;
       udFloat4 eyePositions[TileVertexResolution * TileVertexResolution];
       udFloat4 colour;
+      udFloat4 uvOffsetScale;
     } everyObject;
   } presentShader;
 };
@@ -165,13 +163,6 @@ uint32_t vcTileRenderer_LoadThread(void *pThreadData)
         tileCenter = udDouble3::create(pNode->renderInfo.center, pRenderer->pSettings->maptiles.mapHeight);
         double distanceToCameraSqr = udMagSq3(tileCenter - pRenderer->cameraPosition);
 
-        // root (special case)
-        if (pNode == &pRenderer->quadTree.nodes.pPool[pRenderer->quadTree.rootIndex])
-        {
-          best = i;
-          break;
-        }
-
         bool betterNode = true;
         if (best != -1)
         {
@@ -246,7 +237,6 @@ uint32_t vcTileRenderer_LoadThread(void *pThreadData)
       pData = stbi_load_from_memory((stbi_uc*)pFileData, (int)fileLen, (int*)&width, (int*)&height, (int*)&channelCount, 4);
       UD_ERROR_NULL(pData, udR_InternalError);
 
-      pBestNode->renderInfo.transparency = 0.0f;
       pBestNode->renderInfo.width = width;
       pBestNode->renderInfo.height = height;
       pBestNode->renderInfo.pData = udMemDup(pData, sizeof(uint32_t)*width*height, 0, udAF_None);
@@ -370,7 +360,6 @@ udResult vcTileRenderer_Create(vcTileRenderer **ppTileRenderer, vcSettings *pSet
   UD_ERROR_CHECK(vcMesh_Create(&pTileRenderer->pFullTileMesh, vcP3VertexLayout, (int)udLengthOf(vcP3VertexLayout), verts, TileVertexResolution * TileVertexResolution, indicies, TileIndexResolution * TileIndexResolution * 6));
   UD_ERROR_CHECK(vcTexture_Create(&pTileRenderer->pEmptyTileTexture, 1, 1, &greyPixel));
 
-  pTileRenderer->pTransparentTiles = new std::vector<vcQuadTreeNode*>();
   pTileRenderer->pRenderQueue = new std::vector<std::vector<vcQuadTreeNode*>>();
   for (int i = 0; i < MaxVisibleTileLevel; ++i)
     pTileRenderer->pRenderQueue->push_back(std::vector<vcQuadTreeNode*>());
@@ -415,9 +404,7 @@ udResult vcTileRenderer_Destroy(vcTileRenderer **ppTileRenderer)
   vcMesh_Destroy(&pTileRenderer->pFullTileMesh);
   vcTexture_Destroy(&pTileRenderer->pEmptyTileTexture);
 
-  delete pTileRenderer->pTransparentTiles;
   delete pTileRenderer->pRenderQueue;
-  pTileRenderer->pTransparentTiles = nullptr;
   pTileRenderer->pRenderQueue = nullptr;
 
   vcQuadTree_Destroy(&(*ppTileRenderer)->quadTree);
@@ -438,8 +425,8 @@ bool vcTileRenderer_UpdateTileTexture(vcTileRenderer *pTileRenderer, vcQuadTreeN
     pNode->renderInfo.pTexture = nullptr;
     pNode->renderInfo.timeoutTime = pTileRenderer->totalTime;
 
-    udDouble2 min = udDouble2::create(pNode->worldBounds[0].x, pNode->worldBounds[2].y);
-    udDouble2 max = udDouble2::create(pNode->worldBounds[3].x, pNode->worldBounds[1].y);
+    udDouble2 min = udDouble2::create(pNode->worldBounds[0].x, pNode->worldBounds[6].y);
+    udDouble2 max = udDouble2::create(pNode->worldBounds[8].x, pNode->worldBounds[2].y);
     pNode->renderInfo.center = (max + min) * 0.5;
 
     pTileCache->tileLoadList.PushBack(pNode);
@@ -478,12 +465,6 @@ void vcTileRenderer_UpdateTextureQueuesRecursive(vcTileRenderer *pTileRenderer, 
     if (vcTileRenderer_UpdateTileTexture(pTileRenderer, pNode))
       ++tileUploadCount;
   }
-
-  if (pNode->renderInfo.loadStatus == vcNodeRenderInfo::vcTLS_Loaded && !pNode->renderInfo.fadingIn && pNode->renderInfo.transparency == 0.0f)
-  {
-    pNode->renderInfo.fadingIn = true;
-    pTileRenderer->pTransparentTiles->push_back(pNode);
-  }
 }
 
 void vcTileRenderer_UpdateTextureQueues(vcTileRenderer *pTileRenderer)
@@ -498,9 +479,6 @@ void vcTileRenderer_UpdateTextureQueues(vcTileRenderer *pTileRenderer)
 
   // update visible tiles textures
   vcTileRenderer_UpdateTextureQueuesRecursive(pTileRenderer, &pTileRenderer->quadTree.nodes.pPool[pTileRenderer->quadTree.rootIndex], tileUploadCount);
-
-  // always request root
-  vcTileRenderer_UpdateTileTexture(pTileRenderer, &pTileRenderer->quadTree.nodes.pPool[pTileRenderer->quadTree.rootIndex]);
 
   // remove from the queue any tiles that are invalid
   for (int i = 0; i < (int)pTileRenderer->cache.tileLoadList.length; ++i)
@@ -527,19 +505,17 @@ void vcTileRenderer_UpdateTextureQueues(vcTileRenderer *pTileRenderer)
   // TODO: For each tile in cache, LRU destroy
 }
 
-void vcTileRenderer_Update(vcTileRenderer *pTileRenderer, const double deltaTime, vcGISSpace *pSpace, const udDouble3 worldCorners[4], const udInt3 &slippyCoords, const udDouble3 &cameraWorldPos, const udDouble4x4 &viewProjectionMatrix)
+void vcTileRenderer_Update(vcTileRenderer *pTileRenderer, const double deltaTime, vcGISSpace *pSpace, const udInt3 &slippyCoords, const udDouble3 &cameraWorldPos, const udDouble4x4 &viewProjectionMatrix)
 {
   pTileRenderer->frameDeltaTime = (float)deltaTime;
   pTileRenderer->totalTime += pTileRenderer->frameDeltaTime;
   pTileRenderer->cameraPosition = cameraWorldPos;
 
-  double slippyCornersViewSize = udMag3(worldCorners[1] - worldCorners[2]) * 0.5;
   vcQuadTreeViewInfo viewInfo =
   {
     pSpace,
     slippyCoords,
     cameraWorldPos,
-    slippyCornersViewSize,
     pTileRenderer->pSettings->maptiles.mapHeight,
     viewProjectionMatrix,
     MaxVisibleTileLevel
@@ -557,40 +533,16 @@ void vcTileRenderer_Update(vcTileRenderer *pTileRenderer, const double deltaTime
   pTileRenderer->quadTree.metaData.generateTimeMs = udPerfCounterMilliseconds(startTime);
 }
 
-bool vcTileRenderer_NodeHasValidBounds(vcQuadTreeNode *pNode)
-{
-  return !((pNode->tileExtents.x <= UD_EPSILON || pNode->tileExtents.y <= UD_EPSILON) ||
-    pNode->worldBounds[0].x > pNode->worldBounds[1].x || pNode->worldBounds[2].x > pNode->worldBounds[3].x ||
-    pNode->worldBounds[2].y > pNode->worldBounds[0].y || pNode->worldBounds[3].y > pNode->worldBounds[1].y);
-}
-
-bool vcTileRenderer_IsRootNode(vcTileRenderer *pTileRenderer, vcQuadTreeNode *pNode)
-{
-  return (pNode == &pTileRenderer->quadTree.nodes.pPool[pTileRenderer->quadTree.rootIndex]);
-}
-
 bool vcTileRenderer_CanNodeDraw(vcQuadTreeNode *pNode)
 {
-  if (!pNode->renderInfo.pTexture || pNode->renderInfo.fadingIn)
-    return false;
-
-  return vcTileRenderer_NodeHasValidBounds(pNode);
+  return pNode->renderInfo.pTexture != nullptr;
 }
 
-bool vcTileRenderer_DrawNode(vcTileRenderer *pTileRenderer, vcQuadTreeNode *pNode, vcMesh *pMesh, const udDouble4x4 &view, bool parentCanDraw)
+bool vcTileRenderer_DrawNode(vcTileRenderer *pTileRenderer, vcQuadTreeNode *pNode, vcMesh *pMesh, const udDouble4x4 &view)
 {
-  vcTexture *pTexture = pNode->renderInfo.pTexture;
-  float tileTransparency = pNode->renderInfo.transparency * pTileRenderer->pSettings->maptiles.transparency;
+  vcTexture *pTexture = pNode->renderInfo.pDrawTexture;
   if (pTexture == nullptr)
-  {
-#if !VISUALIZE_DEBUG_TILES
-    if (!vcTileRenderer_IsRootNode(pTileRenderer, pNode) && parentCanDraw)
-      return false;
-#endif
-
     pTexture = pTileRenderer->pEmptyTileTexture;
-    tileTransparency = pTileRenderer->pSettings->maptiles.transparency;
-  }
 
   for (int t = 0; t < TileVertexResolution * TileVertexResolution; ++t)
   {
@@ -598,7 +550,6 @@ bool vcTileRenderer_DrawNode(vcTileRenderer *pTileRenderer, vcQuadTreeNode *pNod
     pTileRenderer->presentShader.everyObject.eyePositions[t] = eyeSpaceVertexPosition;
   }
 
-  pTileRenderer->presentShader.everyObject.colour = udFloat4::create(1.f, 1.f, 1.f, tileTransparency);
 #if VISUALIZE_DEBUG_TILES
   pTileRenderer->presentShader.everyObject.colour.w = 1.0f;
   if (!pNode->renderInfo.pTexture)
@@ -608,6 +559,9 @@ bool vcTileRenderer_DrawNode(vcTileRenderer *pTileRenderer, vcQuadTreeNode *pNod
       pTileRenderer->presentShader.everyObject.colour.z = pNode->level / 21.0f;
   }
 #endif
+
+  pTileRenderer->presentShader.everyObject.uvOffsetScale = udFloat4::create( pNode->renderInfo.uvStart.x, pNode->renderInfo.uvStart.y,
+    pNode->renderInfo.uvEnd.x - pNode->renderInfo.uvStart.x, pNode->renderInfo.uvEnd.y - pNode->renderInfo.uvStart.y);
 
   vcShader_BindTexture(pTileRenderer->presentShader.pProgram, pTexture, 0);
   vcShader_BindConstantBuffer(pTileRenderer->presentShader.pProgram, pTileRenderer->presentShader.pConstantBuffer, &pTileRenderer->presentShader.everyObject, sizeof(pTileRenderer->presentShader.everyObject));
@@ -631,46 +585,58 @@ void vcTileRenderer_RecursiveSetRendered(vcTileRenderer *pTileRenderer, vcQuadTr
 
 // 'true' indicates the node was able to render itself (or it didn't want to render itself).
 // 'false' indicates that the nodes ancestor needs to be rendered.
-bool vcTileRenderer_RecursiveBuildRenderQueue(vcTileRenderer *pTileRenderer, vcQuadTreeNode *pNode, bool canParentDraw)
+bool vcTileRenderer_RecursiveBuildRenderQueue(vcTileRenderer *pTileRenderer, vcQuadTreeNode *pNode, vcQuadTreeNode *pBestTexturedAncestor)
 {
   if (!pNode->touched)
   {
-    vcQuadTreeNode *pParentNode = &pTileRenderer->quadTree.nodes.pPool[pNode->parentIndex];
-
-    // parent can render itself (opaque), so this tile is not needed
-    if (pParentNode->renderInfo.pTexture && !pParentNode->renderInfo.fadingIn)
-      return false;
-
     // re-test visibility
-    pNode->visible = pParentNode->visible && vcQuadTree_IsNodeVisible(&pTileRenderer->quadTree, pNode);
+    pNode->visible = vcQuadTree_IsNodeVisible(&pTileRenderer->quadTree, pNode);
   }
 
   if (!pNode->visible)
     return false;
 
-  bool childrenNeedThisTileRendered = vcQuadTree_IsLeafNode(pNode);
-  if (!childrenNeedThisTileRendered)
+  pNode->renderInfo.pDrawTexture = nullptr;
+  if (vcTileRenderer_CanNodeDraw(pNode))
+  {
+    pNode->renderInfo.pDrawTexture = pNode->renderInfo.pTexture;
+    pBestTexturedAncestor = pNode;
+  }
+
+  if (!vcQuadTree_IsLeafNode(pNode))
   {
     for (int c = 0; c < 4; ++c)
     {
       vcQuadTreeNode *pChildNode = &pTileRenderer->quadTree.nodes.pPool[pNode->childBlockIndex + c];
-      childrenNeedThisTileRendered = !vcTileRenderer_RecursiveBuildRenderQueue(pTileRenderer, pChildNode, canParentDraw || vcTileRenderer_CanNodeDraw(pChildNode)) || childrenNeedThisTileRendered;
+      vcTileRenderer_RecursiveBuildRenderQueue(pTileRenderer, pChildNode, pBestTexturedAncestor);
     }
+
+    // only draw leaves
+    return true;
   }
 
-  if (pNode->renderInfo.fadingIn)
-    return false;
-
-  if (childrenNeedThisTileRendered)
+  pNode->renderInfo.uvStart = udFloat2::zero();
+  pNode->renderInfo.uvEnd = udFloat2::one();
+  if (pBestTexturedAncestor != nullptr && pBestTexturedAncestor != pNode)
   {
-    if (!pNode->renderInfo.pTexture && (!vcTileRenderer_IsRootNode(pTileRenderer, pNode) && canParentDraw))
-      return false;
+    // calculate what portion of ancestors colour to display at this tile
+    pNode->renderInfo.pDrawTexture = pBestTexturedAncestor->renderInfo.pDrawTexture;
+    int depthDiff = pNode->level - pBestTexturedAncestor->level;
+    int slippyRange = (int)udPow(2.0f, (float)depthDiff);
 
-    if (!vcTileRenderer_NodeHasValidBounds(pNode))
-      return false;
+    // top-left, and bottom-right corners
+    udInt2 slippy0 = pNode->slippyPosition.toVector2();
+    udInt2 slippy1 = slippy0 + udInt2::one();
 
-    pTileRenderer->pRenderQueue->at(pNode->level).push_back(pNode);
+    udInt2 ancestorSlippyLocal0 = udInt2::create(pBestTexturedAncestor->slippyPosition.x * slippyRange, pBestTexturedAncestor->slippyPosition.y * slippyRange);
+    udInt2 ancestorSlippyLocal1 = udInt2::create((pBestTexturedAncestor->slippyPosition.x + 1) * slippyRange, (pBestTexturedAncestor->slippyPosition.y + 1) * slippyRange);
+    udFloat2 boundsRange = udFloat2::create(ancestorSlippyLocal1 - ancestorSlippyLocal0);
+
+    pNode->renderInfo.uvStart = udFloat2::create(slippy0 - ancestorSlippyLocal0) / boundsRange;
+    pNode->renderInfo.uvEnd = udFloat2::one() - (udFloat2::create(ancestorSlippyLocal1 - slippy1) / boundsRange);
   }
+
+  pTileRenderer->pRenderQueue->at(pNode->level).push_back(pNode);
 
   // This child doesn't need parent to draw itself
   return true;
@@ -683,7 +649,7 @@ void vcTileRenderer_DrawRenderQueue(vcTileRenderer *pTileRenderer, const udDoubl
   {
     for (size_t t = 0; t < pTileRenderer->pRenderQueue->at(i).size(); ++t)
     {
-      vcTileRenderer_DrawNode(pTileRenderer, pTileRenderer->pRenderQueue->at(i).at(t), pTileRenderer->pFullTileMesh, view, false);
+      vcTileRenderer_DrawNode(pTileRenderer, pTileRenderer->pRenderQueue->at(i).at(t), pTileRenderer->pFullTileMesh, view);
     }
   }
 }
@@ -699,17 +665,12 @@ void vcTileRenderer_Render(vcTileRenderer *pTileRenderer, const udDouble4x4 &vie
 
   udDouble4x4 viewWithMapTranslation = view * udDouble4x4::translation(0, 0, pTileRenderer->pSettings->maptiles.mapHeight);
 
-  vcGLStencilSettings stencil = {};
-  stencil.writeMask = 0xFF;
-  stencil.compareFunc = vcGLSSF_Equal;
-  stencil.compareValue = 0;
-  stencil.compareMask = 0xFF;
-  stencil.onStencilFail = vcGLSSOP_Keep;
-  stencil.onDepthFail = vcGLSSOP_Keep;
-  stencil.onStencilAndDepthPass = vcGLSSOP_Increment;
+  vcGLStateCullMode cullMode = vcGLSCM_Back;
+  if (pTileRenderer->cameraPosition.z < 0)
+    cullMode = vcGLSCM_Front;
 
-  vcGLState_SetFaceMode(vcGLSFM_Solid, vcGLSCM_None);
-  vcGLState_SetDepthStencilMode(vcGLSDM_LessOrEqual, true, &stencil);
+  vcGLState_SetFaceMode(vcGLSFM_Solid, cullMode);
+  vcGLState_SetDepthStencilMode(vcGLSDM_LessOrEqual, true);
 
   if (pTileRenderer->pSettings->maptiles.transparency >= 1.0f)
     vcGLState_SetBlendMode(vcGLSBM_None);
@@ -719,57 +680,20 @@ void vcTileRenderer_Render(vcTileRenderer *pTileRenderer, const udDouble4x4 &vie
   if (pTileRenderer->pSettings->maptiles.blendMode == vcMTBM_Overlay)
   {
     vcGLState_SetViewportDepthRange(0.0f, 0.0f);
-    vcGLState_SetDepthStencilMode(vcGLSDM_Always, false, &stencil);
+    vcGLState_SetDepthStencilMode(vcGLSDM_Always, false);
   }
   else if (pTileRenderer->pSettings->maptiles.blendMode == vcMTBM_Underlay)
   {
     vcGLState_SetViewportDepthRange(1.0f, 1.0f);
   }
 
+  vcTileRenderer_RecursiveBuildRenderQueue(pTileRenderer, pRootNode, nullptr);
+
   vcShader_Bind(pTileRenderer->presentShader.pProgram);
   pTileRenderer->presentShader.everyObject.projectionMatrix = udFloat4x4::create(proj);
+  pTileRenderer->presentShader.everyObject.colour = udFloat4::create(1.f, 1.f, 1.f, pTileRenderer->pSettings->maptiles.transparency);
 
-  pRootNode->renderInfo.transparency = 1.0f;
-  vcTileRenderer_RecursiveBuildRenderQueue(pTileRenderer, pRootNode, vcTileRenderer_CanNodeDraw(pRootNode));
   vcTileRenderer_DrawRenderQueue(pTileRenderer, viewWithMapTranslation);
-
-  // Render the root tile again (if it hasn't already been rendered normally) to cover up gaps between tiles
-  if (!pRootNode->rendered && pRootNode->renderInfo.pTexture && vcTileRenderer_NodeHasValidBounds(pRootNode))
-    vcTileRenderer_DrawNode(pTileRenderer, pRootNode, pTileRenderer->pFullTileMesh, viewWithMapTranslation, false);
-
-  // Draw transparent tiles
-  if (pTileRenderer->pTransparentTiles->size() > 0)
-  {
-    // We know there will always be a stenciled opaque tile behind every transparent tile, so draw
-    // with no depth testing, but stencil testing for map tiles
-    stencil.writeMask = 0xFF;
-    stencil.compareFunc = vcGLSSF_NotEqual;
-    stencil.compareValue = 0;
-    stencil.compareMask = 0xFF;
-    stencil.onStencilFail = vcGLSSOP_Keep;
-    stencil.onDepthFail = vcGLSSOP_Keep;
-    stencil.onStencilAndDepthPass = vcGLSSOP_Keep;
-
-    vcGLState_SetDepthStencilMode(vcGLSDM_Always, false, &stencil);
-    vcGLState_SetBlendMode(vcGLSBM_Interpolative);
-    for (auto tile : (*pTileRenderer->pTransparentTiles))
-    {
-      tile->renderInfo.transparency = udMin(1.0f, tile->renderInfo.transparency + pTileRenderer->frameDeltaTime * sTileFadeSpeed);
-      if (tile->visible && vcTileRenderer_NodeHasValidBounds(tile))
-        vcTileRenderer_DrawNode(pTileRenderer, tile, pTileRenderer->pFullTileMesh, viewWithMapTranslation, false);
-    }
-
-    for (int i = 0; i < int(pTileRenderer->pTransparentTiles->size()); ++i)
-    {
-      if (pTileRenderer->pTransparentTiles->at(i)->renderInfo.transparency >= 1.0f)
-      {
-        pTileRenderer->pTransparentTiles->at(i)->renderInfo.fadingIn = false;
-        pTileRenderer->pTransparentTiles->erase(pTileRenderer->pTransparentTiles->begin() + i);
-        --i;
-      }
-    }
-  }
-
   vcTileRenderer_RecursiveSetRendered(pTileRenderer, pRootNode, pRootNode->rendered);
 
   vcGLState_SetViewportDepthRange(0.0f, 1.0f);
@@ -777,16 +701,14 @@ void vcTileRenderer_Render(vcTileRenderer *pTileRenderer, const udDouble4x4 &vie
   vcGLState_SetBlendMode(vcGLSBM_None);
   vcShader_Bind(nullptr);
 
-#if VISUALIZE_DEBUG_TILES
-  printf("touched=%d, visible=%d, rendered=%d, leaves=%d\n", pTileRenderer->quadTree.metaData.nodeTouchedCount, pTileRenderer->quadTree.metaData.visibleNodeCount, pTileRenderer->quadTree.metaData.nodeRenderCount, pTileRenderer->quadTree.metaData.leafNodeCount);
-#endif
+  // debugging
+  //printf("touched=%d, visible=%d, rendered=%d, leaves=%d, build=%f\n", pTileRenderer->quadTree.metaData.nodeTouchedCount, pTileRenderer->quadTree.metaData.visibleNodeCount, pTileRenderer->quadTree.metaData.nodeRenderCount, pTileRenderer->quadTree.metaData.leafNodeCount, pTileRenderer->quadTree.metaData.generateTimeMs);
 }
 
 void vcTileRenderer_ClearTiles(vcTileRenderer *pTileRenderer)
 {
   udLockMutex(pTileRenderer->cache.pMutex);
 
-  pTileRenderer->pTransparentTiles->clear();
   pTileRenderer->cache.tileLoadList.Clear();
   vcQuadTree_Reset(&pTileRenderer->quadTree);
 

--- a/src/rendering/vcTileRenderer.h
+++ b/src/rendering/vcTileRenderer.h
@@ -14,7 +14,7 @@ struct vcTileRenderer;
 udResult vcTileRenderer_Create(vcTileRenderer **ppTileRenderer, vcSettings *pSettings);
 udResult vcTileRenderer_Destroy(vcTileRenderer **ppTileRenderer);
 
-void vcTileRenderer_Update(vcTileRenderer *pTileRenderer, const double deltaTime, vcGISSpace *pSpace, const udDouble3 worldCorners[4], const udInt3 &slippyCoords, const udDouble3 &cameraWorldPos, const udDouble4x4 &viewProjectionMatrix);
+void vcTileRenderer_Update(vcTileRenderer *pTileRenderer, const double deltaTime, vcGISSpace *pSpace, const udInt3 &slippyCoords, const udDouble3 &cameraWorldPos, const udDouble4x4 &viewProjectionMatrix);
 void vcTileRenderer_Render(vcTileRenderer *pTileRenderer, const udDouble4x4 &view, const udDouble4x4 &proj);
 
 void vcTileRenderer_ClearTiles(vcTileRenderer *pTileRenderer);

--- a/src/vcQuadTree.h
+++ b/src/vcQuadTree.h
@@ -28,8 +28,9 @@ struct vcNodeRenderInfo
   int32_t width, height;
   void *pData;
 
-  bool fadingIn;
-  float transparency;
+  vcTexture *pDrawTexture; // may not own this
+  udFloat2 uvStart;
+  udFloat2 uvEnd;
 
   // cached
   udDouble2 center;
@@ -51,7 +52,7 @@ struct vcQuadTreeNode
   bool rendered;
 
   // cached
-  udDouble2 worldBounds[4]; // corners
+  udDouble2 worldBounds[9]; // corners
   udDouble2 tileCenter, tileExtents;
 
   vcNodeRenderInfo renderInfo;
@@ -79,8 +80,6 @@ struct vcQuadTree
   udInt3 slippyCoords;
   udDouble3 cameraWorldPosition;
   udDouble3 cameraTreePosition;
-  int expectedTreeDepth; // depth of the deepest node
-  double quadTreeWorldSize;
   double quadTreeHeightOffset;
 
   uint32_t rootIndex;
@@ -98,7 +97,6 @@ struct vcQuadTreeViewInfo
   vcGISSpace *pSpace;
   udInt3 slippyCoords;
   udDouble3 cameraPosition;
-  double quadTreeWorldSize;
   double quadTreeHeightOffset;
   udDouble4x4 viewProjectionMatrix;
   int maxVisibleTileLevel;

--- a/src/vcRender.cpp
+++ b/src/vcRender.cpp
@@ -686,13 +686,15 @@ void vcRenderTerrain(vcState *pProgramState, vcRenderContext *pRenderContext)
 
     int currentZoom = 21;
 
-    double farPlane = pProgramState->settings.camera.farPlane;
+    // This technique won't work with ECEF
+    // This 'value' was trial and errored. 
+    double visibleFarPlane = 1000.0 + udAbs(localCamPos.z) * 150.0;
 
     // Cardinal Limits
-    localCorners[0] = localCamPos + udDouble3::create(-farPlane, +farPlane, 0);
-    localCorners[1] = localCamPos + udDouble3::create(+farPlane, +farPlane, 0);
-    localCorners[2] = localCamPos + udDouble3::create(-farPlane, -farPlane, 0);
-    localCorners[3] = localCamPos + udDouble3::create(+farPlane, -farPlane, 0);
+    localCorners[0] = localCamPos + udDouble3::create(-visibleFarPlane, +visibleFarPlane, 0);
+    localCorners[1] = localCamPos + udDouble3::create(+visibleFarPlane, +visibleFarPlane, 0);
+    localCorners[2] = localCamPos + udDouble3::create(-visibleFarPlane, -visibleFarPlane, 0);
+    localCorners[3] = localCamPos + udDouble3::create(+visibleFarPlane, -visibleFarPlane, 0);
 
     for (int i = 0; i < 4; ++i)
       vcGIS_LocalToSlippy(&pProgramState->gis, &slippyCorners[i], localCorners[i], currentZoom);
@@ -708,7 +710,7 @@ void vcRenderTerrain(vcState *pProgramState, vcRenderContext *pRenderContext)
     for (int i = 0; i < 4; ++i)
       vcGIS_SlippyToLocal(&pProgramState->gis, &localCorners[i], slippyCorners[0] + udInt2::create(i & 1, i / 2), currentZoom);
 
-    vcTileRenderer_Update(pRenderContext->pTileRenderer, pProgramState->deltaTime, &pProgramState->gis, localCorners, udInt3::create(slippyCorners[0], currentZoom), localCamPos, viewProjection);
+    vcTileRenderer_Update(pRenderContext->pTileRenderer, pProgramState->deltaTime, &pProgramState->gis, udInt3::create(slippyCorners[0], currentZoom), localCamPos, viewProjection);
     vcTileRenderer_Render(pRenderContext->pTileRenderer, pProgramState->camera.matrices.view, pProgramState->camera.matrices.projection);
   }
 }


### PR DESCRIPTION
Fixed Tile Renderer to work with LogZ.
Preparing the Tile Renderer for globe rendering:
 - Removed stencilling, tile fading, don't "always render root" etc.
 - Changed quad tree descend heuristic
Tile tessellation is now independent of map colour (ancestors colour can be draped onto tiles).
Tiles are now 3x3 resolution.