### PR TITLE
Added ability to display signed distances with model comparisons

### DIFF
--- a/builds/assets/lang/enAU.json
+++ b/builds/assets/lang/enAU.json
@@ -172,7 +172,11 @@
   "settingsVisContoursBandHeight": "Contours Band Height",
   "settingsVisContoursRainbowRepeatRate": "Rainbow Repeat Distance",
   "settingsVisContoursRainbowIntensity": "Rainbow Intensity",
+  "settingsVisDisplacementAbs": "Absolute Displacement",
+  "settingsVisDisplacementSigned": "Signed Displacement",
   "settingsVisDisplacementRange": "Displacement Range",
+  "settingsVisDisplacementErrorClr": "Error Colour",
+  "settingsVisDisplacementOutOfBoundsClr": "Out Of Bounds Colour",
 
   "settingsVisClassShowColourTable": "Show Custom Classification Colour Table",
   "settingsVisClassShowAll": "Show All Classifications",

--- a/builds/defaultsettings.json
+++ b/builds/defaultsettings.json
@@ -51,8 +51,15 @@
   "visualization": {
     "mode": 0,
     "minIntensity": 0,
-    "maxIntensity": 65535
+    "maxIntensity": 65535,
+    "displacement": {
+      "minBound": 0.0,
+      "maxBound": 1.0,
+      "errorColour": 16777215,
+      "outOfBoundsColour": 0
+    }
   },
+  "displacementShaderType": 0,
   "postVisualization": {
     "edgeOutlines": {
       "enabled": false,

--- a/docs/TranslationGuide.md
+++ b/docs/TranslationGuide.md
@@ -336,7 +336,11 @@ Modules are currently:
 - `settingsVisContoursBandHeight`: Label next to slider for setting the vertical size of each contour
 - `settingsVisContoursRainbowRepeatRate`: Label next to the slider for how quickly the rainbow mode for contours repeats
 - `settingsVisContoursRainbowIntensity`: Label next to the slider that sets how strongly the rainbow appears
+- `settingsVisDisplacementAbs`: Label next to the button to view absolute displacements
+- `settingsVisDisplacementSigned`: Label next to the button to view positive and negative displacements
 - `settingsVisDisplacementRange`: Label next to the input fields to specify displacement range values
+- `settingsVisDisplacementErrorClr`: Label next to the input fields to specify an error colour
+- `settingsVisDisplacementOutOfBoundsClr`: Label next to the input fields to specify an out of bounds colour
 - `settingsVisRestoreDefaults`: Used to restore default values for all visualisation settings
 
 - `settingsVisClassRestoreDefaults`: Label on a button that restores default values for all classifications and colours

--- a/src/vcBPA.cpp
+++ b/src/vcBPA.cpp
@@ -130,7 +130,7 @@ void vcBPA_Init(vcBPAManifold **ppManifold, vdkContext *pContext)
   vcBPAManifold *pManifold = udAllocType(vcBPAManifold, 1, udAF_Zero);
   pManifold->grids.Init(1 << 10);
   pManifold->nodes.Init(1 << 13);
-  udWorkerPool_Create(&pManifold->pPool, 8, "vcBPAPool");
+  udWorkerPool_Create(&pManifold->pPool, (uint8_t)udGetHardwareThreadCount(), "vcBPAPool");
   pManifold->pContext = pContext;
   *ppManifold = pManifold;
 }
@@ -351,6 +351,13 @@ void vcBPA_GetNearbyPoints(vcBPAGrid *pGrid, udChunkedArray<uint64_t> *pPoints, 
   }
 }
 
