### PR TITLE
To collapse scene explorer quickly by [F4]/new menu button.

### DIFF
--- a/builds/assets/lang/enAU.json
+++ b/builds/assets/lang/enAU.json
@@ -369,6 +369,7 @@
   "sceneGizmoLocalSpace": "Gizmo Local Space",
   "sceneFullscreen": "Fullscreen",
   "sceneMapMode": "Map Mode",
+  "toggleSceneExplorer": "Show/Hide Scene Explorer",
 
   "sceneCameraSettings": "Camera Settings",
   "sceneCameraLatLongAlt": "Lat: {0}°, Lon: {1}°, Alt {2}",
@@ -591,6 +592,7 @@
   "bindingsSave": "Key to trigger save action.",
   "bindingsLoad": "Key to trigger load or open action.",
   "bindingsUndo": "Key to trigger undo action",
+  "bindingsToggleSceneExplorer": "Key to show/hide scene explorer",
 
   "errorUnknown": "An unexpected error occurred.",
   "errorCorruptData": "Corrupt data.",

--- a/builds/assets/lang/zhCN.json
+++ b/builds/assets/lang/zhCN.json
@@ -387,6 +387,7 @@
   "sceneGizmoLocalSpace": "本地坐标",
   "sceneFullscreen": "全屏",
   "sceneMapMode": "地图模式",
+  "toggleSceneExplorer": "显示/隐藏场景资源管理器",
 
   "sceneCameraSettings": "摄像机设置",
   "sceneCameraLatLongAlt": "纬度: {0}°, 经度: {1}°, 海拔 {2}",
@@ -603,6 +604,7 @@
   "bindingsSave": "保存键绑定。",
   "bindingsLoad": "加载键绑定。",
   "bindingsUndo": "撤销",
+  "bindingsToggleSceneExplorer": "显示/隐藏场景资源管理器",
 
   "errorUnknown": "未知错误",
   "errorCorruptData": "数据损坏",

--- a/src/imgui_ex/vcMenuButtons.h
+++ b/src/imgui_ex/vcMenuButtons.h
@@ -39,8 +39,9 @@ enum vcMenuBarButtonIcon
 
   vcMBBI_FullScreen = 33,
   vcMBBI_MapMode = 34,
+  vcMBBI_ToggleScreenExplorer = 35,
 
