### PR TITLE
Attribution Display

### DIFF
--- a/src/vcRender.cpp
+++ b/src/vcRender.cpp
@@ -1373,7 +1373,7 @@ udResult vcRender_RenderUD(vcState *pProgramState, vcRenderContext *pRenderConte
 
       ++numVisibleModels;
 
-      if (renderData.models[i]->m_hasWatermark)
+      if (renderData.models[i]->m_hasWatermark && pProgramState->showWatermark)
       {
         udDouble3 distVector = pCamera->position - renderData.models[i]->GetWorldSpacePivot();
 

--- a/src/vcState.h
+++ b/src/vcState.h
@@ -100,6 +100,8 @@ struct vcState
 
   vcGISSpace gis;
 
+  bool showWatermark;
+
   vcTexture *pCompanyLogo;
   vcTexture *pCompanyWatermark;
   vcTexture *pSceneWatermark;


### PR DESCRIPTION
[AB#671](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/671)

Attribution now displays at the bottom of the window with the following rules:
 - Displaying attribution overrides displaying of a watermark
 - Attribution is taken from every model in the scene and concatenated into a single string
 - The attribution text will automatically scroll if it does not fit in the render window.