+udDouble3 vcBPA_GetTriangleNormal(const udDouble3 & p0, const udDouble3 & p1, const udDouble3 & p2)
+{
+  udDouble3 a = p1 - p0;
+  udDouble3 b = p2 - p0;
+  return udNormalize(udCross(a, b));
+}
+
 vcBPATriangle vcBPA_FindSeedTriangle(vcBPAGrid *pGrid, double ballRadius)
 {
   // Pick any point not already in the triangle list
@@ -398,16 +405,11 @@ vcBPATriangle vcBPA_FindSeedTriangle(vcBPAGrid *pGrid, double ballRadius)
         udULong3 triangle = udULong3::create((uint64_t)pointIndex, (uint64_t)nearbyPoints[i], (uint64_t)nearbyPoints[j]);
 
         // Check that the triangle normal is consistent with the vertex normals - i.e. pointing outward
-        udDouble3 a = p1 - p0;
-        udDouble3 b = p2 - p0;
-        udDouble3 triangleNormal = udNormalize(udCross(a, b));
+        udDouble3 triangleNormal = vcBPA_GetTriangleNormal(p0, p1, p2);
         if (triangleNormal.z < 0) // Normal is pointing down, that's bad!
         {
           triangle.x = (uint64_t)nearbyPoints[i];
           triangle.y = (uint64_t)pointIndex;
-          a = p0 - p1;
-          b = p2 - p1;
-          triangleNormal = udNormalize(udCross(a, b));
         }
 
         // Test that a p-ball with center in the outward halfspace touches all three vertices and contains no other points
@@ -516,9 +518,7 @@ bool vcBPA_BallPivot(vcBPAGrid *pGrid, double ballRadius, vcBPAEdge edge, uint64
     };
 
     // Check that the triangle normal is consistent with the vertex normals - i.e. pointing outward
-    udDouble3 a = vertices[1] - vertices[0];
-    udDouble3 b = vertices[2] - vertices[0];
-    udDouble3 triangleNormal = udNormalize(udCross(a, b));
+    udDouble3 triangleNormal = vcBPA_GetTriangleNormal(vertices[0], vertices[1], vertices[2]);
     if (triangleNormal.z < 0) // Normal is pointing down, that's bad!
       continue;
 
@@ -781,7 +781,7 @@ void vcBPA_DoGrid(vcBPAGrid *pGrid, double ballRadius)
   }
 }
 
