### PR TITLE
ShaderConductor OpenGL Fixes

### DIFF
--- a/buildscripts/compile-shaders.sh
+++ b/buildscripts/compile-shaders.sh
@@ -26,7 +26,7 @@ GenerateShader () {
 
 	DstName=$(echo ${SrcName} | sed "s%${SrcFolder}%${2}%" | sed "s%hlsl%${ShaderExt}%")
 
-	${SC} -E main -I ${SrcName} -O ${DstName} -S ${ShaderStage} -T ${Target} -V "${Version}"
+	"${SC}" -E main -I ${SrcName} -O ${DstName} -S ${ShaderStage} -T ${Target} -V "${Version}"
 }
 
 for SrcName in ${SrcFolder}/*.hlsl; do

--- a/src/gl/directx11/shaders/blurVertexShader.hlsl
+++ b/src/gl/directx11/shaders/blurVertexShader.hlsl
@@ -2,8 +2,8 @@ cbuffer u_cameraPlaneParams
 {
   float s_CameraNearPlane;
   float s_CameraFarPlane;
-  float u_unused1;
-  float u_unused2;
+  float u_clipZNear;
+  float u_clipZFar;
 };
 
 struct VS_INPUT
@@ -29,11 +29,11 @@ PS_INPUT main(VS_INPUT input)
 {
   PS_INPUT output;
 
-  output.pos = float4(input.pos.x, input.pos.y, 0.0, 1.0);
+  output.pos = float4(input.pos.xy, 0.0, 1.0);
 
   // sample on edges, taking advantage of bilinear sampling
   float2 sampleOffset = 1.42 * u_stepSize.xy;
-  float2 uv = float2(input.uv.x, 1.0 - input.uv.y);
+  float2 uv = input.uv;
   output.uv0 = uv - sampleOffset;
   output.uv1 = uv;
   output.uv2 = uv + sampleOffset;

--- a/src/gl/directx11/shaders/imageColourSkyboxVertexShader.hlsl
+++ b/src/gl/directx11/shaders/imageColourSkyboxVertexShader.hlsl
@@ -2,8 +2,8 @@ cbuffer u_cameraPlaneParams
 {
   float s_CameraNearPlane;
   float s_CameraFarPlane;
-  float u_unused1;
-  float u_unused2;
+  float u_clipZNear;
+  float u_clipZFar;
 };
 
 struct VS_INPUT
@@ -29,7 +29,7 @@ PS_INPUT main(VS_INPUT input)
 {
   PS_INPUT output;
   output.pos = float4(input.pos.xy, 0.f, 1.f);
-  output.uv = float2(input.uv.x, 1.0 - input.uv.y) / u_imageSize.xy;
+  output.uv = input.uv / u_imageSize.xy;
   output.tintColour = u_tintColour;
   return output;
 }

--- a/src/gl/directx11/shaders/imageRendererBillboardVertexShader.hlsl
+++ b/src/gl/directx11/shaders/imageRendererBillboardVertexShader.hlsl
@@ -2,8 +2,8 @@ cbuffer u_cameraPlaneParams
 {
   float s_CameraNearPlane;
   float s_CameraFarPlane;
-  float u_unused1;
-  float u_unused2;
+  float u_clipZNear;
+  float u_clipZFar;
 };
 
 struct VS_INPUT
@@ -31,10 +31,10 @@ PS_INPUT main(VS_INPUT input)
 {
   PS_INPUT output;
 
-  output.pos = mul(u_worldViewProjectionMatrix, float4(input.pos, 1.0));
-  output.pos.xy += u_screenSize.z * output.pos.w * u_screenSize.xy * float2(input.uv.x * 2.0 - 1.0, input.uv.y * 2.0 - 1.0); // expand billboard
+  output.pos = mul(u_worldViewProjectionMatrix, float4(0, 0, 0, 1.0));
+  output.pos.xy += u_screenSize.z * output.pos.w * u_screenSize.xy * input.pos.xy; // expand billboard
 
-  output.uv = float2(input.uv.x, 1.0 - input.uv.y);
+  output.uv = input.uv;
   output.colour = u_colour;
   output.fLogDepth.x = 1.0 + output.pos.w;
 

--- a/src/gl/directx11/shaders/imgui3DVertexShader.hlsl
+++ b/src/gl/directx11/shaders/imgui3DVertexShader.hlsl
@@ -2,8 +2,8 @@ cbuffer u_cameraPlaneParams
 {
   float s_CameraNearPlane;
   float s_CameraFarPlane;
-  float u_unused1;
-  float u_unused2;
+  float u_clipZNear;
+  float u_clipZFar;
 };
 
 struct VS_INPUT
@@ -30,7 +30,7 @@ PS_INPUT main(VS_INPUT input)
 {
   PS_INPUT output;
   output.pos = mul(u_worldViewProjectionMatrix, float4(0.0, 0.0, 0.0, 1.0));
-  output.pos.xy += u_screenSize.xy * float2(input.pos.x, -input.pos.y) * output.pos.w; // expand
+  output.pos.xy += u_screenSize.xy * input.pos.xy * output.pos.w; // expand
 
   output.col = input.col;
   output.uv = input.uv;

--- a/src/gl/directx11/shaders/panoramaSkyboxFragmentShader.hlsl
+++ b/src/gl/directx11/shaders/panoramaSkyboxFragmentShader.hlsl
@@ -2,14 +2,14 @@ cbuffer u_cameraPlaneParams
 {
   float s_CameraNearPlane;
   float s_CameraFarPlane;
-  float u_unused1;
-  float u_unused2;
+  float u_clipZNear;
+  float u_clipZFar;
 };
 
 struct PS_INPUT
 {
   float4 pos : SV_POSITION;
-  float2 uv : TEXCOORD0;
+  float4 clip : TEXCOORD0;
 };
 
 cbuffer u_EveryFrame : register(b0)
@@ -31,7 +31,7 @@ float2 directionToLatLong(float3 dir)
 float4 main(PS_INPUT input) : SV_Target
 {
   // work out 3D point
-  float4 point3D = mul(u_inverseViewProjection, float4(input.uv * float2(2.0, 2.0) - float2(1.0, 1.0), 1.0, 1.0));
+  float4 point3D = mul(u_inverseViewProjection, float4(input.clip.xy, 1.0, 1.0));
   point3D.xyz = normalize(point3D.xyz / point3D.w);
   return u_texture.Sample(sampler0, directionToLatLong(point3D.xyz));
 }

--- a/src/gl/directx11/shaders/panoramaSkyboxVertexShader.hlsl
+++ b/src/gl/directx11/shaders/panoramaSkyboxVertexShader.hlsl
@@ -2,8 +2,8 @@ cbuffer u_cameraPlaneParams
 {
   float s_CameraNearPlane;
   float s_CameraFarPlane;
-  float u_unused1;
-  float u_unused2;
+  float u_clipZNear;
+  float u_clipZFar;
 };
 
 struct VS_INPUT
@@ -15,13 +15,13 @@ struct VS_INPUT
 struct PS_INPUT
 {
   float4 pos : SV_POSITION;
-  float2 uv : TEXCOORD0;
+  float4 clip : TEXCOORD0;
 };
 
 PS_INPUT main(VS_INPUT input)
 {
   PS_INPUT output;
   output.pos = float4(input.pos.xy, 0.f, 1.f);
-  output.uv = float2(input.uv.x, 1.0 - input.uv.y);
+  output.clip = output.pos;
   return output;
 }

--- a/src/gl/directx11/shaders/viewShedFragmentShader.hlsl
+++ b/src/gl/directx11/shaders/viewShedFragmentShader.hlsl
@@ -9,7 +9,8 @@ cbuffer u_cameraPlaneParams
 struct PS_INPUT
 {
   float4 pos : SV_POSITION;
-  float2 uv : TEXCOORD0;
+  float4 clip : TEXCOORD0;
+  float2 uv : TEXCOORD1;
 };
 
 struct PS_OUTPUT
@@ -48,15 +49,20 @@ float logToLinearDepth(float logDepth)
   return a + b / worldDepth;
 }
 
+float linearDepthToClipZ(float depth)
+{
+  return depth * (u_clipZFar - u_clipZNear) + u_clipZNear;
+}
+
 PS_OUTPUT main(PS_INPUT input)
 {
   PS_OUTPUT output;
 
   float4 col = float4(0.0, 0.0, 0.0, 0.0);
   float logDepth = texture0.Sample(sampler0, input.uv).x;
-  float depth = logToLinearDepth(logDepth);
-
-  float4 fragEyePosition = mul(u_inverseProjection, float4(input.uv.x * 2.0 - 1.0, (1.0 - input.uv.y) * 2.0 - 1.0, depth, 1.0));
+  float clipZ = linearDepthToClipZ(logToLinearDepth(logDepth));
+	
+  float4 fragEyePosition = mul(u_inverseProjection, float4(input.clip.xy, clipZ, 1.0));
   fragEyePosition /= fragEyePosition.w;
 
   float4 shadowUV = float4(0, 0, 0, 0);

--- a/src/gl/directx11/shaders/viewShedFragmentShader.hlsl
+++ b/src/gl/directx11/shaders/viewShedFragmentShader.hlsl
@@ -61,7 +61,7 @@ PS_OUTPUT main(PS_INPUT input)
   float4 col = float4(0.0, 0.0, 0.0, 0.0);
   float logDepth = texture0.Sample(sampler0, input.uv).x;
   float clipZ = linearDepthToClipZ(logToLinearDepth(logDepth));
-	
+
   float4 fragEyePosition = mul(u_inverseProjection, float4(input.clip.xy, clipZ, 1.0));
   fragEyePosition /= fragEyePosition.w;
 

--- a/src/gl/directx11/shaders/viewShedVertexShader.hlsl
+++ b/src/gl/directx11/shaders/viewShedVertexShader.hlsl
@@ -15,13 +15,15 @@ struct VS_INPUT
 struct PS_INPUT
 {
   float4 pos : SV_POSITION;
-  float2 uv : TEXCOORD0;
+  float4 clip : TEXCOORD0;
+  float2 uv : TEXCOORD1;
 };
 
 PS_INPUT main(VS_INPUT input)
 {
   PS_INPUT output;
   output.pos = float4(input.pos.xy, 0.f, 1.f);
+  output.clip = output.pos;
   output.uv = input.uv;
   return output;
 }

--- a/src/gl/directx11/shaders/visualizationVertexShader.hlsl
+++ b/src/gl/directx11/shaders/visualizationVertexShader.hlsl
@@ -2,8 +2,8 @@ cbuffer u_cameraPlaneParams
 {
   float s_CameraNearPlane;
   float s_CameraFarPlane;
-  float u_unused1;
-  float u_unused2;
+  float u_clipZNear;
+  float u_clipZFar;
 };
 
 struct VS_INPUT
@@ -15,11 +15,12 @@ struct VS_INPUT
 struct PS_INPUT
 {
   float4 pos : SV_POSITION;
-  float2 uv : TEXCOORD0;
-  float2 edgeSampleUV0 : TEXCOORD1;
-  float2 edgeSampleUV1 : TEXCOORD2;
-  float2 edgeSampleUV2 : TEXCOORD3;
-  float2 edgeSampleUV3 : TEXCOORD4;
+  float4 clip : TEXCOORD0;
+  float2 uv : TEXCOORD1;
+  float2 edgeSampleUV0 : TEXCOORD2;
+  float2 edgeSampleUV1 : TEXCOORD3;
+  float2 edgeSampleUV2 : TEXCOORD4;
+  float2 edgeSampleUV3 : TEXCOORD5;
 };
 
 cbuffer u_vertParams : register(b1)
@@ -32,6 +33,7 @@ PS_INPUT main(VS_INPUT input)
   PS_INPUT output;
   output.pos = float4(input.pos.xy, 0.f, 1.f);
   output.uv = input.uv;
+  output.clip = output.pos;
 
   float3 sampleOffsets = float3(u_outlineStepSize.xy, 0.0);
   output.edgeSampleUV0 = output.uv + sampleOffsets.xz;

--- a/src/gl/directx11/vcShader.cpp
+++ b/src/gl/directx11/vcShader.cpp
@@ -230,9 +230,9 @@ bool vcShader_Bind(vcShader *pShader)
     {
       float cameraNearPlane;
       float cameraFarPlane;
-      float unused1;
-      float unused2;
-    } cameraPlane = { s_CameraNearPlane, s_CameraFarPlane, 0.f, 0.f };
+      float clipZNear;
+      float clipZFar;
+    } cameraPlane = { s_CameraNearPlane, s_CameraFarPlane, 0.f, 1.f };
     vcShader_BindConstantBuffer(pShader, pShader->pCameraPlaneParams, &cameraPlane, sizeof(cameraPlane));
   }
 

--- a/src/gl/opengl/vcGLState.cpp
+++ b/src/gl/opengl/vcGLState.cpp
@@ -93,6 +93,9 @@ bool vcGLState_ResetState(bool force /*= false*/)
 
 bool vcGLState_SetFaceMode(vcGLStateFillMode fillMode, vcGLStateCullMode cullMode, bool isFrontCCW /*= true*/, bool force /*= false*/)
 {
+  // reverse convention for what is front-facing, due to flipped projection
+  isFrontCCW = !isFrontCCW;
+
 #if UDPLATFORM_IOS || UDPLATFORM_IOS_SIMULATOR
   if (fillMode != vcGLSFM_Solid)
     return false;

--- a/src/gl/opengl/vcShader.cpp
+++ b/src/gl/opengl/vcShader.cpp
@@ -132,9 +132,9 @@ bool vcShader_Bind(vcShader *pShader)
     {
       float cameraNearPlane;
       float cameraFarPlane;
-      float unused1;
-      float unused2;
-    } cameraPlane = { s_CameraNearPlane, s_CameraFarPlane, 0.f, 0.f };
+      float clipZNear;
+      float clipZFar;
+    } cameraPlane = { s_CameraNearPlane, s_CameraFarPlane, -1.f, 1.f };
     vcShader_BindConstantBuffer(pShader, pShader->pCameraPlaneParams, &cameraPlane, sizeof(cameraPlane));
   }
 

