### PR TITLE
Switched to using an Image again 

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1687,7 +1687,7 @@ void vcRenderSceneWindow(vcState *pProgramState)
 #endif
 
     // Actual rendering to this texture is deferred
-    ImGui::ImageButton(renderData.pSceneTexture, windowSize, uv0, uv1, 0);
+    ImGui::Image(renderData.pSceneTexture, windowSize, uv0, uv1);
 
     if (pProgramState->settings.screenshot.taking)
       pProgramState->screenshot.pImage = renderData.pSceneTexture;


### PR DESCRIPTION
Now that the window can't be undocked- this improves the activation of the ContextMenu