### PR TITLE
awu/TrueNorthButtonTooltip

### DIFF
--- a/builds/assets/lang/enAU.json
+++ b/builds/assets/lang/enAU.json
@@ -387,6 +387,7 @@
   "sceneFullscreen": "Fullscreen",
   "sceneMapMode": "Map Mode",
   "toggleSceneExplorer": "Show/Hide Scene Explorer",
+  "sceneTrueNorthTooltip": "Rotate The View",
 
   "sceneCameraSettings": "Camera Settings",
   "sceneCameraLatLongAlt": "Lat: {0}°, Lon: {1}°, Alt {2}",

--- a/builds/assets/lang/zhCN.json
+++ b/builds/assets/lang/zhCN.json
@@ -401,6 +401,7 @@
   "sceneFullscreen": "全屏",
   "sceneMapMode": "地图模式",
   "toggleSceneExplorer": "显示/隐藏场景资源管理器",
+  "sceneTrueNorthTooltip": "旋转视图",
 
   "sceneCameraSettings": "摄像机设置",
   "sceneCameraLatLongAlt": "纬度: {0}°, 经度: {1}°, 海拔 {2}",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1373,12 +1373,20 @@ void vcRenderSceneUI(vcState *pProgramState, const ImVec2 &windowPos, const ImVe
         float northX = -(float)udSin(angle);
         float northY = -(float)udCos(angle);
 
+        ImGui::PushID("compassButton");
         if (ImGui::ButtonEx("", ImVec2(28, 28)))
         {
           pProgramState->cameraInput.targetEulerRotation = UD_DEG2RAD(udDouble3::create(0, -90, 0));
           pProgramState->cameraInput.inputState = vcCIS_Rotate;
           pProgramState->cameraInput.progress = 0.0;
         }
+        if (ImGui::IsItemHovered())
+        {
+          ImGui::BeginTooltip();
+          ImGui::TextUnformatted(vcString::Get("sceneTrueNorthTooltip"));
+          ImGui::EndTooltip();
+        }
+        ImGui::PopID();
 
         ImVec2 sizeMin = ImGui::GetItemRectMin();
         ImVec2 sizeMax = ImGui::GetItemRectMax();
@@ -1386,8 +1394,8 @@ void vcRenderSceneUI(vcState *pProgramState, const ImVec2 &windowPos, const ImVe
         ImVec2 middle = ImVec2((sizeMin.x + sizeMax.x) / 2, (sizeMin.y + sizeMax.y) / 2);
         ImVec2 north = ImVec2(middle.x + northX * distance, middle.y + northY * distance);
         ImVec2 south = ImVec2(middle.x - northX * distance, middle.y - northY * distance);
-        ImGui::GetForegroundDrawList()->AddLine(middle, north, 0xFF0000FF, 2);
-        ImGui::GetForegroundDrawList()->AddLine(middle, south, 0xFFFFFFFF, 2);
+        ImGui::GetWindowDrawList()->AddLine(middle, north, 0xFF0000FF, 2);
+        ImGui::GetWindowDrawList()->AddLine(middle, south, 0xFFFFFFFF, 2);
       }
 
       // Hide/show screen explorer


### PR DESCRIPTION
Fixed [AB#1340](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1340).
Added tooltip and the compass needle doesn't overlap the setting popup window too.