### PR TITLE
awu/turn to north

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1375,7 +1375,7 @@ void vcRenderSceneUI(vcState *pProgramState, const ImVec2 &windowPos, const ImVe
 
         if (ImGui::ButtonEx("", ImVec2(28, 28)))
         {
-          pProgramState->cameraInput.targetEulerRotation = UD_DEG2RAD(udDouble3::create(0, -90, 0));
+          pProgramState->cameraInput.targetEulerRotation = udDouble3::create(0, pProgramState->camera.eulerRotation.y, 0);
           pProgramState->cameraInput.inputState = vcCIS_Rotate;
           pProgramState->cameraInput.progress = 0.0;
         }


### PR DESCRIPTION
Fixed [AB#1342](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1342).

Keeping pitch angle when camera is set to North by button.