### PR TITLE
Fixes in preparation for using Shader Conductor

### DIFF
--- a/src/gl/directx11/shaders/imguiVertexShader.hlsl
+++ b/src/gl/directx11/shaders/imguiVertexShader.hlsl
@@ -14,8 +14,8 @@ cbuffer u_EveryFrame : register(b0)
 struct VS_INPUT
 {
   float2 pos : POSITION;
-  float4 col : COLOR0;
   float2 uv  : TEXCOORD0;
+  float4 col : COLOR0;
 };
 
 struct PS_INPUT

--- a/src/gl/directx11/shaders/polygonP3N3UV2VertexShader.hlsl
+++ b/src/gl/directx11/shaders/polygonP3N3UV2VertexShader.hlsl
@@ -9,8 +9,8 @@ cbuffer u_cameraPlaneParams
 struct VS_INPUT
 {
   float3 pos : POSITION;
-  float2 uv  : TEXCOORD0;
   float3 normal : NORMAL;
+  float2 uv  : TEXCOORD0;
   //float4 colour : COLOR0;
 };
 

--- a/src/gl/opengl/vcShader.cpp
+++ b/src/gl/opengl/vcShader.cpp
@@ -156,8 +156,15 @@ bool vcShader_BindTexture(vcShader *pShader, vcTexture *pTexture, uint16_t sampl
   glBindTexture(vcTTToGL[pTexture->type], pTexture->id);
   VERIFY_GL();
 
-  if (pSampler != nullptr)
+  if (pSampler == nullptr)
+  {
+    GLuint samplerId = glGetUniformLocation(pShader->programID, udTempStr("SPIRV_Cross_Combinedtexture%dsampler%d", samplerIndex, samplerIndex));
+    glUniform1i(samplerId, samplerIndex);
+  }
+  else
+  {
     glUniform1i(pSampler->id, samplerIndex);
+  }
 
   VERIFY_GL();
 
@@ -201,6 +208,9 @@ bool vcShader_GetConstantBuffer(vcShaderConstantBuffer **ppBuffer, vcShader *pSh
     }
   }
 
+  if ((*ppBuffer) == nullptr && !udStrBeginsWith(pBufferName, "type_"))
+    return vcShader_GetConstantBuffer(ppBuffer, pShader, udTempStr("type_%s", pBufferName), bufferSize);
+
   return ((*ppBuffer) != nullptr);
 }
 
@@ -235,7 +245,7 @@ bool vcShader_GetSamplerIndex(vcShaderSampler **ppSampler, vcShader *pShader, co
   GLuint uID = glGetUniformLocation(pShader->programID, pSamplerName);
 
   if (uID == GL_INVALID_INDEX)
-    return false;
+    return true;
 
   vcShaderSampler *pSampler = &pShader->samplerIndexes[pShader->numSamplerIndexes];
   pShader->numSamplerIndexes++;

--- a/src/gl/vcLayout.h
+++ b/src/gl/vcLayout.h
@@ -58,19 +58,6 @@ struct vcP3UV2RI4Vertex
   udFloat4 ribbonInfo; // xyz: expand vector; w: pair id (0 or 1)
 };
 
-struct vcP4C1Vertex
-{
-  udFloat4 pos;
-  uint32_t color;
-};
-
-struct vcP4C1QC2Vertex
-{
-  udFloat4 pos;
-  uint32_t color;
-  float corner[2];
-};
-
 struct vcP2UV2C1Vertex
 {
   udFloat2 position;  
@@ -84,8 +71,6 @@ const vcVertexLayoutTypes vcP3N3VertexLayout[] = { vcVLT_Position3, vcVLT_Normal
 const vcVertexLayoutTypes vcP3UV2VertexLayout[] = { vcVLT_Position3, vcVLT_TextureCoords2 }; // screen quad
 const vcVertexLayoutTypes vcP3N3UV2VertexLayout[] = { vcVLT_Position3, vcVLT_Normal3, vcVLT_TextureCoords2 }; // polygon model
 const vcVertexLayoutTypes vcP3UV2RI4VertexLayout[] = { vcVLT_Position3, vcVLT_TextureCoords2, vcVLT_RibbonInfo4 }; // ribbon
-const vcVertexLayoutTypes vcP4C1VertexLayout[] = { vcVLT_Position4, vcVLT_ColourBGRA }; // gpu renderer (point)
-const vcVertexLayoutTypes vcP4C1QC2VertexLayout[] = { vcVLT_Position4, vcVLT_ColourBGRA, vcVLT_QuadCorner }; // gpu renderer (quad)
 
 // ImGui
 const vcVertexLayoutTypes vcImGuiVertexLayout[] = { vcVLT_Position2, vcVLT_TextureCoords2, vcVLT_ColourBGRA };


### PR DESCRIPTION
- vcShader handles uniform and sampler names generated from Shader Conductor
- imguiVertexShader.hlsl uses the same layout as the vcLayout.h
- polygonP3N3UV2VertexShader.hlsl uses the same layout as the vcLayout.h
- Removed unused structures and predefined layouts in vcLayout.h