--- a/src/gl/vcGLState.h
+++ b/src/gl/vcGLState.h
@@ -155,4 +155,15 @@ int32_t vcGLState_GetMaxAnisotropy(int32_t desiredAniLevel);
 void vcGLState_ReportGPUWork(size_t drawCount, size_t triCount, size_t uploadBytesCount);
 bool vcGLState_IsGPUDataUploadAllowed();
 
+template <typename T>
+udMatrix4x4<T> vcGLState_ProjectionMatrix(T fovY, T aspectRatio, T znear, T zfar)
+{
+#if GRAPHICS_API_OPENGL
+  static const udMatrix4x4<T> FlipVertically = udMatrix4x4<T>::scaleNonUniform(T(1), T(-1), T(1));
+  return FlipVertically * udMatrix4x4<T>::perspectiveNO(fovY, aspectRatio, znear, zfar);
+#else
+  return udMatrix4x4<T>::perspectiveZO(fovY, aspectRatio, znear, zfar);
+#endif
+}
+
 #endif // vcGLState_h__

--- a/src/imgui_ex/ImGuizmo.cpp
+++ b/src/imgui_ex/ImGuizmo.cpp
@@ -148,7 +148,9 @@ static ImVec2 vcGizmo_WorldToScreen(const udDouble3& worldPos, const udDouble4x4
   if (trans.w != 0)
     trans *= 0.5f / trans.w;
   trans += udDouble4::create(0.5, 0.5, 0.0, 0.0);
+#if GRAPHICS_API_D3D11
   trans.y = 1.0 - trans.y;
+#endif
   trans.x *= sGizmoContext.mWidth;
   trans.y *= sGizmoContext.mHeight;
   trans.x += sGizmoContext.mX;

--- a/src/imgui_ex/ImGuizmo.cpp
+++ b/src/imgui_ex/ImGuizmo.cpp
@@ -148,7 +148,7 @@ static ImVec2 vcGizmo_WorldToScreen(const udDouble3& worldPos, const udDouble4x4
   if (trans.w != 0)
     trans *= 0.5f / trans.w;
   trans += udDouble4::create(0.5, 0.5, 0.0, 0.0);
-#if GRAPHICS_API_D3D11
+#if !GRAPHICS_API_OPENGL
   trans.y = 1.0 - trans.y;
 #endif
   trans.x *= sGizmoContext.mWidth;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1683,16 +1683,8 @@ void vcMain_RenderSceneWindow(vcState *pProgramState)
   {
     vcRender_BeginFrame(pProgramState, pProgramState->pRenderContext, renderData);
 
-    ImVec2 uv0 = ImVec2(0, 0);
-    ImVec2 uv1 = ImVec2(renderData.sceneScaling.x, renderData.sceneScaling.y);
-#if GRAPHICS_API_OPENGL
-    // flip vertically
-    uv1.y = 0;
-    uv0.y = renderData.sceneScaling.y;
-#endif
-
     // Actual rendering to this texture is deferred
-    ImGui::Image(renderData.pSceneTexture, windowSize, uv0, uv1);
+    ImGui::Image(renderData.pSceneTexture, windowSize, ImVec2(0, 0), ImVec2(renderData.sceneScaling.x, renderData.sceneScaling.y));
 
     if (pProgramState->settings.screenshot.taking)
       pProgramState->screenshot.pImage = renderData.pSceneTexture;

--- a/src/rendering/vcInternalModels.cpp
+++ b/src/rendering/vcInternalModels.cpp
@@ -16,7 +16,6 @@ udResult vcInternalModels_Init()
   UD_ERROR_IF(gRefCount != 1, udR_Success);
 
   UD_ERROR_CHECK(vcMesh_Create(&gInternalMeshes[vcInternalMeshType_ScreenQuad], vcP3UV2VertexLayout, int(udLengthOf(vcP3UV2VertexLayout)), screenQuadVertices, 4, screenQuadIndices, 6));
-  UD_ERROR_CHECK(vcMesh_Create(&gInternalMeshes[vcInternalMeshType_FlippedScreenQuad], vcP3UV2VertexLayout, int(udLengthOf(vcP3UV2VertexLayout)), flippedScreenQuadVertices, 4, flippedScreenQuadIndices, 6));
   UD_ERROR_CHECK(vcMesh_Create(&gInternalMeshes[vcInternalMeshType_ImGuiQuad], vcImGuiVertexLayout, int(udLengthOf(vcImGuiVertexLayout)), imGuiQuadVertices, 4, imGuiQuadIndices, 6));
 
   UD_ERROR_CHECK(vcMesh_Create(&gInternalMeshes[vcInternalMeshType_WorldQuad], vcP3N3UV2VertexLayout, int(udLengthOf(vcP3N3UV2VertexLayout)), worldQuadVertices, 4, worldQuadIndices, 6, vcMF_IndexShort));

--- a/src/rendering/vcInternalModels.h
+++ b/src/rendering/vcInternalModels.h
@@ -9,7 +9,6 @@ struct vcPolygonModel;
 enum vcInternalMeshType
 {
   vcInternalMeshType_ScreenQuad,
-  vcInternalMeshType_FlippedScreenQuad,
   vcInternalMeshType_ImGuiQuad,
 
   vcInternalMeshType_WorldQuad,

--- a/src/rendering/vcInternalModelsData.h
+++ b/src/rendering/vcInternalModelsData.h
@@ -4,12 +4,13 @@
 #include "gl/vcLayout.h"
 
 // screen quad
-const vcP3UV2Vertex screenQuadVertices[4]{ { { -1.f, 1.f, 0.f },{ 0, 0 } },{ { -1.f, -1.f, 0.f },{ 0, 1 } },{ { 1.f, -1.f, 0.f },{ 1, 1 } },{ { 1.f, 1.f, 0.f },{ 1, 0 } } };
+#if GRAPHICS_API_D3D11
+const vcP3UV2Vertex screenQuadVertices[4]{ { { -1.f, -1.f, 0.f },{ 0, 1 } },{ { 1.f, -1.f, 0.f },{ 1, 1 } },{ { 1.f, 1.f, 0.f },{ 1, 0 } },{ { -1.f, 1.f, 0.f },{ 0, 0 } } };
 const uint32_t screenQuadIndices[6] = { 0, 1, 2, 0, 2, 3 };
-
-// inverted screen quad
-const vcP3UV2Vertex flippedScreenQuadVertices[4]{ { { -1.f, -1.f, 0.f },{ 0, 0 } },{ { -1.f, 1.f, 0.f },{ 0, 1 } },{ { 1.f, 1.f, 0.f },{ 1, 1 } },{ { 1.f, -1.f, 0.f },{ 1, 0 } } };
-const uint32_t flippedScreenQuadIndices[6] = { 2, 1, 0, 3, 2, 0 };
+#else
+const vcP3UV2Vertex screenQuadVertices[4]{ { { -1.f, -1.f, 0.f },{ 0, 0 } },{ { 1.f, -1.f, 0.f },{ 1, 0 } },{ { 1.f, 1.f, 0.f },{ 1, 1 } },{ { -1.f, 1.f, 0.f },{ 0, 1 } } };
+const uint32_t screenQuadIndices[6] = { 2, 1, 0, 3, 2, 0 };
+#endif
 
 // imgui quad
 const vcImGuiVertex imGuiQuadVertices[4]{ { { -0.5f, -0.5f }, { 0.f, 0.0f }, 0xffffffff },{ { -0.5f, 0.5f }, { 0.0f, 1.0f }, 0xffffffff },{ { 0.5f, 0.5f }, { 1.0f, 1.0f }, 0xffffffff },{ { 0.5f, -0.5f }, { 1.0f, 0.0f }, 0xffffffff } };
@@ -20,8 +21,13 @@ const vcP3N3UV2Vertex worldQuadVertices[4]{ { { -1.f, 0.f, -1.f }, { 0.f, 1.f, 0
 const uint32_t worldQuadIndices[6] = { 0, 1, 2, 0, 2, 3 };
 
 // billboard
-const vcP3UV2Vertex billboardVertices[4]{ { { 0.f, 0.f, 0.f },{ 0, 0 } },{ { 0.f, 0.f, 0.f },{ 0, 1 } },{ { 0.f, 0.f, 0.f },{ 1, 1 } },{ { 0.f, 0.f, 0.f },{ 1, 0 } } };
+#if GRAPHICS_API_D3D11
+const vcP3UV2Vertex billboardVertices[4]{ { { -1.f, -1.f, 0.f },{ 0, 1 } },{ { -1.f, 1.f, 0.f },{ 0, 0 } },{ { 1.f, 1.f, 0.f },{ 1, 0 } },{ { 1.f, -1.f, 0.f },{ 1, 1 } } };
 const uint32_t billboardIndices[6] = { 0, 1, 2, 0, 2, 3 };
+#else
+const vcP3UV2Vertex billboardVertices[4]{ { { -1.f, -1.f, 0.f },{ 0, 0 } },{ { -1.f, 1.f, 0.f },{ 0, 1 } },{ { 1.f, 1.f, 0.f },{ 1, 1 } },{ { 1.f, -1.f, 0.f },{ 1, 0 } } };
+const uint32_t billboardIndices[6] = { 2, 1, 0, 3, 2, 0 };
+#endif
 
 const float cylinderVerticesFltArray[][8] = {
 { 0.000000f, 1.000000f, -1.000000f, 0.0000f, 1.0000f, 0.0000f, 1.000000f, 0.500000f },

--- a/src/rendering/vcInternalModelsData.h
+++ b/src/rendering/vcInternalModelsData.h
@@ -4,12 +4,12 @@
 #include "gl/vcLayout.h"
 
 // screen quad
-#if GRAPHICS_API_D3D11
-const vcP3UV2Vertex screenQuadVertices[4]{ { { -1.f, -1.f, 0.f },{ 0, 1 } },{ { 1.f, -1.f, 0.f },{ 1, 1 } },{ { 1.f, 1.f, 0.f },{ 1, 0 } },{ { -1.f, 1.f, 0.f },{ 0, 0 } } };
-const uint32_t screenQuadIndices[6] = { 0, 1, 2, 0, 2, 3 };
-#else
+#if GRAPHICS_API_OPENGL
 const vcP3UV2Vertex screenQuadVertices[4]{ { { -1.f, -1.f, 0.f },{ 0, 0 } },{ { 1.f, -1.f, 0.f },{ 1, 0 } },{ { 1.f, 1.f, 0.f },{ 1, 1 } },{ { -1.f, 1.f, 0.f },{ 0, 1 } } };
 const uint32_t screenQuadIndices[6] = { 2, 1, 0, 3, 2, 0 };
+#else
+const vcP3UV2Vertex screenQuadVertices[4]{ { { -1.f, -1.f, 0.f },{ 0, 1 } },{ { 1.f, -1.f, 0.f },{ 1, 1 } },{ { 1.f, 1.f, 0.f },{ 1, 0 } },{ { -1.f, 1.f, 0.f },{ 0, 0 } } };
+const uint32_t screenQuadIndices[6] = { 0, 1, 2, 0, 2, 3 };
 #endif
 
 // imgui quad
@@ -21,12 +21,12 @@ const vcP3N3UV2Vertex worldQuadVertices[4]{ { { -1.f, 0.f, -1.f }, { 0.f, 1.f, 0
 const uint32_t worldQuadIndices[6] = { 0, 1, 2, 0, 2, 3 };
 
 // billboard
-#if GRAPHICS_API_D3D11
-const vcP3UV2Vertex billboardVertices[4]{ { { -1.f, -1.f, 0.f },{ 0, 1 } },{ { -1.f, 1.f, 0.f },{ 0, 0 } },{ { 1.f, 1.f, 0.f },{ 1, 0 } },{ { 1.f, -1.f, 0.f },{ 1, 1 } } };
-const uint32_t billboardIndices[6] = { 0, 1, 2, 0, 2, 3 };
-#else
+#if GRAPHICS_API_OPENGL
 const vcP3UV2Vertex billboardVertices[4]{ { { -1.f, -1.f, 0.f },{ 0, 0 } },{ { -1.f, 1.f, 0.f },{ 0, 1 } },{ { 1.f, 1.f, 0.f },{ 1, 1 } },{ { 1.f, -1.f, 0.f },{ 1, 0 } } };
 const uint32_t billboardIndices[6] = { 2, 1, 0, 3, 2, 0 };
+#else
+const vcP3UV2Vertex billboardVertices[4]{ { { -1.f, -1.f, 0.f },{ 0, 1 } },{ { -1.f, 1.f, 0.f },{ 0, 0 } },{ { 1.f, 1.f, 0.f },{ 1, 0 } },{ { 1.f, -1.f, 0.f },{ 1, 1 } } };
+const uint32_t billboardIndices[6] = { 0, 1, 2, 0, 2, 3 };
 #endif
 
 const float cylinderVerticesFltArray[][8] = {

--- a/src/rendering/vcLabelRenderer.cpp
+++ b/src/rendering/vcLabelRenderer.cpp
@@ -94,6 +94,11 @@ bool vcLabelRenderer_Render(ImDrawList *drawList, vcLabelInfo *pLabelRenderer, c
   gShader.everyObject.u_worldViewProjectionMatrix = udFloat4x4::create(mvp);
   gShader.everyObject.u_screenSize = udFloat4::create(2.0f / screenSize.x, 2.0f / screenSize.y, 0.0f, 0.0f);
 
+#if GRAPHICS_API_D3D11
+  // ImGui vertices are built with origin in bottom left corner
+  gShader.everyObject.u_screenSize.y *= -1;
+#endif
+
   ImDrawCmd *pcmd = &drawList->CmdBuffer.back();
   int vtx = drawList->VtxBuffer.Size;
   int idx = drawList->IdxBuffer.Size;

--- a/src/rendering/vcLabelRenderer.cpp
+++ b/src/rendering/vcLabelRenderer.cpp
@@ -94,7 +94,7 @@ bool vcLabelRenderer_Render(ImDrawList *drawList, vcLabelInfo *pLabelRenderer, c
   gShader.everyObject.u_worldViewProjectionMatrix = udFloat4x4::create(mvp);
   gShader.everyObject.u_screenSize = udFloat4::create(2.0f / screenSize.x, 2.0f / screenSize.y, 0.0f, 0.0f);
 
-#if GRAPHICS_API_D3D11
+#if !GRAPHICS_API_OPENGL
   // ImGui vertices are built with origin in bottom left corner
   gShader.everyObject.u_screenSize.y *= -1;
 #endif

--- a/src/vcCamera.cpp
+++ b/src/vcCamera.cpp
@@ -110,19 +110,9 @@ void vcCamera_UpdateMatrices(vcCamera *pCamera, const vcCameraSettings &settings
 
   pCamera->matrices.camera = vcCamera_GetMatrix(pCamera);
 
-#if GRAPHICS_API_OPENGL
-  pCamera->matrices.projectionNear = udDouble4x4::perspectiveNO(fov, aspect, 0.5f, 10000.f);
-#else
-  pCamera->matrices.projectionNear = udDouble4x4::perspectiveZO(fov, aspect, 0.5f, 10000.f);
-#endif
-
+  pCamera->matrices.projectionNear = vcGLState_ProjectionMatrix<double>(fov, aspect, 0.5f, 10000.f);
+  pCamera->matrices.projection = vcGLState_ProjectionMatrix<double>(fov, aspect, zNear, zFar);
   pCamera->matrices.projectionUD = udDouble4x4::perspectiveZO(fov, aspect, zNear, zFar);
-
-#if GRAPHICS_API_OPENGL
-  pCamera->matrices.projection = udDouble4x4::perspectiveNO(fov, aspect, zNear, zFar);
-#else
-  pCamera->matrices.projection = pCamera->matrices.projectionUD;
-#endif
 
   pCamera->matrices.view = pCamera->matrices.camera;
   pCamera->matrices.view.inverse();
@@ -138,6 +128,7 @@ void vcCamera_UpdateMatrices(vcCamera *pCamera, const vcCameraSettings &settings
     double nearClipZ = 0.0;
 #if GRAPHICS_API_OPENGL
     nearClipZ = -1.0;
+    mousePosClip.y = -mousePosClip.y;
 #endif
     udDouble4 mouseNear = (pCamera->matrices.inverseViewProjection * udDouble4::create(mousePosClip, nearClipZ, 1.0));
     udDouble4 mouseFar = (pCamera->matrices.inverseViewProjection * udDouble4::create(mousePosClip, 1.0, 1.0));


### PR DESCRIPTION
Opengl now renders upside down (this allows unmodified ShaderConductor generated shaders to work correctly between the graphics APIs).

[AB#171](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/171)