-double vcBPA_DistanceToTriangle(vcBPAGrid *pOldGrid, size_t triangleIndex, udDouble3 position)
+double vcBPA_DistanceToTriangle(vcBPAGrid *pOldGrid, size_t triangleIndex, udDouble3 position, udDouble3 *pPoint)
 {
   udDouble3 vertices[3] = {
     pOldGrid->vertices[pOldGrid->triangles[triangleIndex].vertices.x].position,
@@ -789,7 +789,23 @@ double vcBPA_DistanceToTriangle(vcBPAGrid *pOldGrid, size_t triangleIndex, udDou
     pOldGrid->vertices[pOldGrid->triangles[triangleIndex].vertices.z].position,
   };
 
-  return udDistanceToTriangle(vertices[0], vertices[1], vertices[2], position);
+  return udDistanceToTriangle(vertices[0], vertices[1], vertices[2], position, pPoint);
+}
+
+double vcBPA_SignedDistanceToTriangle(vcBPAGrid *pOldGrid, size_t triangleIndex, udDouble3 position, udDouble3 *pPoint)
+{
+  udDouble3 vertices[3] = {
+    pOldGrid->vertices[pOldGrid->triangles[triangleIndex].vertices.x].position,
+    pOldGrid->vertices[pOldGrid->triangles[triangleIndex].vertices.y].position,
+    pOldGrid->vertices[pOldGrid->triangles[triangleIndex].vertices.z].position,
+  };
+
+  double distance = udDistanceToTriangle(vertices[0], vertices[1], vertices[2], position, pPoint);
+  udDouble3 normal = vcBPA_GetTriangleNormal(vertices[0], vertices[1], vertices[2]);
+  udDouble3 p0_to_position = position - vertices[0];
+  if (udDot3(p0_to_position, normal) < 0.0)
+    distance = -distance;
+  return distance;
 }
 
 size_t vcBPA_FindClosestTriangle(vcBPAGrid *pOldGrid, udDouble3 position)
@@ -799,7 +815,7 @@ size_t vcBPA_FindClosestTriangle(vcBPAGrid *pOldGrid, udDouble3 position)
 
   for (size_t i = 0; i < pOldGrid->triangles.length; ++i)
   {
-    double distance = udAbs(vcBPA_DistanceToTriangle(pOldGrid, i, position));
+    double distance = vcBPA_DistanceToTriangle(pOldGrid, i, position, nullptr);
     if (distance < closestDistance)
     {
       closest = i;
@@ -947,6 +963,7 @@ vdkError vcBPA_ConvertReadPoints(vdkConvertCustomItem *pConvertInput, vdkPointBu
   bool getNextGrid = true;
 
   uint32_t displacementOffset = 0;
+  udUInt3 displacementDistanceOffset = {};
   vdkError error = vE_Failure;
 
   static int gridCount = 0;
@@ -957,6 +974,18 @@ vdkError vcBPA_ConvertReadPoints(vdkConvertCustomItem *pConvertInput, vdkPointBu
     goto epilogue;
 
   error = vdkAttributeSet_GetOffsetOfNamedAttribute(&pBuffer->attributes, "udDisplacement", &displacementOffset);
+  if (error != vE_Success)
+    return error;
+
+  error = vdkAttributeSet_GetOffsetOfNamedAttribute(&pBuffer->attributes, "udDisplacementDirectionX", &displacementDistanceOffset.x);
+  if (error != vE_Success)
+    return error;
+
+  error = vdkAttributeSet_GetOffsetOfNamedAttribute(&pBuffer->attributes, "udDisplacementDirectionY", &displacementDistanceOffset.y);
+  if (error != vE_Success)
+    return error;
+
+  error = vdkAttributeSet_GetOffsetOfNamedAttribute(&pBuffer->attributes, "udDisplacementDirectionZ", &displacementDistanceOffset.z);
   if (error != vE_Success)
     return error;
 
@@ -972,9 +1001,11 @@ vdkError vcBPA_ConvertReadPoints(vdkConvertCustomItem *pConvertInput, vdkPointBu
     udDouble3 position = pData->activeItem.pGrid->vertices[i].position;
     size_t triangle = vcBPA_FindClosestTriangle(&pData->activeItem.oldGrid, position);
 
+    udDouble3 trianglePoint = {};
+
     double distance = FLT_MAX;
     if (triangle < pData->activeItem.oldGrid.triangles.length)
-      distance = udAbs(vcBPA_DistanceToTriangle(&pData->activeItem.oldGrid, triangle, position));
+      distance = vcBPA_SignedDistanceToTriangle(&pData->activeItem.oldGrid, triangle, position, &trianglePoint);
 
     // Position XYZ
     memcpy(&pBuffer->pPositions[pBuffer->pointCount * 3], &pData->activeItem.pGrid->pBuffer->pPositions[i * 3], sizeof(double) * 3);
@@ -1007,6 +1038,15 @@ vdkError vcBPA_ConvertReadPoints(vdkConvertCustomItem *pConvertInput, vdkPointBu
     // Displacement
     float *pDisplacement = (float*)udAddBytes(pBuffer->pAttributes, pointAttrOffset + displacementOffset);
     *pDisplacement = (float)distance;
+
+    for (int elementIndex = 0; elementIndex < 3; ++elementIndex) //X,Y,Z
+    {
+      float *pDisplacementDistance = (float*)udAddBytes(pBuffer->pAttributes, pointAttrOffset + displacementDistanceOffset[elementIndex]);
+      if (distance != FLT_MAX)
+        *pDisplacementDistance = (float)((trianglePoint[elementIndex] - position[elementIndex]) / distance);
+      else
+        *pDisplacementDistance = 0.0;
+    }
 
     ++pBuffer->pointCount;
   }
@@ -1099,10 +1139,17 @@ void vcBPA_CompareExport(vcState *pProgramState, const char *pOldModelPath, cons
 
   uint32_t displacementOffset = 0;
   bool addDisplacement = true;
+
+  uint32_t displacementDirectionOffset = 0;
+  bool addDisplacementDirection = true;
+
   if (vdkAttributeSet_GetOffsetOfNamedAttribute(&header.attributes, "udDisplacement", &displacementOffset) == vE_Success)
     addDisplacement = false;
 
-  vdkAttributeSet_Generate(&item.attributes, vdkSAC_None, header.attributes.count + (addDisplacement ? 1 : 0));
+  if (vdkAttributeSet_GetOffsetOfNamedAttribute(&header.attributes, "udDisplacementDirectionX", &displacementDirectionOffset) == vE_Success)
+    addDisplacementDirection = false;
+
+  vdkAttributeSet_Generate(&item.attributes, vdkSAC_None, header.attributes.count + (addDisplacement ? 1 : 0) + (addDisplacementDirection ? 3 : 0));
 
   for (uint32_t i = 0; i < header.attributes.count; ++i)
   {
@@ -1117,6 +1164,24 @@ void vcBPA_CompareExport(vcState *pProgramState, const char *pOldModelPath, cons
     item.attributes.pDescriptors[item.attributes.count].blendMode = vdkABM_SingleValue;
     item.attributes.pDescriptors[item.attributes.count].typeInfo = vdkAttributeTypeInfo_float32;
     udStrcpy(item.attributes.pDescriptors[item.attributes.count].name, "udDisplacement");
+    ++item.attributes.count;
+  }
+
+  if (addDisplacementDirection)
+  {
+    item.attributes.pDescriptors[item.attributes.count].blendMode = vdkABM_SingleValue;
+    item.attributes.pDescriptors[item.attributes.count].typeInfo = vdkAttributeTypeInfo_float32;
+    udStrcpy(item.attributes.pDescriptors[item.attributes.count].name, "udDisplacementDirectionX");
+    ++item.attributes.count;
+
+    item.attributes.pDescriptors[item.attributes.count].blendMode = vdkABM_SingleValue;
+    item.attributes.pDescriptors[item.attributes.count].typeInfo = vdkAttributeTypeInfo_float32;
+    udStrcpy(item.attributes.pDescriptors[item.attributes.count].name, "udDisplacementDirectionY");
+    ++item.attributes.count;
+
+    item.attributes.pDescriptors[item.attributes.count].blendMode = vdkABM_SingleValue;
+    item.attributes.pDescriptors[item.attributes.count].typeInfo = vdkAttributeTypeInfo_float32;
+    udStrcpy(item.attributes.pDescriptors[item.attributes.count].name, "udDisplacementDirectionZ");
     ++item.attributes.count;
   }
 

--- a/src/vcRender.cpp
+++ b/src/vcRender.cpp
@@ -1403,10 +1403,15 @@ udResult vcRender_RenderUD(vcState *pProgramState, vcRenderContext *pRenderConte
       }
       else if ((pVisSettings->mode == vcVM_Default || pVisSettings->mode == vcVM_Displacement) && vdkAttributeSet_GetOffsetOfNamedAttribute(&renderData.models[i]->m_pointCloudHeader.attributes, "udDisplacement", &pVoxelShaderData[numVisibleModels].attributeOffset) == vE_Success)
       {
-        pModels[numVisibleModels].pVoxelShader = vcVoxelShader_Displacement;
+        if (pProgramState->settings.displacementShaderType == vcDST_Absolute)
+          pModels[numVisibleModels].pVoxelShader = vcVoxelShader_DisplacementAbs;
+        else
+          pModels[numVisibleModels].pVoxelShader = vcVoxelShader_DisplacementSigned;
 
-        pVoxelShaderData[numVisibleModels].data.displacement.minThreshold = pVisSettings->displacement.x;
-        pVoxelShaderData[numVisibleModels].data.displacement.maxThreshold = pVisSettings->displacement.y;
+        pVoxelShaderData[numVisibleModels].data.displacement.minBound = pVisSettings->displacement.bounds.x;
+        pVoxelShaderData[numVisibleModels].data.displacement.maxBound = pVisSettings->displacement.bounds.y;
+        pVoxelShaderData[numVisibleModels].data.displacement.errorColour = pVisSettings->displacement.errorColour;
+        pVoxelShaderData[numVisibleModels].data.displacement.outOfBoundsColour = pVisSettings->displacement.outOfBoundsColour;
       }
 
       ++numVisibleModels;

--- a/src/vcSettings.cpp
+++ b/src/vcSettings.cpp
@@ -209,6 +209,12 @@ bool vcSettings_Load(vcSettings *pSettings, bool forceReset /*= false*/, vcSetti
     pSettings->camera.lensIndex = data.Get("camera.lensId").AsInt(vcLS_30mm);
     pSettings->camera.fieldOfView = data.Get("camera.fieldOfView").AsFloat(vcLens30mm);
 
+    pSettings->displacementShaderType = (vcDisplacementShaderType)data.Get("displacementShaderType").AsInt(0);
+    pSettings->visualization.displacement.bounds.x = data.Get("visualization.displacement.minBound").AsFloat(0.f);
+    pSettings->visualization.displacement.bounds.y = data.Get("visualization.displacement.maxBound").AsFloat(1.f);
+    pSettings->visualization.displacement.errorColour = data.Get("visualization.displacement.errorColour").AsInt(0);
+    pSettings->visualization.displacement.outOfBoundsColour = data.Get("visualization.displacement.outOfBoundsColour").AsInt(16777215);
+
     pSettings->objectHighlighting.enable = data.Get("objectHighlighting.enable").AsBool(true);
     pSettings->objectHighlighting.colour = data.Get("objectHighlighting.colour").AsFloat4(udFloat4::create(0.925f, 0.553f, 0.263f, 1.0f));
     pSettings->objectHighlighting.thickness = data.Get("objectHighlighting.thickness").AsFloat(2.0f);
@@ -520,6 +526,12 @@ bool vcSettings_Save(vcSettings *pSettings)
   data.Set("camera.scrollwheelBinding = %d", pSettings->camera.scrollWheelMode);
 
   // Visualization
+  data.Set("displacementShaderType = %i", pSettings->displacementShaderType);
+  data.Set("visualization.displacement.minBound = %f", pSettings->visualization.displacement.bounds.x);
+  data.Set("visualization.displacement.maxBound = %f", pSettings->visualization.displacement.bounds.y);
+  data.Set("visualization.displacement.errorColour = %i", pSettings->visualization.displacement.errorColour);
+  data.Set("visualization.displacement.outOfBoundsColour = %i", pSettings->visualization.displacement.outOfBoundsColour);
+
   data.Set("visualization.mode = %d", pSettings->visualization.mode - 1);
   data.Set("visualization.minIntensity = %d", pSettings->visualization.minIntensity);
   data.Set("visualization.maxIntensity = %d", pSettings->visualization.maxIntensity);

--- a/src/vcSettings.h
+++ b/src/vcSettings.h
@@ -34,6 +34,12 @@ enum vcVisualizatationMode
   vcVM_Displacement
 };
 
+enum vcDisplacementShaderType
+{
+  vcDST_Absolute,
+  vcDST_Signed
+};
+
 enum vcAnchorStyle
 {
   vcAS_None,
@@ -123,7 +129,13 @@ struct vcVisualizationSettings
   int minIntensity;
   int maxIntensity;
 
-  udFloat2 displacement;
+  struct
+  {
+    udFloat2 bounds;
+    uint32_t errorColour;
+    uint32_t outOfBoundsColour;
+  } displacement;
+
 
   bool useCustomClassificationColours;
   bool customClassificationToggles[256];
@@ -209,6 +221,7 @@ struct vcSettings
   } loginInfo;
 
   vcVisualizationSettings visualization;
+  vcDisplacementShaderType displacementShaderType;
 
   struct
   {

--- a/src/vcSettingsUI.cpp
+++ b/src/vcSettingsUI.cpp
@@ -876,10 +876,38 @@ void vcSettingsUI_VisualizationSettings(vcState *pProgramState, vcVisualizationS
 
   if (pVisualizationSettings->mode == vcVM_Displacement)
   {
-    if (ImGui::InputFloat2(vcString::Get("settingsVisDisplacementRange"), &pVisualizationSettings->displacement.x))
+    int displacementType = pProgramState->settings.displacementShaderType;
+    ImGui::RadioButton(vcString::Get("settingsVisDisplacementAbs"), &displacementType, vcDST_Absolute); ImGui::SameLine();
+    ImGui::RadioButton(vcString::Get("settingsVisDisplacementSigned"), &displacementType, vcDST_Signed);
+    pProgramState->settings.displacementShaderType = (vcDisplacementShaderType)displacementType;
+
+    if (displacementType == vcDST_Absolute)
     {
-      pVisualizationSettings->displacement.x = udClamp(pVisualizationSettings->displacement.x, 0.f, MAX_DISPLACEMENT);
-      pVisualizationSettings->displacement.y = udClamp(pVisualizationSettings->displacement.y, pVisualizationSettings->displacement.x, MAX_DISPLACEMENT);
+      pProgramState->settings.displacementShaderType = vcDST_Absolute;
+      ImGui::DragFloat2(vcString::Get("settingsVisDisplacementRange"), &pVisualizationSettings->displacement.bounds.x, 0.02f, 0.f, MAX_DISPLACEMENT);
+      pVisualizationSettings->displacement.bounds.x = udClamp(pVisualizationSettings->displacement.bounds.x, 0.f, MAX_DISPLACEMENT);
+      pVisualizationSettings->displacement.bounds.y = udClamp(pVisualizationSettings->displacement.bounds.y, pVisualizationSettings->displacement.bounds.x, MAX_DISPLACEMENT);
     }
+    else
+    {
+      ImGui::DragFloat(vcString::Get("settingsVisDisplacementRange"), &pVisualizationSettings->displacement.bounds.y, 0.02f, 0.f, MAX_DISPLACEMENT, "+-%.3f");
+      pVisualizationSettings->displacement.bounds.x = -pVisualizationSettings->displacement.bounds.y;
+    }
+
+    float s_errorColour[3] = {};
+    s_errorColour[0] = float((pProgramState->settings.visualization.displacement.errorColour >> 16) & 0xFF) / 255.f;
+    s_errorColour[1] = float((pProgramState->settings.visualization.displacement.errorColour >> 8) & 0xFF) / 255.f;
+    s_errorColour[2] = float(pProgramState->settings.visualization.displacement.errorColour & 0xFF) / 255.f;
+
+    float s_outOfBoundsColour[3] = {};
+    s_outOfBoundsColour[0] = float((pProgramState->settings.visualization.displacement.outOfBoundsColour >> 16) & 0xFF) / 255.f;
+    s_outOfBoundsColour[1] = float((pProgramState->settings.visualization.displacement.outOfBoundsColour >> 8) & 0xFF) / 255.f;
+    s_outOfBoundsColour[2] = float( pProgramState->settings.visualization.displacement.outOfBoundsColour & 0xFF) / 255.f;
+
+    if (ImGui::ColorEdit3(vcString::Get("settingsVisDisplacementErrorClr"), s_errorColour))
+      pProgramState->settings.visualization.displacement.errorColour = (uint32_t(s_errorColour[0] * 255) << 16) | (uint32_t(s_errorColour[1] * 255) << 8) | uint32_t(s_errorColour[2] * 255);
+
+    if (ImGui::ColorEdit3(vcString::Get("settingsVisDisplacementOutOfBoundsClr"), s_outOfBoundsColour))
+      pProgramState->settings.visualization.displacement.outOfBoundsColour = (uint32_t(s_outOfBoundsColour[0] * 255) << 16) | (uint32_t(s_outOfBoundsColour[1] * 255) << 8) | uint32_t(s_outOfBoundsColour[2] * 255);
   }
 }

--- a/src/vcVoxelShaders.h
+++ b/src/vcVoxelShaders.h
@@ -22,8 +22,10 @@ struct vcUDRSData
     } classification;
     struct
     {
-      float minThreshold;
-      float maxThreshold;
+      float minBound;
+      float maxBound;
+      uint32_t errorColour;
+      uint32_t outOfBoundsColour;
     } displacement;
   } data;
 };
@@ -32,4 +34,5 @@ uint32_t vcVoxelShader_Black(vdkPointCloud *pPointCloud, uint64_t voxelID, const
 uint32_t vcVoxelShader_Colour(vdkPointCloud *pPointCloud, uint64_t voxelID, const void *pUserData);
 uint32_t vcVoxelShader_Intensity(vdkPointCloud *pPointCloud, uint64_t voxelID, const void *pUserData);
 uint32_t vcVoxelShader_Classification(vdkPointCloud *pPointCloud, uint64_t voxelID, const void *pUserData);
-uint32_t vcVoxelShader_Displacement(vdkPointCloud *pPointCloud, uint64_t voxelID, const void *pUserData);
+uint32_t vcVoxelShader_DisplacementAbs(vdkPointCloud *pPointCloud, uint64_t voxelID, const void *pUserData);
+uint32_t vcVoxelShader_DisplacementSigned(vdkPointCloud *pPointCloud, uint64_t voxelID, const void *pUserData);


### PR DESCRIPTION
[AB#1197](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1197)

- Comparison models now export with signed distances
- The user now has a choice of rendering absolute or signed distances
- New UI elements to set up comparison viewing
- Gradient colour banding
- Possibility for users to set custom colours for colour banding (not implemented)