### PR TITLE
Use uniforms in shader headers instead of globals

### DIFF
--- a/src/gl/directx11/vcD3D11.h
+++ b/src/gl/directx11/vcD3D11.h
@@ -49,11 +49,12 @@ struct vcFramebuffer
 
 struct vcShaderConstantBuffer
 {
-  int type; // 0 = VSConstantBuffer, 1 = PSConstantBuffer
-  int expectedSize;
-  uint32_t registerSlot;
-
-  ID3D11Buffer *pBuffer;
+  struct {
+    int type; // 0 = VSConstantBuffer, 1 = PSConstantBuffer
+    int expectedSize;
+    uint32_t registerSlot;
+    ID3D11Buffer *pBuffer;
+  } buffers[2]; // One for each shader stage
   char bufferName[32];
 };
 
@@ -66,6 +67,8 @@ struct vcShader
 
   vcShaderConstantBuffer bufferObjects[16];
   int numBufferObjects;
+
+  vcShaderConstantBuffer *pCameraPlaneParams;
 };
 
 struct vcShaderSampler

--- a/src/gl/directx11/vcRenderShaders.cpp
+++ b/src/gl/directx11/vcRenderShaders.cpp
@@ -1,9 +1,8 @@
 #include "gl/vcRenderShaders.h"
 #include "udPlatformUtil.h"
-#include "vcConstants.h"
 
-#define FRAG_HEADER "static float s_CameraNearPlane=" UDSTRINGIFY(s_CameraNearPlane) ";\nstatic float s_CameraFarPlane=" UDSTRINGIFY(s_CameraFarPlane) ";\n"
-#define VERT_HEADER "static float s_CameraNearPlane=" UDSTRINGIFY(s_CameraNearPlane) ";\nstatic float s_CameraFarPlane=" UDSTRINGIFY(s_CameraFarPlane) ";\n"
+#define FRAG_HEADER "cbuffer u_cameraPlaneParams { float s_CameraNearPlane; float s_CameraFarPlane; float u_unused1; float u_unused2; };"
+#define VERT_HEADER "cbuffer u_cameraPlaneParams { float s_CameraNearPlane; float s_CameraFarPlane; float u_unused1; float u_unused2; };"
 
 const char *const g_VisualizationFragmentShader = FRAG_HEADER R"shader(
  struct PS_INPUT

--- a/src/gl/opengl/vcOpenGL.h
+++ b/src/gl/opengl/vcOpenGL.h
@@ -76,6 +76,8 @@ struct vcShader
   int numBufferObjects;
   vcShaderSampler samplerIndexes[16];
   int numSamplerIndexes;
+
+  vcShaderConstantBuffer *pCameraPlaneParams;
 };
 
 struct vcMesh

--- a/src/gl/opengl/vcRenderShaders.cpp
+++ b/src/gl/opengl/vcRenderShaders.cpp
@@ -1,13 +1,12 @@
 #include "gl/vcRenderShaders.h"
 #include "udPlatformUtil.h"
-#include "vcConstants.h"
 
 #if UDPLATFORM_IOS || UDPLATFORM_IOS_SIMULATOR || UDPLATFORM_EMSCRIPTEN || UDPLATFORM_ANDROID
-# define FRAG_HEADER "#version 300 es\nprecision highp float;\nfloat s_CameraNearPlane=" UDSTRINGIFY(s_CameraNearPlane) ";\nfloat s_CameraFarPlane=" UDSTRINGIFY(s_CameraFarPlane) ";\n"
-# define VERT_HEADER "#version 300 es\nfloat s_CameraNearPlane=" UDSTRINGIFY(s_CameraNearPlane) ";\nfloat s_CameraFarPlane=" UDSTRINGIFY(s_CameraFarPlane) ";\n"
+# define FRAG_HEADER "#version 300 es\nprecision highp float;\nlayout (std140) uniform u_cameraPlaneParams { float s_CameraNearPlane; float s_CameraFarPlane; float u_unused1; float u_unused2; };\n"
+# define VERT_HEADER "#version 300 es\nlayout (std140) uniform u_cameraPlaneParams { float s_CameraNearPlane; float s_CameraFarPlane; float u_unused1; float u_unused2; };\n"
 #else
-# define FRAG_HEADER "#version 330 core\n#extension GL_ARB_explicit_attrib_location : enable\nfloat s_CameraNearPlane=" UDSTRINGIFY(s_CameraNearPlane) ";\nfloat s_CameraFarPlane=" UDSTRINGIFY(s_CameraFarPlane) ";\n"
-# define VERT_HEADER "#version 330 core\n#extension GL_ARB_explicit_attrib_location : enable\nfloat s_CameraNearPlane=" UDSTRINGIFY(s_CameraNearPlane) ";\nfloat s_CameraFarPlane=" UDSTRINGIFY(s_CameraFarPlane) ";\n"
+# define FRAG_HEADER "#version 330 core\n#extension GL_ARB_explicit_attrib_location : enable\nlayout (std140) uniform u_cameraPlaneParams { float s_CameraNearPlane; float s_CameraFarPlane; float u_unused1; float u_unused2; };\n"
+# define VERT_HEADER "#version 330 core\n#extension GL_ARB_explicit_attrib_location : enable\nlayout (std140) uniform u_cameraPlaneParams { float s_CameraNearPlane; float s_CameraFarPlane; float u_unused1; float u_unused2; };\n"
 #endif
 
 const char *const g_VisualizationFragmentShader = FRAG_HEADER R"shader(

--- a/src/gl/opengl/vcShader.cpp
+++ b/src/gl/opengl/vcShader.cpp
@@ -1,5 +1,6 @@
 #include "gl/vcShader.h"
 #include "vcOpenGL.h"
+#include "vcConstants.h"
 #include "udPlatformUtil.h"
 #include "udStringUtil.h"
 #include "udFile.h"
@@ -82,6 +83,9 @@ bool vcShader_CreateFromText(vcShader **ppShader, const char *pVertexShader, con
   if (pShader->programID == GL_INVALID_INDEX)
     udFree(pShader);
 
+  if (pShader)
+    vcShader_GetConstantBuffer(&pShader->pCameraPlaneParams, pShader, "u_cameraPlaneParams", sizeof(float) * 4);
+
   *ppShader = pShader;
 
   return (pShader != nullptr);
@@ -121,6 +125,18 @@ bool vcShader_Bind(vcShader *pShader)
     glUseProgram(0);
   else
     glUseProgram(pShader->programID);
+
+  if (pShader)
+  {
+    struct
+    {
+      float cameraNearPlane;
+      float cameraFarPlane;
+      float unused1;
+      float unused2;
+    } cameraPlane = { s_CameraNearPlane, s_CameraFarPlane, 0.f, 0.f };
+    vcShader_BindConstantBuffer(pShader, pShader->pCameraPlaneParams, &cameraPlane, sizeof(cameraPlane));
+  }
 
   VERIFY_GL();
 


### PR DESCRIPTION
- DirectX uniforms are now internally grouped across shader stages based on name