-  //Reserved = 35 - 39
+  //Reserved = 36 - 39
 
   vcMBBI_Crosshair = 40,
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1124,6 +1124,13 @@ void vcRenderSceneUI(vcState *pProgramState, const ImVec2 &windowPos, const ImVe
       if (vcMenuBarButton(pProgramState->pUITexture, vcString::Get("sceneFullscreen"), SDL_GetScancodeName((SDL_Scancode)vcHotkey::Get(vcB_Fullscreen)), vcMBBI_FullScreen, vcMBBG_NewGroup, pProgramState->settings.window.isFullscreen))
         vcMain_PresentationMode(pProgramState);
 
+      // Hide/show screen explorer
+      if (vcMenuBarButton(pProgramState->pUITexture, vcString::Get("toggleSceneExplorer"), SDL_GetScancodeName((SDL_Scancode)vcHotkey::Get(vcB_ToggleSceneExplorer)), vcMBBI_ToggleScreenExplorer, vcMBBG_SameGroup) || (vcHotkey::IsPressed(vcB_ToggleSceneExplorer) && !ImGui::IsAnyItemActive()))
+      {
+        pProgramState->sceneExplorerCollapsed = !pProgramState->sceneExplorerCollapsed;
+        pProgramState->settings.presentation.columnSizeCorrect = false;
+      }
+
       if (pProgramState->settings.presentation.showCameraInfo)
       {
         ImGui::Separator();
@@ -2346,6 +2353,12 @@ void vcRenderWindow(vcState *pProgramState)
       {
         ImGui::PopStyleVar();
 
+        int sceneExplorerSize = pProgramState->settings.presentation.sceneExplorerSize;
+        if (pProgramState->sceneExplorerCollapsed)
+        {
+          sceneExplorerSize = 0;
+        }
+
         switch (pProgramState->settings.presentation.layout)
         {
         case vcWL_SceneLeft:
@@ -2353,11 +2366,11 @@ void vcRenderWindow(vcState *pProgramState)
 
           if (!pProgramState->settings.presentation.columnSizeCorrect)
           {
-            ImGui::SetColumnWidth(0, size.x - pProgramState->settings.presentation.sceneExplorerSize);
+            ImGui::SetColumnWidth(0, size.x - sceneExplorerSize);
             pProgramState->settings.presentation.columnSizeCorrect = true;
           }
 
-          if (ImGui::GetColumnWidth(0) != size.x - pProgramState->settings.presentation.sceneExplorerSize)
+          if (ImGui::GetColumnWidth(0) != size.x - sceneExplorerSize && !pProgramState->sceneExplorerCollapsed)
             pProgramState->settings.presentation.sceneExplorerSize = (int)(size.x - ImGui::GetColumnWidth());
 
           if (ImGui::BeginChild(udTempStr("%s###sceneDock", vcString::Get("sceneTitle"))))
@@ -2378,11 +2391,11 @@ void vcRenderWindow(vcState *pProgramState)
 
           if (!pProgramState->settings.presentation.columnSizeCorrect)
           {
-            ImGui::SetColumnWidth(0, (float)pProgramState->settings.presentation.sceneExplorerSize);
+            ImGui::SetColumnWidth(0, (float)sceneExplorerSize);
             pProgramState->settings.presentation.columnSizeCorrect = true;
           }
 
-          if (ImGui::GetColumnWidth(0) != pProgramState->settings.presentation.sceneExplorerSize)
+          if (ImGui::GetColumnWidth(0) != sceneExplorerSize && !pProgramState->sceneExplorerCollapsed)
             pProgramState->settings.presentation.sceneExplorerSize = (int)ImGui::GetColumnWidth();
 
           if (ImGui::BeginChild(udTempStr("%s###sceneExplorerDock", vcString::Get("sceneExplorerTitle"))))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2355,9 +2355,7 @@ void vcRenderWindow(vcState *pProgramState)
 
         int sceneExplorerSize = pProgramState->settings.presentation.sceneExplorerSize;
         if (pProgramState->sceneExplorerCollapsed)
-        {
           sceneExplorerSize = 0;
-        }
 
         switch (pProgramState->settings.presentation.layout)
         {

--- a/src/vcHotkey.cpp
+++ b/src/vcHotkey.cpp
@@ -41,7 +41,8 @@ namespace vcHotkey
     "AddUDS",
     "BindingsInterface",
     "Undo",
-    "TakeScreenshot"
+    "TakeScreenshot",
+    "ToggleSceneExplorer"
   };
   UDCOMPILEASSERT(udLengthOf(vcHotkey::bindNames) == vcB_Count, "Hotkey count discrepancy.");
 

--- a/src/vcHotkey.h
+++ b/src/vcHotkey.h
@@ -38,6 +38,7 @@ enum vcBind
   vcB_BindingsInterface,
   vcB_Undo,
   vcB_TakeScreenshot,
+  vcB_ToggleSceneExplorer,
 
   vcB_Count
 };

--- a/src/vcSettings.cpp
+++ b/src/vcSettings.cpp
@@ -315,6 +315,7 @@ bool vcSettings_Load(vcSettings *pSettings, bool forceReset /*= false*/, vcSetti
     vcHotkey::Set(vcB_BindingsInterface, data.Get("keys.%s", vcHotkey::GetBindName(vcB_BindingsInterface)).AsInt(1029));
     vcHotkey::Set(vcB_Undo, data.Get("keys.%s", vcHotkey::GetBindName(vcB_Undo)).AsInt(1053));
     vcHotkey::Set(vcB_TakeScreenshot, data.Get("keys.%s", vcHotkey::GetBindName(vcB_TakeScreenshot)).AsInt(70));
+    vcHotkey::Set(vcB_ToggleSceneExplorer, data.Get("keys.%s", vcHotkey::GetBindName(vcB_ToggleSceneExplorer)).AsInt(61));
   }
 
   if (group == vcSC_All || group == vcSC_Connection)

--- a/src/vcState.h
+++ b/src/vcState.h
@@ -183,6 +183,7 @@ struct vcState
   int64_t lastEventTime;
   vcTranslationInfo languageInfo;
   bool showUI;
+  bool sceneExplorerCollapsed; // True if scene explorer is collapsed.
 
   int currentKey;
 };


### PR DESCRIPTION
Resolved [AB#322](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/322).