### PR TITLE
Removed matrix equivalent check.

### DIFF
--- a/src/scene/vcModel.cpp
+++ b/src/scene/vcModel.cpp
@@ -490,7 +490,16 @@ void vcModel::HandleContextMenu(vcState *pProgramState)
 #if VC_HASCONVERT
   if ((m_pPreferredProjection == nullptr && pProgramState->gis.SRID == 0) || (m_pPreferredProjection != nullptr && m_pPreferredProjection->srid == pProgramState->gis.SRID))
   {
-    if (ImGui::BeginMenu(vcString::Get("sceneExplorerExportPointCloud")))
+    bool matrixEqual = true;
+    for (int i = 0; i < m_defaultMatrix.ElementCount; i++)
+    {
+      if (abs(m_defaultMatrix.a[i] - m_sceneMatrix.a[i]) > UD_EPSILON)
+      {
+        matrixEqual = false;
+        break;
+      }
+    }
+    if (matrixEqual && ImGui::BeginMenu(vcString::Get("sceneExplorerExportPointCloud")))
     {
       static vcQueryNode *s_pQuery = nullptr;
 

--- a/src/scene/vcModel.cpp
+++ b/src/scene/vcModel.cpp
@@ -490,15 +490,7 @@ void vcModel::HandleContextMenu(vcState *pProgramState)
 #if VC_HASCONVERT
   if ((m_pPreferredProjection == nullptr && pProgramState->gis.SRID == 0) || (m_pPreferredProjection != nullptr && m_pPreferredProjection->srid == pProgramState->gis.SRID))
   {
-    bool matrixEqual = true;
-    for (int i = 0; i < m_defaultMatrix.ElementCount; i++)
-    {
-      if (abs(m_defaultMatrix.a[i] - m_sceneMatrix.a[i]) > UD_EPSILON)
-      {
-        matrixEqual = false;
-        break;
-      }
-    }
+    bool matrixEqual = udMatrixEqualApprox(m_defaultMatrix, m_sceneMatrix);
     if (matrixEqual && ImGui::BeginMenu(vcString::Get("sceneExplorerExportPointCloud")))
     {
       static vcQueryNode *s_pQuery = nullptr;

--- a/src/scene/vcModel.cpp
+++ b/src/scene/vcModel.cpp
@@ -488,7 +488,7 @@ void vcModel::HandleContextMenu(vcState *pProgramState)
   ImGui::Separator();
 
 #if VC_HASCONVERT
-  if (((m_pPreferredProjection == nullptr && pProgramState->gis.SRID == 0) || (m_pPreferredProjection != nullptr && m_pPreferredProjection->srid == pProgramState->gis.SRID)) && (m_defaultMatrix == m_sceneMatrix))
+  if ((m_pPreferredProjection == nullptr && pProgramState->gis.SRID == 0) || (m_pPreferredProjection != nullptr && m_pPreferredProjection->srid == pProgramState->gis.SRID))
   {
     if (ImGui::BeginMenu(vcString::Get("sceneExplorerExportPointCloud")))
     {


### PR DESCRIPTION
For [AB#1166](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1166). Always show export pointcloud menu.