### PR TITLE
Use generated shaders for Metal

### DIFF
--- a/src/gl/metal/shaders/desktop/blurFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/blurFragmentShader.metal
@@ -1,27 +1,24 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct BlVSOutput
+struct main0_out
 {
-  float4 pos [[position]];
-  float2 uv0;
-  float2 uv1;
-  float2 uv2;
+    float4 out_var_SV_Target [[color(0)]];
 };
 
-constant static float4 multipliers[3] = {float4(0.0, 0.0, 0.0, 0.27901), float4(1.0, 1.0, 1.0, 0.44198), float4(0.0, 0.0, 0.0, 0.27901)};
-
-fragment float4
-main0(BlVSOutput in [[stage_in]], texture2d<float, access::sample> BlFSimg [[texture(0)]], sampler BlFSSampler [[sampler(0)]])
+struct main0_in
 {
-  float4 color = float4(0.0, 0.0, 0.0, 0.0);
-  
-  color += multipliers[0] * BlFSimg.sample(BlFSSampler, in.uv0);
-  color += multipliers[1] * BlFSimg.sample(BlFSSampler, in.uv1);
-  color += multipliers[2] * BlFSimg.sample(BlFSSampler, in.uv2);
-  
-  return color;
+    float2 in_var_TEXCOORD0 [[user(locn0)]];
+    float2 in_var_TEXCOORD1 [[user(locn1)]];
+    float2 in_var_TEXCOORD2 [[user(locn2)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> texture0 [[texture(0)]], sampler sampler0 [[sampler(0)]])
+{
+    main0_out out = {};
+    out.out_var_SV_Target = ((float4(0.0, 0.0, 0.0, 0.279009997844696044921875) * texture0.sample(sampler0, in.in_var_TEXCOORD0)) + (float4(1.0, 1.0, 1.0, 0.44198000431060791015625) * texture0.sample(sampler0, in.in_var_TEXCOORD1))) + (float4(0.0, 0.0, 0.0, 0.279009997844696044921875) * texture0.sample(sampler0, in.in_var_TEXCOORD2));
+    return out;
 }
+

--- a/src/gl/metal/shaders/desktop/blurVertexShader.metal
+++ b/src/gl/metal/shaders/desktop/blurVertexShader.metal
@@ -1,41 +1,35 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct BlVSInput
+struct type_u_EveryFrame
 {
-  float3 pos [[attribute(0)]];
-  float2 uv [[attribute(1)]];
+    float4 u_stepSize;
 };
 
-struct BlVSOutput
+struct main0_out
 {
-  float4 pos [[position]];
-  float2 uv0;
-  float2 uv1;
-  float2 uv2;
+    float2 out_var_TEXCOORD0 [[user(locn0)]];
+    float2 out_var_TEXCOORD1 [[user(locn1)]];
+    float2 out_var_TEXCOORD2 [[user(locn2)]];
+    float4 gl_Position [[position]];
 };
 
-struct BlVSUniforms
+struct main0_in
 {
-  float4 u_stepSize; // remember: requires 16 byte alignment
+    float3 in_var_POSITION [[attribute(0)]];
+    float2 in_var_TEXCOORD0 [[attribute(1)]];
 };
 
-vertex BlVSOutput
-main0(BlVSInput in [[stage_in]], constant BlVSUniforms& uniforms [[buffer(1)]])
+vertex main0_out main0(main0_in in [[stage_in]], constant type_u_EveryFrame& u_EveryFrame [[buffer(0)]])
 {
-  BlVSOutput out;
-  
-  out.pos = float4(in.pos.x, in.pos.y, 0.0, 1.0);
-  
-  // sample on edges, taking advantage of bilinear sampling
-  float2 sampleOffset = 1.42 * uniforms.u_stepSize.xy;
-  float2 uv = float2(in.uv.x, 1.0 - in.uv.y);
-  out.uv0 = uv - sampleOffset;
-  out.uv1 = uv;
-  out.uv2 = uv + sampleOffset;
-  
-  return out;
+    main0_out out = {};
+    float2 _36 = u_EveryFrame.u_stepSize.xy * 1.41999995708465576171875;
+    out.gl_Position = float4(in.in_var_POSITION.xy, 0.0, 1.0);
+    out.out_var_TEXCOORD0 = in.in_var_TEXCOORD0 - _36;
+    out.out_var_TEXCOORD1 = in.in_var_TEXCOORD0;
+    out.out_var_TEXCOORD2 = in.in_var_TEXCOORD0 + _36;
+    return out;
 }
+

--- a/src/gl/metal/shaders/desktop/compassFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/compassFragmentShader.metal
@@ -1,26 +1,37 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct CVSOutput
+struct type_u_cameraPlaneParams
 {
-  float4 pos [[position]];
-  float4 v_color;
-  float3 v_normal;
-  float4 v_fragClipPosition;
-  float3 v_sunDirection;
+    float s_CameraNearPlane;
+    float s_CameraFarPlane;
+    float u_clipZNear;
+    float u_clipZFar;
 };
 
-fragment float4
-main0(CVSOutput in [[stage_in]])
+struct main0_out
 {
-  float3 fakeEyeVector = normalize(in.v_fragClipPosition.xyz / in.v_fragClipPosition.w);
-  float3 worldNormal = in.v_normal * float3(2.0) - float3(1.0);
-  float ndotl = 0.5 + 0.5 * (-dot(in.v_sunDirection, worldNormal));
-  float edotr = max(0.0, -dot(-fakeEyeVector, worldNormal));
-  edotr = pow(edotr, 60.0);
-  float3 sheenColor = float3(1.0, 1.0, 0.9);
-  return float4(in.v_color.a * (ndotl * in.v_color.rgb + edotr * sheenColor), 1.0);
+    float4 out_var_SV_Target [[color(0)]];
+    float gl_FragDepth [[depth(any)]];
+};
+
+struct main0_in
+{
+    float3 in_var_COLOR0 [[user(locn0)]];
+    float4 in_var_COLOR1 [[user(locn1)]];
+    float3 in_var_COLOR2 [[user(locn2)]];
+    float4 in_var_COLOR3 [[user(locn3)]];
+    float2 in_var_TEXCOORD0 [[user(locn4)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]])
+{
+    main0_out out = {};
+    float3 _50 = (in.in_var_COLOR0 * float3(2.0)) - float3(1.0);
+    out.out_var_SV_Target = float4(((in.in_var_COLOR1.xyz * (0.5 + (dot(in.in_var_COLOR2, _50) * (-0.5)))) + (float3(1.0, 1.0, 0.89999997615814208984375) * pow(fast::max(0.0, -dot(-normalize(in.in_var_COLOR3.xyz / float3(in.in_var_COLOR3.w)), _50)), 60.0))) * in.in_var_COLOR1.w, 1.0);
+    out.gl_FragDepth = log2(in.in_var_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    return out;
 }
+

--- a/src/gl/metal/shaders/desktop/compassVertexShader.metal
+++ b/src/gl/metal/shaders/desktop/compassVertexShader.metal
@@ -1,39 +1,46 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct CVSInput
+struct type_u_EveryObject
 {
-  float3 a_pos [[attribute(0)]];
-  float3 a_normal [[attribute(1)]];
+    float4x4 u_worldViewProjectionMatrix;
+    float4 u_colour;
+    packed_float3 u_sunDirection;
+    float _padding;
 };
 
-struct CVSOutput
+constant float2 _34 = {};
+
+struct main0_out
 {
-  float4 pos [[position]];
-  float4 v_color;
-  float3 v_normal;
-  float4 v_fragClipPosition;
-  float3 v_sunDirection;
+    float3 out_var_COLOR0 [[user(locn0)]];
+    float4 out_var_COLOR1 [[user(locn1)]];
+    float3 out_var_COLOR2 [[user(locn2)]];
+    float4 out_var_COLOR3 [[user(locn3)]];
+    float2 out_var_TEXCOORD0 [[user(locn4)]];
+    float4 gl_Position [[position]];
 };
 
-struct CVSUniforms
+struct main0_in
 {
-  float4x4 u_worldViewProjectionMatrix;
-  float4 u_color;
-  float3 u_sunDirection;
+    float3 in_var_POSITION [[attribute(0)]];
+    float3 in_var_NORMAL [[attribute(1)]];
 };
 
-vertex CVSOutput
-main0(CVSInput in [[stage_in]], constant CVSUniforms& uCVS [[buffer(1)]])
+vertex main0_out main0(main0_in in [[stage_in]], constant type_u_EveryObject& u_EveryObject [[buffer(0)]])
 {
-  CVSOutput out;
-  out.v_fragClipPosition = uCVS.u_worldViewProjectionMatrix * float4(in.a_pos, 1.0);
-  out.pos = out.v_fragClipPosition;
-  out.v_normal = (in.a_normal * 0.5) + 0.5;
-  out.v_color = uCVS.u_color;
-  out.v_sunDirection = uCVS.u_sunDirection;
-  return out;
+    main0_out out = {};
+    float4 _44 = u_EveryObject.u_worldViewProjectionMatrix * float4(in.in_var_POSITION, 1.0);
+    float2 _53 = _34;
+    _53.x = 1.0 + _44.w;
+    out.gl_Position = _44;
+    out.out_var_COLOR0 = (in.in_var_NORMAL * 0.5) + float3(0.5);
+    out.out_var_COLOR1 = u_EveryObject.u_colour;
+    out.out_var_COLOR2 = float3(u_EveryObject.u_sunDirection);
+    out.out_var_COLOR3 = _44;
+    out.out_var_TEXCOORD0 = _53;
+    return out;
 }
+

--- a/src/gl/metal/shaders/desktop/depthOnlyFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/depthOnlyFragmentShader.metal
@@ -1,18 +1,32 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct DOFSInput
+struct type_u_cameraPlaneParams
 {
-  float4 pos [[attribute(0)]];
-  float2 uv [[attribute(1)]];
-  float3 normal [[attribute(2)]];
-  float4 color [[attribute(3)]];
+    float s_CameraNearPlane;
+    float s_CameraFarPlane;
+    float u_clipZNear;
+    float u_clipZFar;
 };
 
-float4 main0(DOFSInput in [[stage_in]])
+struct main0_out
 {
-  return float4(0.0, 0.0, 0.0, 0.0);
+    float4 out_var_SV_Target [[color(0)]];
+    float gl_FragDepth [[depth(any)]];
+};
+
+struct main0_in
+{
+    float2 in_var_TEXCOORD1 [[user(locn3)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]])
+{
+    main0_out out = {};
+    out.out_var_SV_Target = float4(0.0);
+    out.gl_FragDepth = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    return out;
 }
+

--- a/src/gl/metal/shaders/desktop/fenceFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/fenceFragmentShader.metal
@@ -1,18 +1,35 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct PCU
+struct type_u_cameraPlaneParams
 {
-  float4 v_position [[position]];
-  float4 v_color;
-  float2 v_uv;
+    float s_CameraNearPlane;
+    float s_CameraFarPlane;
+    float u_clipZNear;
+    float u_clipZFar;
 };
 
-fragment float4 main0(PCU in [[stage_in]], texture2d<float, access::sample> FFSimg [[texture(0)]], sampler FFSsampler [[sampler(0)]])
+struct main0_out
 {
-  float4 texCol = FFSimg.sample(FFSsampler, in.v_uv);
-  return float4(texCol.xyz * in.v_color.xyz, texCol.w * in.v_color.w);
+    float4 out_var_SV_Target [[color(0)]];
+    float gl_FragDepth [[depth(any)]];
+};
+
+struct main0_in
+{
+    float4 in_var_COLOR0 [[user(locn0)]];
+    float2 in_var_TEXCOORD0 [[user(locn1)]];
+    float2 in_var_TEXCOORD1 [[user(locn2)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], texture2d<float> texture0 [[texture(0)]], sampler sampler0 [[sampler(0)]])
+{
+    main0_out out = {};
+    float4 _40 = texture0.sample(sampler0, in.in_var_TEXCOORD0);
+    out.out_var_SV_Target = float4(_40.xyz * in.in_var_COLOR0.xyz, _40.w * in.in_var_COLOR0.w);
+    out.gl_FragDepth = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    return out;
 }
+

--- a/src/gl/metal/shaders/desktop/fenceVertexShader.metal
+++ b/src/gl/metal/shaders/desktop/fenceVertexShader.metal
@@ -1,52 +1,53 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct FVSUniforms
+struct type_u_EveryFrame
 {
-  float4 u_bottomColor;
-  float4 u_topColor;
-
-  float u_orientation;
-  float u_width;
-  float u_textureRepeatScale;
-  float u_textureScrollSpeed;
-  float u_time;
+    float4 u_bottomColour;
+    float4 u_topColour;
+    float u_orientation;
+    float u_width;
+    float u_textureRepeatScale;
+    float u_textureScrollSpeed;
+    float u_time;
+    float _padding1;
+    float2 _padding2;
 };
 
-struct FVSEveryObject
+struct type_u_EveryObject
 {
-  float4x4 u_worldViewProjectionMatrix;
+    float4x4 u_worldViewProjectionMatrix;
 };
 
-struct FVSInput
+constant float2 _41 = {};
+
+struct main0_out
 {
-  float3 a_position [[attribute(0)]];
-  float2 a_uv [[attribute(1)]];
-  float4 a_ribbonInfo [[attribute(2)]]; // xyz: expand floattor; z: pair id (0 or 1)
+    float4 out_var_COLOR0 [[user(locn0)]];
+    float2 out_var_TEXCOORD0 [[user(locn1)]];
+    float2 out_var_TEXCOORD1 [[user(locn2)]];
+    float4 gl_Position [[position]];
 };
 
-struct PCU
+struct main0_in
 {
-  float4 v_position [[position]];
-  float4 v_color;
-  float2 v_uv;
+    float3 in_var_POSITION [[attribute(0)]];
+    float2 in_var_TEXCOORD0 [[attribute(1)]];
+    float4 in_var_COLOR0 [[attribute(2)]];
 };
 
-vertex PCU
-main0(FVSInput in [[stage_in]], constant FVSUniforms& uFVS [[buffer(1)]], constant FVSEveryObject& uFVSEO [[buffer(2)]])
+vertex main0_out main0(main0_in in [[stage_in]], constant type_u_EveryFrame& u_EveryFrame [[buffer(0)]], constant type_u_EveryObject& u_EveryObject [[buffer(1)]])
 {
-  PCU out;
-
-  // fence horizontal UV pos packed into Y channel
-  out.v_uv = float2(mix(in.a_uv.y, in.a_uv.x, uFVS.u_orientation) * uFVS.u_textureRepeatScale - uFVS.u_time * uFVS.u_textureScrollSpeed, in.a_ribbonInfo.w);
-  out.v_color = mix(uFVS.u_bottomColor, uFVS.u_topColor, in.a_ribbonInfo.w);
-
-  // fence or flat
-  float3 worldPosition = in.a_position + mix(float3(0, 0, in.a_ribbonInfo.w) * uFVS.u_width, in.a_ribbonInfo.xyz, uFVS.u_orientation);
-
-  out.v_position = uFVSEO.u_worldViewProjectionMatrix * float4(worldPosition, 1.0);
-  return out;
+    main0_out out = {};
+    float4 _82 = u_EveryObject.u_worldViewProjectionMatrix * float4(in.in_var_POSITION + mix(float3(0.0, 0.0, in.in_var_COLOR0.w) * u_EveryFrame.u_width, in.in_var_COLOR0.xyz, float3(u_EveryFrame.u_orientation)), 1.0);
+    float2 _85 = _41;
+    _85.x = 1.0 + _82.w;
+    out.gl_Position = _82;
+    out.out_var_COLOR0 = mix(u_EveryFrame.u_bottomColour, u_EveryFrame.u_topColour, float4(in.in_var_COLOR0.w));
+    out.out_var_TEXCOORD0 = float2((mix(in.in_var_TEXCOORD0.y, in.in_var_TEXCOORD0.x, u_EveryFrame.u_orientation) * u_EveryFrame.u_textureRepeatScale) - (u_EveryFrame.u_time * u_EveryFrame.u_textureScrollSpeed), in.in_var_COLOR0.w);
+    out.out_var_TEXCOORD1 = _85;
+    return out;
 }
+

--- a/src/gl/metal/shaders/desktop/flatColourFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/flatColourFragmentShader.metal
@@ -1,18 +1,33 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct FCFSInput
+struct type_u_cameraPlaneParams
 {
-  float4 pos [[attribute(0)]];
-  float2 uv [[attribute(1)]];
-  float3 normal [[attribute(2)]];
-  float4 color [[attribute(3)]];
+    float s_CameraNearPlane;
+    float s_CameraFarPlane;
+    float u_clipZNear;
+    float u_clipZFar;
 };
 
-float4 main0(FCFSInput in [[stage_in]])
+struct main0_out
 {
-  return float4(in.color);
+    float4 out_var_SV_Target [[color(0)]];
+    float gl_FragDepth [[depth(any)]];
+};
+
+struct main0_in
+{
+    float4 in_var_COLOR0 [[user(locn2)]];
+    float2 in_var_TEXCOORD1 [[user(locn3)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]])
+{
+    main0_out out = {};
+    out.out_var_SV_Target = in.in_var_COLOR0;
+    out.gl_FragDepth = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    return out;
 }
+

--- a/src/gl/metal/shaders/desktop/highlightFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/highlightFragmentShader.metal
@@ -1,44 +1,46 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct HFSInput
+struct main0_out
 {
-  float4 pos [[position]];
-  float2 uv0;
-  float2 uv1;
-  float2 uv2;
-  float2 uv3;
-  float2 uv4;
+    float4 out_var_SV_Target [[color(0)]];
 };
 
-struct HVSUniforms
+struct main0_in
 {
-  float4 u_stepSizeThickness; // (stepSize.xy, outline thickness, inner overlay strength)
-  float4 u_color;
+    float2 in_var_TEXCOORD0 [[user(locn0)]];
+    float2 in_var_TEXCOORD1 [[user(locn1)]];
+    float2 in_var_TEXCOORD2 [[user(locn2)]];
+    float2 in_var_TEXCOORD3 [[user(locn3)]];
+    float2 in_var_TEXCOORD4 [[user(locn4)]];
+    float4 in_var_COLOR0 [[user(locn5)]];
+    float4 in_var_COLOR1 [[user(locn6)]];
 };
 
-fragment float4
-main0(HFSInput in [[stage_in]], constant HVSUniforms& uniforms [[buffer(1)]], texture2d<float, access::sample> HFSimg [[texture(0)]], sampler HFSSampler [[sampler(0)]])
+fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> u_texture [[texture(0)]], sampler sampler0 [[sampler(0)]])
 {
-  float4 middle = HFSimg.sample(HFSSampler, in.uv0);
-  float result = middle.w;
-  
-  // 'outside' the geometry, just use the blurred 'distance'
-  if (middle.x == 0.0)
-      return float4(uniforms.u_color.xyz, result * uniforms.u_stepSizeThickness.z * uniforms.u_color.a);
-  
-  result = 1.0 - result;
-  
-  // look for an edge, setting to full color if found
-  float softenEdge = 0.15 * uniforms.u_color.a;
-  result += softenEdge * step(HFSimg.sample(HFSSampler, in.uv1).x - middle.x, -0.00001);
-  result += softenEdge * step(HFSimg.sample(HFSSampler, in.uv2).x - middle.x, -0.00001);
-  result += softenEdge * step(HFSimg.sample(HFSSampler, in.uv3).x - middle.x, -0.00001);
-  result += softenEdge * step(HFSimg.sample(HFSSampler, in.uv4).x - middle.x, -0.00001);
-  
-  result = max(uniforms.u_stepSizeThickness.w, result) * uniforms.u_color.w; // overlay color
-  return float4(uniforms.u_color.xyz, result);
+    main0_out out = {};
+    float4 _99;
+    switch (0u)
+    {
+        default:
+        {
+            float4 _47 = u_texture.sample(sampler0, in.in_var_TEXCOORD0);
+            float _48 = _47.w;
+            float _49 = _47.x;
+            if (_49 == 0.0)
+            {
+                _99 = float4(in.in_var_COLOR0.xyz, (_48 * in.in_var_COLOR1.z) * in.in_var_COLOR0.w);
+                break;
+            }
+            float _63 = 0.1500000059604644775390625 * in.in_var_COLOR0.w;
+            _99 = float4(in.in_var_COLOR0.xyz, fast::max(in.in_var_COLOR1.w, ((((1.0 - _48) + (_63 * step(u_texture.sample(sampler0, in.in_var_TEXCOORD1).x - _49, -9.9999997473787516355514526367188e-06))) + (_63 * step(u_texture.sample(sampler0, in.in_var_TEXCOORD2).x - _49, -9.9999997473787516355514526367188e-06))) + (_63 * step(u_texture.sample(sampler0, in.in_var_TEXCOORD3).x - _49, -9.9999997473787516355514526367188e-06))) + (_63 * step(u_texture.sample(sampler0, in.in_var_TEXCOORD4).x - _49, -9.9999997473787516355514526367188e-06))) * in.in_var_COLOR0.w);
+            break;
+        }
+    }
+    out.out_var_SV_Target = _99;
+    return out;
 }
+

--- a/src/gl/metal/shaders/desktop/highlightVertexShader.metal
+++ b/src/gl/metal/shaders/desktop/highlightVertexShader.metal
@@ -1,45 +1,43 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct HVSInput
+struct type_u_EveryFrame
 {
-  float3 pos [[attribute(0)]];
-  float2 uv [[attribute(1)]];
+    float4 u_stepSizeThickness;
+    float4 u_colour;
 };
 
-struct HFSInput
+struct main0_out
 {
-  float4 pos [[position]];
-  float2 uv0;
-  float2 uv1;
-  float2 uv2;
-  float2 uv3;
-  float2 uv4;
+    float2 out_var_TEXCOORD0 [[user(locn0)]];
+    float2 out_var_TEXCOORD1 [[user(locn1)]];
+    float2 out_var_TEXCOORD2 [[user(locn2)]];
+    float2 out_var_TEXCOORD3 [[user(locn3)]];
+    float2 out_var_TEXCOORD4 [[user(locn4)]];
+    float4 out_var_COLOR0 [[user(locn5)]];
+    float4 out_var_COLOR1 [[user(locn6)]];
+    float4 gl_Position [[position]];
 };
 
-constant static float2 searchKernel[4] = {float2(-1, -1), float2(1, -1), float2(-1,  1), float2(1, 1)};
-
-struct HVSUniforms
+struct main0_in
 {
-  float4 u_stepSizeThickness; // (stepSize.xy, outline thickness, inner overlay strength)
-  float4 u_color;
+    float3 in_var_POSITION [[attribute(0)]];
+    float2 in_var_TEXCOORD0 [[attribute(1)]];
 };
 
-vertex HFSInput
-main0(HVSInput in [[stage_in]], constant HVSUniforms& uniforms [[buffer(1)]])
+vertex main0_out main0(main0_in in [[stage_in]], constant type_u_EveryFrame& u_EveryFrame [[buffer(0)]])
 {
-  HFSInput out;
-  
-  out.pos = float4(in.pos.x, in.pos.y, 0.0, 1.0);
-  
-  out.uv0 = in.uv;
-  out.uv1 = in.uv + uniforms.u_stepSizeThickness.xy * searchKernel[0];
-  out.uv2 = in.uv + uniforms.u_stepSizeThickness.xy * searchKernel[1];
-  out.uv3 = in.uv + uniforms.u_stepSizeThickness.xy * searchKernel[2];
-  out.uv4 = in.uv + uniforms.u_stepSizeThickness.xy * searchKernel[3];
-  
-  return out;
+    main0_out out = {};
+    out.gl_Position = float4(in.in_var_POSITION.xy, 0.0, 1.0);
+    out.out_var_TEXCOORD0 = in.in_var_TEXCOORD0;
+    out.out_var_TEXCOORD1 = in.in_var_TEXCOORD0 + (u_EveryFrame.u_stepSizeThickness.xy * float2(-1.0));
+    out.out_var_TEXCOORD2 = in.in_var_TEXCOORD0 + (u_EveryFrame.u_stepSizeThickness.xy * float2(1.0, -1.0));
+    out.out_var_TEXCOORD3 = in.in_var_TEXCOORD0 + (u_EveryFrame.u_stepSizeThickness.xy * float2(-1.0, 1.0));
+    out.out_var_TEXCOORD4 = in.in_var_TEXCOORD0 + u_EveryFrame.u_stepSizeThickness.xy;
+    out.out_var_COLOR0 = u_EveryFrame.u_colour;
+    out.out_var_COLOR1 = u_EveryFrame.u_stepSizeThickness;
+    return out;
 }
+

--- a/src/gl/metal/shaders/desktop/imageColourSkyboxFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/imageColourSkyboxFragmentShader.metal
@@ -1,25 +1,25 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct SVSOutput
+struct main0_out
 {
-  float4 position [[position]];
-  float2 v_texCoord;
+    float4 out_var_SV_Target [[color(0)]];
 };
 
-struct SFSTCUniforms
+struct main0_in
 {
-  float4 u_tintColor; //0 is full color, 1 is full image
-  float4 u_imageSize; //For purposes of tiling/stretching
+    float2 in_var_TEXCOORD0 [[user(locn0)]];
+    float4 in_var_COLOR0 [[user(locn1)]];
 };
 
-fragment float4
-main0(SVSOutput in [[stage_in]], constant SFSTCUniforms& uSFS [[buffer(1)]], texture2d<float, access::sample> SFSimg [[texture(0)]], sampler SFSsampler [[sampler(0)]])
+fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> u_texture [[texture(0)]], sampler sampler0 [[sampler(0)]])
 {
-  float4 color = SFSimg.sample(SFSsampler, in.v_texCoord / uSFS.u_imageSize.xy);
-  float effectiveAlpha = min(color.a, uSFS.u_tintColor.a);
-  return float4((color.rgb * effectiveAlpha) + (uSFS.u_tintColor.rgb * (1 - effectiveAlpha)), 1);
+    main0_out out = {};
+    float4 _30 = u_texture.sample(sampler0, in.in_var_TEXCOORD0);
+    float _33 = fast::min(_30.w, in.in_var_COLOR0.w);
+    out.out_var_SV_Target = float4((_30.xyz * _33) + (in.in_var_COLOR0.xyz * (1.0 - _33)), 1.0);
+    return out;
 }
+

--- a/src/gl/metal/shaders/desktop/imageColourSkyboxVertexShader.metal
+++ b/src/gl/metal/shaders/desktop/imageColourSkyboxVertexShader.metal
@@ -1,27 +1,33 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct SVSInput
+struct type_u_EveryFrame
 {
-  float3 a_position [[attribute(0)]];
-  float2 a_texCoord [[attribute(1)]];
+    float4 u_tintColour;
+    float4 u_imageSize;
 };
 
-struct SVSOutput
+struct main0_out
 {
-  float4 position [[position]];
-  float2 v_texCoord;
+    float2 out_var_TEXCOORD0 [[user(locn0)]];
+    float4 out_var_COLOR0 [[user(locn1)]];
+    float4 gl_Position [[position]];
 };
 
-vertex SVSOutput
-main0(SVSInput in [[stage_in]])
+struct main0_in
 {
-  SVSOutput out;
-  out.position = float4(in.a_position.xy, 0.0, 1.0);
-  out.v_texCoord = float2(in.a_texCoord.x, 1.0 - in.a_texCoord.y);
-  return out;
+    float3 in_var_POSITION [[attribute(0)]];
+    float2 in_var_TEXCOORD0 [[attribute(1)]];
+};
+
+vertex main0_out main0(main0_in in [[stage_in]], constant type_u_EveryFrame& u_EveryFrame [[buffer(0)]])
+{
+    main0_out out = {};
+    out.gl_Position = float4(in.in_var_POSITION.xy, 0.0, 1.0);
+    out.out_var_TEXCOORD0 = in.in_var_TEXCOORD0 / u_EveryFrame.u_imageSize.xy;
+    out.out_var_COLOR0 = u_EveryFrame.u_tintColour;
+    return out;
 }
 

--- a/src/gl/metal/shaders/desktop/imageRendererBillboardVertexShader.metal
+++ b/src/gl/metal/shaders/desktop/imageRendererBillboardVertexShader.metal
@@ -1,39 +1,43 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct PUC
+struct type_u_EveryObject
 {
-  float4 pos [[position]];
-  float2 uv;
-  float4 color;
+    float4x4 u_worldViewProjectionMatrix;
+    float4 u_colour;
+    float4 u_screenSize;
 };
 
-struct IRBVSInput
+constant float2 _32 = {};
+
+struct main0_out
 {
-  float3 pos [[attribute(0)]];
-  float2 uv [[attribute(1)]];
+    float2 out_var_TEXCOORD0 [[user(locn0)]];
+    float4 out_var_COLOR0 [[user(locn1)]];
+    float2 out_var_TEXCOORD1 [[user(locn2)]];
+    float4 gl_Position [[position]];
 };
 
-struct IRBVSUniforms
+struct main0_in
 {
-  float4x4 u_worldViewProjectionMatrix;
-  float4 u_color;
-  float4 u_screenSize;
+    float3 in_var_POSITION [[attribute(0)]];
+    float2 in_var_TEXCOORD0 [[attribute(1)]];
 };
 
-vertex PUC
-main0(IRBVSInput in [[stage_in]], constant IRBVSUniforms& uniforms [[buffer(1)]])
+vertex main0_out main0(main0_in in [[stage_in]], constant type_u_EveryObject& u_EveryObject [[buffer(0)]])
 {
-  PUC out;
-  
-  out.pos = uniforms.u_worldViewProjectionMatrix * float4(in.pos, 1.0);
-  out.pos.xy += uniforms.u_screenSize.z * out.pos.w * uniforms.u_screenSize.xy * float2(in.uv.x * 2.0 - 1.0, in.uv.y * 2.0 - 1.0); // expand billboard
-  out.uv = float2(in.uv.x, 1.0 - in.uv.y);
-  
-  out.color = uniforms.u_color;
-  
-  return out;
+    main0_out out = {};
+    float4 _38 = u_EveryObject.u_worldViewProjectionMatrix * float4(0.0, 0.0, 0.0, 1.0);
+    float _44 = _38.w;
+    float2 _50 = _38.xy + ((u_EveryObject.u_screenSize.xy * (u_EveryObject.u_screenSize.z * _44)) * in.in_var_POSITION.xy);
+    float2 _55 = _32;
+    _55.x = 1.0 + _44;
+    out.gl_Position = float4(_50.x, _50.y, _38.z, _38.w);
+    out.out_var_TEXCOORD0 = in.in_var_TEXCOORD0;
+    out.out_var_COLOR0 = u_EveryObject.u_colour;
+    out.out_var_TEXCOORD1 = _55;
+    return out;
 }
+

--- a/src/gl/metal/shaders/desktop/imageRendererFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/imageRendererFragmentShader.metal
@@ -1,19 +1,34 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct PUC
+struct type_u_cameraPlaneParams
 {
-  float4 pos [[position]];
-  float2 uv;
-  float4 color;
+    float s_CameraNearPlane;
+    float s_CameraFarPlane;
+    float u_clipZNear;
+    float u_clipZFar;
 };
 
-fragment float4
-main0(PUC in [[stage_in]], texture2d<float, access::sample> IRFSimg [[texture(0)]], sampler IRFSsampler [[sampler(0)]])
+struct main0_out
 {
-  float4 col = IRFSimg.sample(IRFSsampler, in.uv);
-  return col * in.color;
+    float4 out_var_SV_Target [[color(0)]];
+    float gl_FragDepth [[depth(any)]];
+};
+
+struct main0_in
+{
+    float2 in_var_TEXCOORD0 [[user(locn0)]];
+    float4 in_var_COLOR0 [[user(locn1)]];
+    float2 in_var_TEXCOORD1 [[user(locn2)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], texture2d<float> texture0 [[texture(0)]], sampler sampler0 [[sampler(0)]])
+{
+    main0_out out = {};
+    out.out_var_SV_Target = texture0.sample(sampler0, in.in_var_TEXCOORD0) * in.in_var_COLOR0;
+    out.gl_FragDepth = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    return out;
 }
+

--- a/src/gl/metal/shaders/desktop/imageRendererMeshVertexShader.metal
+++ b/src/gl/metal/shaders/desktop/imageRendererMeshVertexShader.metal
@@ -1,38 +1,41 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct PUC
+struct type_u_EveryObject
 {
-  float4 pos [[position]];
-  float2 uv;
-  float4 color;
+    float4x4 u_worldViewProjectionMatrix;
+    float4 u_colour;
+    float4 u_screenSize;
 };
 
-struct PNUVVSInput
+constant float2 _29 = {};
+
+struct main0_out
 {
-  float3 pos [[attribute(0)]];
-  float3 normal [[attribute(1)]]; // unused
-  float2 uv [[attribute(2)]];
+    float2 out_var_TEXCOORD0 [[user(locn0)]];
+    float4 out_var_COLOR0 [[user(locn1)]];
+    float2 out_var_TEXCOORD1 [[user(locn2)]];
+    float4 gl_Position [[position]];
 };
 
-struct IRMVSUniforms
+struct main0_in
 {
-  float4x4 u_worldViewProjectionMatrix;
-  float4 u_color;
-  float4 u_screenSize; // unused
+    float3 in_var_POSITION [[attribute(0)]];
+    float2 in_var_TEXCOORD0 [[attribute(2)]];
 };
 
-vertex PUC
-main0(PNUVVSInput in [[stage_in]], constant IRMVSUniforms& uniforms [[buffer(1)]])
+vertex main0_out main0(main0_in in [[stage_in]], constant type_u_EveryObject& u_EveryObject [[buffer(0)]])
 {
-  PUC out;
-  
-  out.pos = uniforms.u_worldViewProjectionMatrix * float4(in.pos, 1.0);
-  out.uv = float2(in.uv[0], 1.0 - in.uv[1]);
-  out.color = uniforms.u_color;
-  
-  return out;
+    main0_out out = {};
+    float4 _39 = u_EveryObject.u_worldViewProjectionMatrix * float4(in.in_var_POSITION, 1.0);
+    float2 _44 = _29;
+    _44.x = 1.0 + _39.w;
+    out.gl_Position = _39;
+    out.out_var_TEXCOORD0 = in.in_var_TEXCOORD0;
+    out.out_var_COLOR0 = u_EveryObject.u_colour;
+    out.out_var_TEXCOORD1 = _44;
+    return out;
 }
+

--- a/src/gl/metal/shaders/desktop/imgui3DVertexShader.metal
+++ b/src/gl/metal/shaders/desktop/imgui3DVertexShader.metal
@@ -1,30 +1,36 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct Uniforms {
-  float4x4 projectionMatrix;
-};
-
-struct VertexIn {
-  float2 position  [[attribute(0)]];
-  float2 texCoords [[attribute(1)]];
-  float4 color     [[attribute(2)]];
-};
-
-struct VertexOut {
-  float4 position [[position]];
-  float2 texCoords;
-  float4 color;
-};
-
-vertex VertexOut main0(VertexIn in [[stage_in]], constant Uniforms& uIMGUI [[buffer(1)]])
+struct type_u_EveryObject
 {
-  VertexOut out;
-  out.position = uIMGUI.projectionMatrix * float4(in.position, 0, 1);
-  out.texCoords = in.texCoords;
-  out.color = in.color;
-  return out;
+    float4x4 u_worldViewProjectionMatrix;
+    float4 u_screenSize;
+};
+
+struct main0_out
+{
+    float4 out_var_COLOR0 [[user(locn0)]];
+    float2 out_var_TEXCOORD0 [[user(locn1)]];
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float2 in_var_POSITION [[attribute(0)]];
+    float2 in_var_TEXCOORD0 [[attribute(1)]];
+    float4 in_var_COLOR0 [[attribute(2)]];
+};
+
+vertex main0_out main0(main0_in in [[stage_in]], constant type_u_EveryObject& u_EveryObject [[buffer(0)]])
+{
+    main0_out out = {};
+    float4 _35 = u_EveryObject.u_worldViewProjectionMatrix * float4(0.0, 0.0, 0.0, 1.0);
+    float2 _43 = _35.xy + ((u_EveryObject.u_screenSize.xy * in.in_var_POSITION) * _35.w);
+    out.gl_Position = float4(_43.x, _43.y, _35.z, _35.w);
+    out.out_var_COLOR0 = in.in_var_COLOR0;
+    out.out_var_TEXCOORD0 = in.in_var_TEXCOORD0;
+    return out;
 }
+

--- a/src/gl/metal/shaders/desktop/imguiFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/imguiFragmentShader.metal
@@ -1,17 +1,23 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct VertexOut {
-  float4 position [[position]];
-  float2 texCoords;
-  float4 color;
+struct main0_out
+{
+    float4 out_var_SV_Target [[color(0)]];
 };
 
-fragment half4 main0(VertexOut in [[stage_in]], texture2d<half, access::sample> IMtexture [[texture(0)]], sampler imguiSampler [[sampler(0)]])
+struct main0_in
 {
-  half4 texColor = IMtexture.sample(imguiSampler, in.texCoords);
-  return half4(in.color) * texColor;
+    float4 in_var_COLOR0 [[user(locn0)]];
+    float2 in_var_TEXCOORD0 [[user(locn1)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> texture0 [[texture(0)]], sampler sampler0 [[sampler(0)]])
+{
+    main0_out out = {};
+    out.out_var_SV_Target = in.in_var_COLOR0 * texture0.sample(sampler0, in.in_var_TEXCOORD0);
+    return out;
 }
+

--- a/src/gl/metal/shaders/desktop/imguiVertexShader.metal
+++ b/src/gl/metal/shaders/desktop/imguiVertexShader.metal
@@ -1,30 +1,33 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct Uniforms {
-  float4x4 projectionMatrix;
-};
-
-struct VertexIn {
-  float2 position  [[attribute(0)]];
-  float2 texCoords [[attribute(1)]];
-  float4 color     [[attribute(2)]];
-};
-
-struct VertexOut {
-  float4 position [[position]];
-  float2 texCoords;
-  float4 color;
-};
-
-vertex VertexOut main0(VertexIn in [[stage_in]], constant Uniforms& uIMGUI [[buffer(1)]])
+struct type_u_EveryFrame
 {
-  VertexOut out;
-  out.position = uIMGUI.projectionMatrix * float4(in.position, 0, 1);
-  out.texCoords = in.texCoords;
-  out.color = in.color;
-  return out;
+    float4x4 ProjectionMatrix;
+};
+
+struct main0_out
+{
+    float4 out_var_COLOR0 [[user(locn0)]];
+    float2 out_var_TEXCOORD0 [[user(locn1)]];
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float2 in_var_POSITION [[attribute(0)]];
+    float2 in_var_TEXCOORD0 [[attribute(1)]];
+    float4 in_var_COLOR0 [[attribute(2)]];
+};
+
+vertex main0_out main0(main0_in in [[stage_in]], constant type_u_EveryFrame& u_EveryFrame [[buffer(0)]])
+{
+    main0_out out = {};
+    out.gl_Position = u_EveryFrame.ProjectionMatrix * float4(in.in_var_POSITION, 0.0, 1.0);
+    out.out_var_COLOR0 = in.in_var_COLOR0;
+    out.out_var_TEXCOORD0 = in.in_var_TEXCOORD0;
+    return out;
 }
+

--- a/src/gl/metal/shaders/desktop/panoramaSkyboxFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/panoramaSkyboxFragmentShader.metal
@@ -1,26 +1,29 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct SVSOutput
+struct type_u_EveryFrame
 {
-  float4 position [[position]];
-  float2 v_texCoord;
+    float4x4 u_inverseViewProjection;
 };
 
-struct SFSPUniforms
+struct main0_out
 {
-  float4x4 u_inverseViewProjection;
+    float4 out_var_SV_Target [[color(0)]];
 };
 
-fragment float4
-main0(SVSOutput in [[stage_in]], constant SFSPUniforms& uSFS [[buffer(1)]], texture2d<float, access::sample> SFSimg [[texture(0)]], sampler SFSsampler [[sampler(0)]])
+struct main0_in
 {
-  // work out 3D point
-  float4 point3D = uSFS.u_inverseViewProjection * float4(in.v_texCoord * float2(2.0) - float2(1.0), 1.0, 1.0);
-  point3D.xyz = normalize(point3D.xyz / point3D.w);
-  float2 longlat = float2(atan2(point3D.x, point3D.y) + M_PI_F, acos(point3D.z));
-  return SFSimg.sample(SFSsampler, longlat / float2(2.0 * M_PI_F, M_PI_F));
+    float4 in_var_TEXCOORD0 [[user(locn0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], constant type_u_EveryFrame& u_EveryFrame [[buffer(0)]], texture2d<float> u_texture [[texture(0)]], sampler sampler0 [[sampler(0)]])
+{
+    main0_out out = {};
+    float4 _40 = u_EveryFrame.u_inverseViewProjection * float4(in.in_var_TEXCOORD0.xy, 1.0, 1.0);
+    float3 _45 = normalize(_40.xyz / float3(_40.w));
+    out.out_var_SV_Target = u_texture.sample(sampler0, (float2(atan2(_45.x, _45.y) + 3.1415927410125732421875, acos(_45.z)) * float2(0.15915493667125701904296875, 0.3183098733425140380859375)));
+    return out;
 }
+

--- a/src/gl/metal/shaders/desktop/panoramaSkyboxVertexShader.metal
+++ b/src/gl/metal/shaders/desktop/panoramaSkyboxVertexShader.metal
@@ -1,26 +1,25 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct SVSInput
+struct main0_out
 {
-  float3 a_position [[attribute(0)]];
-  float2 a_texCoord [[attribute(1)]];
+    float4 out_var_TEXCOORD0 [[user(locn0)]];
+    float4 gl_Position [[position]];
 };
 
-struct SVSOutput
+struct main0_in
 {
-  float4 position [[position]];
-  float2 v_texCoord;
+    float3 in_var_POSITION [[attribute(0)]];
 };
 
-vertex SVSOutput
-main0(SVSInput in [[stage_in]])
+vertex main0_out main0(main0_in in [[stage_in]])
 {
-  SVSOutput out;
-  out.position = float4(in.a_position.xy, 0.0, 1.0);
-  out.v_texCoord = float2(in.a_texCoord.x, 1.0 - in.a_texCoord.y);
-  return out;
+    main0_out out = {};
+    float4 _21 = float4(in.in_var_POSITION.xy, 0.0, 1.0);
+    out.gl_Position = _21;
+    out.out_var_TEXCOORD0 = _21;
+    return out;
 }
+

--- a/src/gl/metal/shaders/desktop/polygonP3N3UV2FragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/polygonP3N3UV2FragmentShader.metal
@@ -1,27 +1,36 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct PNUVSOutput
+struct type_u_cameraPlaneParams
 {
-  float4 pos [[position]];
-  float2 uv;
-  float3 normal;
-  float4 color;
+    float s_CameraNearPlane;
+    float s_CameraFarPlane;
+    float u_clipZNear;
+    float u_clipZFar;
 };
 
-fragment float4
-main0(PNUVSOutput in [[stage_in]], texture2d<float, access::sample> PNUFSimg [[texture(0)]], sampler PNUFSsampler [[sampler(0)]])
+struct main0_out
 {
-    float4 col = PNUFSimg.sample(PNUFSsampler, in.uv);
-    float4 diffuseColour = col * in.color;
+    float4 out_var_SV_Target [[color(0)]];
+    float gl_FragDepth [[depth(any)]];
+};
 
-    // some fixed lighting
-    float3 lightDirection = normalize(float3(0.85, 0.15, 0.5));
-    float ndotl = dot(in.normal, lightDirection) * 0.5 + 0.5;
-    float3 diffuse = diffuseColour.xyz * ndotl;
+struct main0_in
+{
+    float2 in_var_TEXCOORD0 [[user(locn0)]];
+    float3 in_var_NORMAL [[user(locn1)]];
+    float4 in_var_COLOR0 [[user(locn2)]];
+    float2 in_var_TEXCOORD1 [[user(locn3)]];
+};
 
-    return float4(diffuse, diffuseColour.a);
+fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], texture2d<float> texture0 [[texture(0)]], sampler sampler0 [[sampler(0)]])
+{
+    main0_out out = {};
+    float4 _48 = texture0.sample(sampler0, in.in_var_TEXCOORD0) * in.in_var_COLOR0;
+    out.out_var_SV_Target = float4(_48.xyz * ((dot(in.in_var_NORMAL, normalize(float3(0.85000002384185791015625, 0.1500000059604644775390625, 0.5))) * 0.5) + 0.5), _48.w);
+    out.gl_FragDepth = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    return out;
 }
+

--- a/src/gl/metal/shaders/desktop/polygonP3N3UV2VertexShader.metal
+++ b/src/gl/metal/shaders/desktop/polygonP3N3UV2VertexShader.metal
@@ -1,43 +1,44 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct PNUVSInput
+struct type_u_EveryObject
 {
-  float3 pos [[attribute(0)]];
-  float3 normal [[attribute(1)]];
-  float2 uv [[attribute(2)]];
+    float4x4 u_worldViewProjectionMatrix;
+    float4x4 u_worldMatrix;
+    float4 u_colour;
 };
 
-struct PNUVSOutput
+constant float2 _34 = {};
+
+struct main0_out
 {
-  float4 pos [[position]];
-  float2 uv;
-  float3 normal;
-  float4 color;
+    float2 out_var_TEXCOORD0 [[user(locn0)]];
+    float3 out_var_NORMAL [[user(locn1)]];
+    float4 out_var_COLOR0 [[user(locn2)]];
+    float2 out_var_TEXCOORD1 [[user(locn3)]];
+    float4 gl_Position [[position]];
 };
 
-struct PNUVSUniforms1
+struct main0_in
 {
-  float4x4 u_worldViewProjectionMatrix;
-  float4x4 u_worldMatrix;
-  float4 u_color;
+    float3 in_var_POSITION [[attribute(0)]];
+    float3 in_var_NORMAL [[attribute(1)]];
+    float2 in_var_TEXCOORD0 [[attribute(2)]];
 };
 
-vertex PNUVSOutput
-main0(PNUVSInput in [[stage_in]], constant PNUVSUniforms1& PNUVS1 [[buffer(1)]])
+vertex main0_out main0(main0_in in [[stage_in]], constant type_u_EveryObject& u_EveryObject [[buffer(0)]])
 {
-  PNUVSOutput out;
-
-  // making the assumption that the model matrix won't contain non-uniform scale
-  float3 worldNormal = normalize((PNUVS1.u_worldMatrix * float4(in.normal, 0.0)).xyz);
-
-  out.pos = PNUVS1.u_worldViewProjectionMatrix * float4(in.pos, 1.0);
-  out.uv = in.uv;
-  out.normal = worldNormal;
-  out.color = PNUVS1.u_color;
-  
-  return out;
+    main0_out out = {};
+    float4 _54 = u_EveryObject.u_worldViewProjectionMatrix * float4(in.in_var_POSITION, 1.0);
+    float2 _59 = _34;
+    _59.x = 1.0 + _54.w;
+    out.gl_Position = _54;
+    out.out_var_TEXCOORD0 = in.in_var_TEXCOORD0;
+    out.out_var_NORMAL = normalize((u_EveryObject.u_worldMatrix * float4(in.in_var_NORMAL, 0.0)).xyz);
+    out.out_var_COLOR0 = u_EveryObject.u_colour;
+    out.out_var_TEXCOORD1 = _59;
+    return out;
 }
+

--- a/src/gl/metal/shaders/desktop/postEffectsFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/postEffectsFragmentShader.metal
@@ -1,539 +1,539 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
 constant float _66 = {};
 constant float2 _67 = {};
 constant float2 _68 = {};
 
-struct PEFOutput
+struct main0_out
 {
-  float4 out_var_SV_Target [[color(0)]];
+    float4 out_var_SV_Target [[color(0)]];
 };
 
-struct PEFInput
+struct main0_in
 {
-  float2 in_var_TEXCOORD0 [[user(locn0)]];
-  float2 in_var_TEXCOORD1 [[user(locn1)]];
-  float2 in_var_TEXCOORD2 [[user(locn2)]];
-  float2 in_var_TEXCOORD3 [[user(locn3)]];
-  float2 in_var_TEXCOORD4 [[user(locn4)]];
-  float2 in_var_TEXCOORD5 [[user(locn5)]];
-  float in_var_TEXCOORD6 [[user(locn6)]];
+    float2 in_var_TEXCOORD0 [[user(locn0)]];
+    float2 in_var_TEXCOORD1 [[user(locn1)]];
+    float2 in_var_TEXCOORD2 [[user(locn2)]];
+    float2 in_var_TEXCOORD3 [[user(locn3)]];
+    float2 in_var_TEXCOORD4 [[user(locn4)]];
+    float2 in_var_TEXCOORD5 [[user(locn5)]];
+    float in_var_TEXCOORD6 [[user(locn6)]];
 };
 
-fragment PEFOutput main0(PEFInput in [[stage_in]], texture2d<float> texture0 [[texture(0)]], texture2d<float> texture1 [[texture(1)]], sampler sampler0 [[sampler(0)]], sampler sampler1 [[sampler(1)]])
+fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> texture0 [[texture(0)]], texture2d<float> texture1 [[texture(1)]], sampler sampler0 [[sampler(0)]], sampler sampler1 [[sampler(1)]])
 {
-  PEFOutput out = {};
-  float4 _80 = texture1.sample(sampler1, in.in_var_TEXCOORD0);
-  float _81 = _80.x;
-  float4 _535;
-  if ((1.0 - (((step(abs(texture1.sample(sampler1, in.in_var_TEXCOORD1).x - _81), 0.0030000000260770320892333984375) * step(abs(texture1.sample(sampler1, in.in_var_TEXCOORD2).x - _81), 0.0030000000260770320892333984375)) * step(abs(texture1.sample(sampler1, in.in_var_TEXCOORD3).x - _81), 0.0030000000260770320892333984375)) * step(abs(texture1.sample(sampler1, in.in_var_TEXCOORD4).x - _81), 0.0030000000260770320892333984375))) == 0.0)
-  {
-    _535 = texture0.sample(sampler0, in.in_var_TEXCOORD0);
-  }
-  else
-  {
-    float4 _534;
-    switch (0u)
+    main0_out out = {};
+    float4 _80 = texture1.sample(sampler1, in.in_var_TEXCOORD0);
+    float _81 = _80.x;
+    float4 _535;
+    if ((1.0 - (((step(abs(texture1.sample(sampler1, in.in_var_TEXCOORD1).x - _81), 0.0030000000260770320892333984375) * step(abs(texture1.sample(sampler1, in.in_var_TEXCOORD2).x - _81), 0.0030000000260770320892333984375)) * step(abs(texture1.sample(sampler1, in.in_var_TEXCOORD3).x - _81), 0.0030000000260770320892333984375)) * step(abs(texture1.sample(sampler1, in.in_var_TEXCOORD4).x - _81), 0.0030000000260770320892333984375))) == 0.0)
     {
-      default:
-      {
-        float2 _123 = _67;
-        _123.x = in.in_var_TEXCOORD0.x;
-        float2 _125 = _123;
-        _125.y = in.in_var_TEXCOORD0.y;
-        float4 _127 = texture0.sample(sampler0, _125, level(0.0));
-        float4 _129 = texture0.sample(sampler0, _125, level(0.0), int2(0, 1));
-        float _130 = _129.y;
-        float4 _132 = texture0.sample(sampler0, _125, level(0.0), int2(1, 0));
-        float _133 = _132.y;
-        float4 _135 = texture0.sample(sampler0, _125, level(0.0), int2(0, -1));
-        float _136 = _135.y;
-        float4 _138 = texture0.sample(sampler0, _125, level(0.0), int2(-1, 0));
-        float _139 = _138.y;
-        float _140 = _127.y;
-        float _147 = fast::max(fast::max(_136, _139), fast::max(_133, fast::max(_130, _140)));
-        float _150 = _147 - fast::min(fast::min(_136, _139), fast::min(_133, fast::min(_130, _140)));
-        if (_150 < fast::max(0.0, _147 * 0.125))
-        {
-          _534 = _127;
-          break;
-        }
-        float4 _156 = texture0.sample(sampler0, _125, level(0.0), int2(-1));
-        float _157 = _156.y;
-        float4 _159 = texture0.sample(sampler0, _125, level(0.0), int2(1));
-        float _160 = _159.y;
-        float4 _162 = texture0.sample(sampler0, _125, level(0.0), int2(1, -1));
-        float _163 = _162.y;
-        float4 _165 = texture0.sample(sampler0, _125, level(0.0), int2(-1, 1));
-        float _166 = _165.y;
-        float _167 = _136 + _130;
-        float _168 = _139 + _133;
-        float _171 = (-2.0) * _140;
-        float _174 = _163 + _160;
-        float _180 = _157 + _166;
-        bool _200 = (abs(((-2.0) * _139) + _180) + ((abs(_171 + _167) * 2.0) + abs(((-2.0) * _133) + _174))) >= (abs(((-2.0) * _130) + (_166 + _160)) + ((abs(_171 + _168) * 2.0) + abs(((-2.0) * _136) + (_157 + _163))));
-        bool _203 = !_200;
-        float _204 = _203 ? _139 : _136;
-        float _205 = _203 ? _133 : _130;
-        float _209;
-        if (_200)
-        {
-          _209 = in.in_var_TEXCOORD5.y;
-        }
-        else
-        {
-          _209 = in.in_var_TEXCOORD5.x;
-        }
-        float _216 = abs(_204 - _140);
-        float _217 = abs(_205 - _140);
-        bool _218 = _216 >= _217;
-        float _223;
-        if (_218)
-        {
-          _223 = -_209;
-        }
-        else
-        {
-          _223 = _209;
-        }
-        float _226 = fast::clamp(abs(((((_167 + _168) * 2.0) + (_180 + _174)) * 0.083333335816860198974609375) - _140) * (1.0 / _150), 0.0, 1.0);
-        float _227 = _203 ? 0.0 : in.in_var_TEXCOORD5.x;
-        float _229 = _200 ? 0.0 : in.in_var_TEXCOORD5.y;
-        float2 _235;
-        if (_203)
-        {
-          float2 _234 = _125;
-          _234.x = in.in_var_TEXCOORD0.x + (_223 * 0.5);
-          _235 = _234;
-        }
-        else
-        {
-          _235 = _125;
-        }
-        float2 _242;
-        if (_200)
-        {
-          float2 _241 = _235;
-          _241.y = _235.y + (_223 * 0.5);
-          _242 = _241;
-        }
-        else
-        {
-          _242 = _235;
-        }
-        float _244 = _242.x - _227;
-        float2 _245 = _67;
-        _245.x = _244;
-        float2 _248 = _245;
-        _248.y = _242.y - _229;
-        float _249 = _242.x + _227;
-        float2 _250 = _67;
-        _250.x = _249;
-        float2 _252 = _250;
-        _252.y = _242.y + _229;
-        float _264 = fast::max(_216, _217) * 0.25;
-        float _265 = ((!_218) ? (_205 + _140) : (_204 + _140)) * 0.5;
-        float _267 = (((-2.0) * _226) + 3.0) * (_226 * _226);
-        bool _268 = (_140 - _265) < 0.0;
-        float _269 = texture0.sample(sampler0, _248, level(0.0)).y - _265;
-        float _270 = texture0.sample(sampler0, _252, level(0.0)).y - _265;
-        bool _275 = !(abs(_269) >= _264);
-        float2 _281;
-        if (_275)
-        {
-          float2 _280 = _248;
-          _280.x = _244 - (_227 * 1.5);
-          _281 = _280;
-        }
-        else
-        {
-          _281 = _248;
-        }
-        float2 _288;
-        if (_275)
-        {
-          float2 _287 = _281;
-          _287.y = _281.y - (_229 * 1.5);
-          _288 = _287;
-        }
-        else
-        {
-          _288 = _281;
-        }
-        bool _289 = !(abs(_270) >= _264);
-        float2 _296;
-        if (_289)
-        {
-          float2 _295 = _252;
-          _295.x = _249 + (_227 * 1.5);
-          _296 = _295;
-        }
-        else
-        {
-          _296 = _252;
-        }
-        float2 _303;
-        if (_289)
-        {
-          float2 _302 = _296;
-          _302.y = _296.y + (_229 * 1.5);
-          _303 = _302;
-        }
-        else
-        {
-          _303 = _296;
-        }
-        float2 _482;
-        float2 _483;
-        float _484;
-        float _485;
-        if (_275 || _289)
-        {
-          float _311;
-          if (_275)
-          {
-            _311 = texture0.sample(sampler0, _288, level(0.0)).y;
-          }
-          else
-          {
-            _311 = _269;
-          }
-          float _317;
-          if (_289)
-          {
-            _317 = texture0.sample(sampler0, _303, level(0.0)).y;
-          }
-          else
-          {
-            _317 = _270;
-          }
-          float _321;
-          if (_275)
-          {
-            _321 = _311 - _265;
-          }
-          else
-          {
-            _321 = _311;
-          }
-          float _325;
-          if (_289)
-          {
-            _325 = _317 - _265;
-          }
-          else
-          {
-            _325 = _317;
-          }
-          bool _330 = !(abs(_321) >= _264);
-          float2 _337;
-          if (_330)
-          {
-            float2 _336 = _288;
-            _336.x = _288.x - (_227 * 2.0);
-            _337 = _336;
-          }
-          else
-          {
-            _337 = _288;
-          }
-          float2 _344;
-          if (_330)
-          {
-            float2 _343 = _337;
-            _343.y = _337.y - (_229 * 2.0);
-            _344 = _343;
-          }
-          else
-          {
-            _344 = _337;
-          }
-          bool _345 = !(abs(_325) >= _264);
-          float2 _353;
-          if (_345)
-          {
-            float2 _352 = _303;
-            _352.x = _303.x + (_227 * 2.0);
-            _353 = _352;
-          }
-          else
-          {
-            _353 = _303;
-          }
-          float2 _360;
-          if (_345)
-          {
-            float2 _359 = _353;
-            _359.y = _353.y + (_229 * 2.0);
-            _360 = _359;
-          }
-          else
-          {
-            _360 = _353;
-          }
-          float2 _478;
-          float2 _479;
-          float _480;
-          float _481;
-          if (_330 || _345)
-          {
-            float _368;
-            if (_330)
-            {
-              _368 = texture0.sample(sampler0, _344, level(0.0)).y;
-            }
-            else
-            {
-              _368 = _321;
-            }
-            float _374;
-            if (_345)
-            {
-              _374 = texture0.sample(sampler0, _360, level(0.0)).y;
-            }
-            else
-            {
-              _374 = _325;
-            }
-            float _378;
-            if (_330)
-            {
-              _378 = _368 - _265;
-            }
-            else
-            {
-              _378 = _368;
-            }
-            float _382;
-            if (_345)
-            {
-              _382 = _374 - _265;
-            }
-            else
-            {
-              _382 = _374;
-            }
-            bool _387 = !(abs(_378) >= _264);
-            float2 _394;
-            if (_387)
-            {
-              float2 _393 = _344;
-              _393.x = _344.x - (_227 * 4.0);
-              _394 = _393;
-            }
-            else
-            {
-              _394 = _344;
-            }
-            float2 _401;
-            if (_387)
-            {
-              float2 _400 = _394;
-              _400.y = _394.y - (_229 * 4.0);
-              _401 = _400;
-            }
-            else
-            {
-              _401 = _394;
-            }
-            bool _402 = !(abs(_382) >= _264);
-            float2 _410;
-            if (_402)
-            {
-              float2 _409 = _360;
-              _409.x = _360.x + (_227 * 4.0);
-              _410 = _409;
-            }
-            else
-            {
-              _410 = _360;
-            }
-            float2 _417;
-            if (_402)
-            {
-              float2 _416 = _410;
-              _416.y = _410.y + (_229 * 4.0);
-              _417 = _416;
-            }
-            else
-            {
-              _417 = _410;
-            }
-            float2 _474;
-            float2 _475;
-            float _476;
-            float _477;
-            if (_387 || _402)
-            {
-              float _425;
-              if (_387)
-              {
-                _425 = texture0.sample(sampler0, _401, level(0.0)).y;
-              }
-              else
-              {
-                _425 = _378;
-              }
-              float _431;
-              if (_402)
-              {
-                _431 = texture0.sample(sampler0, _417, level(0.0)).y;
-              }
-              else
-              {
-                _431 = _382;
-              }
-              float _435;
-              if (_387)
-              {
-                _435 = _425 - _265;
-              }
-              else
-              {
-                _435 = _425;
-              }
-              float _439;
-              if (_402)
-              {
-                _439 = _431 - _265;
-              }
-              else
-              {
-                _439 = _431;
-              }
-              bool _444 = !(abs(_435) >= _264);
-              float2 _451;
-              if (_444)
-              {
-                float2 _450 = _401;
-                _450.x = _401.x - (_227 * 12.0);
-                _451 = _450;
-              }
-              else
-              {
-                _451 = _401;
-              }
-              float2 _458;
-              if (_444)
-              {
-                float2 _457 = _451;
-                _457.y = _451.y - (_229 * 12.0);
-                _458 = _457;
-              }
-              else
-              {
-                _458 = _451;
-              }
-              bool _459 = !(abs(_439) >= _264);
-              float2 _466;
-              if (_459)
-              {
-                float2 _465 = _417;
-                _465.x = _417.x + (_227 * 12.0);
-                _466 = _465;
-              }
-              else
-              {
-                _466 = _417;
-              }
-              float2 _473;
-              if (_459)
-              {
-                float2 _472 = _466;
-                _472.y = _466.y + (_229 * 12.0);
-                _473 = _472;
-              }
-              else
-              {
-                _473 = _466;
-              }
-              _474 = _473;
-              _475 = _458;
-              _476 = _439;
-              _477 = _435;
-            }
-            else
-            {
-              _474 = _417;
-              _475 = _401;
-              _476 = _382;
-              _477 = _378;
-            }
-            _478 = _474;
-            _479 = _475;
-            _480 = _476;
-            _481 = _477;
-          }
-          else
-          {
-            _478 = _360;
-            _479 = _344;
-            _480 = _325;
-            _481 = _321;
-          }
-          _482 = _478;
-          _483 = _479;
-          _484 = _480;
-          _485 = _481;
-        }
-        else
-        {
-          _482 = _303;
-          _483 = _288;
-          _484 = _270;
-          _485 = _269;
-        }
-        float _494;
-        if (_203)
-        {
-          _494 = in.in_var_TEXCOORD0.y - _483.y;
-        }
-        else
-        {
-          _494 = in.in_var_TEXCOORD0.x - _483.x;
-        }
-        float _499;
-        if (_203)
-        {
-          _499 = _482.y - in.in_var_TEXCOORD0.y;
-        }
-        else
-        {
-          _499 = _482.x - in.in_var_TEXCOORD0.x;
-        }
-        float _514 = fast::max(((_494 < _499) ? ((_485 < 0.0) != _268) : ((_484 < 0.0) != _268)) ? ((fast::min(_494, _499) * ((-1.0) / (_499 + _494))) + 0.5) : 0.0, (_267 * _267) * 0.75);
-        float2 _520;
-        if (_203)
-        {
-          float2 _519 = _125;
-          _519.x = in.in_var_TEXCOORD0.x + (_514 * _223);
-          _520 = _519;
-        }
-        else
-        {
-          _520 = _125;
-        }
-        float2 _527;
-        if (_200)
-        {
-          float2 _526 = _520;
-          _526.y = _520.y + (_514 * _223);
-          _527 = _526;
-        }
-        else
-        {
-          _527 = _520;
-        }
-        _534 = float4(texture0.sample(sampler0, _527, level(0.0)).xyz, _66);
-        break;
-      }
+        _535 = texture0.sample(sampler0, in.in_var_TEXCOORD0);
     }
-    _535 = _534;
-  }
-  out.out_var_SV_Target = float4(mix(float3(dot(_535.xyz, float3(0.2125000059604644775390625, 0.7153999805450439453125, 0.07209999859333038330078125))), _535.xyz, float3(in.in_var_TEXCOORD6)), 1.0);
-  return out;
+    else
+    {
+        float4 _534;
+        switch (0u)
+        {
+            default:
+            {
+                float2 _123 = _67;
+                _123.x = in.in_var_TEXCOORD0.x;
+                float2 _125 = _123;
+                _125.y = in.in_var_TEXCOORD0.y;
+                float4 _127 = texture0.sample(sampler0, _125, level(0.0));
+                float4 _129 = texture0.sample(sampler0, _125, level(0.0), int2(0, 1));
+                float _130 = _129.y;
+                float4 _132 = texture0.sample(sampler0, _125, level(0.0), int2(1, 0));
+                float _133 = _132.y;
+                float4 _135 = texture0.sample(sampler0, _125, level(0.0), int2(0, -1));
+                float _136 = _135.y;
+                float4 _138 = texture0.sample(sampler0, _125, level(0.0), int2(-1, 0));
+                float _139 = _138.y;
+                float _140 = _127.y;
+                float _147 = fast::max(fast::max(_136, _139), fast::max(_133, fast::max(_130, _140)));
+                float _150 = _147 - fast::min(fast::min(_136, _139), fast::min(_133, fast::min(_130, _140)));
+                if (_150 < fast::max(0.0, _147 * 0.125))
+                {
+                    _534 = _127;
+                    break;
+                }
+                float4 _156 = texture0.sample(sampler0, _125, level(0.0), int2(-1));
+                float _157 = _156.y;
+                float4 _159 = texture0.sample(sampler0, _125, level(0.0), int2(1));
+                float _160 = _159.y;
+                float4 _162 = texture0.sample(sampler0, _125, level(0.0), int2(1, -1));
+                float _163 = _162.y;
+                float4 _165 = texture0.sample(sampler0, _125, level(0.0), int2(-1, 1));
+                float _166 = _165.y;
+                float _167 = _136 + _130;
+                float _168 = _139 + _133;
+                float _171 = (-2.0) * _140;
+                float _174 = _163 + _160;
+                float _180 = _157 + _166;
+                bool _200 = (abs(((-2.0) * _139) + _180) + ((abs(_171 + _167) * 2.0) + abs(((-2.0) * _133) + _174))) >= (abs(((-2.0) * _130) + (_166 + _160)) + ((abs(_171 + _168) * 2.0) + abs(((-2.0) * _136) + (_157 + _163))));
+                bool _203 = !_200;
+                float _204 = _203 ? _139 : _136;
+                float _205 = _203 ? _133 : _130;
+                float _209;
+                if (_200)
+                {
+                    _209 = in.in_var_TEXCOORD5.y;
+                }
+                else
+                {
+                    _209 = in.in_var_TEXCOORD5.x;
+                }
+                float _216 = abs(_204 - _140);
+                float _217 = abs(_205 - _140);
+                bool _218 = _216 >= _217;
+                float _223;
+                if (_218)
+                {
+                    _223 = -_209;
+                }
+                else
+                {
+                    _223 = _209;
+                }
+                float _226 = fast::clamp(abs(((((_167 + _168) * 2.0) + (_180 + _174)) * 0.083333335816860198974609375) - _140) * (1.0 / _150), 0.0, 1.0);
+                float _227 = _203 ? 0.0 : in.in_var_TEXCOORD5.x;
+                float _229 = _200 ? 0.0 : in.in_var_TEXCOORD5.y;
+                float2 _235;
+                if (_203)
+                {
+                    float2 _234 = _125;
+                    _234.x = in.in_var_TEXCOORD0.x + (_223 * 0.5);
+                    _235 = _234;
+                }
+                else
+                {
+                    _235 = _125;
+                }
+                float2 _242;
+                if (_200)
+                {
+                    float2 _241 = _235;
+                    _241.y = _235.y + (_223 * 0.5);
+                    _242 = _241;
+                }
+                else
+                {
+                    _242 = _235;
+                }
+                float _244 = _242.x - _227;
+                float2 _245 = _67;
+                _245.x = _244;
+                float2 _248 = _245;
+                _248.y = _242.y - _229;
+                float _249 = _242.x + _227;
+                float2 _250 = _67;
+                _250.x = _249;
+                float2 _252 = _250;
+                _252.y = _242.y + _229;
+                float _264 = fast::max(_216, _217) * 0.25;
+                float _265 = ((!_218) ? (_205 + _140) : (_204 + _140)) * 0.5;
+                float _267 = (((-2.0) * _226) + 3.0) * (_226 * _226);
+                bool _268 = (_140 - _265) < 0.0;
+                float _269 = texture0.sample(sampler0, _248, level(0.0)).y - _265;
+                float _270 = texture0.sample(sampler0, _252, level(0.0)).y - _265;
+                bool _275 = !(abs(_269) >= _264);
+                float2 _281;
+                if (_275)
+                {
+                    float2 _280 = _248;
+                    _280.x = _244 - (_227 * 1.5);
+                    _281 = _280;
+                }
+                else
+                {
+                    _281 = _248;
+                }
+                float2 _288;
+                if (_275)
+                {
+                    float2 _287 = _281;
+                    _287.y = _281.y - (_229 * 1.5);
+                    _288 = _287;
+                }
+                else
+                {
+                    _288 = _281;
+                }
+                bool _289 = !(abs(_270) >= _264);
+                float2 _296;
+                if (_289)
+                {
+                    float2 _295 = _252;
+                    _295.x = _249 + (_227 * 1.5);
+                    _296 = _295;
+                }
+                else
+                {
+                    _296 = _252;
+                }
+                float2 _303;
+                if (_289)
+                {
+                    float2 _302 = _296;
+                    _302.y = _296.y + (_229 * 1.5);
+                    _303 = _302;
+                }
+                else
+                {
+                    _303 = _296;
+                }
+                float2 _482;
+                float2 _483;
+                float _484;
+                float _485;
+                if (_275 || _289)
+                {
+                    float _311;
+                    if (_275)
+                    {
+                        _311 = texture0.sample(sampler0, _288, level(0.0)).y;
+                    }
+                    else
+                    {
+                        _311 = _269;
+                    }
+                    float _317;
+                    if (_289)
+                    {
+                        _317 = texture0.sample(sampler0, _303, level(0.0)).y;
+                    }
+                    else
+                    {
+                        _317 = _270;
+                    }
+                    float _321;
+                    if (_275)
+                    {
+                        _321 = _311 - _265;
+                    }
+                    else
+                    {
+                        _321 = _311;
+                    }
+                    float _325;
+                    if (_289)
+                    {
+                        _325 = _317 - _265;
+                    }
+                    else
+                    {
+                        _325 = _317;
+                    }
+                    bool _330 = !(abs(_321) >= _264);
+                    float2 _337;
+                    if (_330)
+                    {
+                        float2 _336 = _288;
+                        _336.x = _288.x - (_227 * 2.0);
+                        _337 = _336;
+                    }
+                    else
+                    {
+                        _337 = _288;
+                    }
+                    float2 _344;
+                    if (_330)
+                    {
+                        float2 _343 = _337;
+                        _343.y = _337.y - (_229 * 2.0);
+                        _344 = _343;
+                    }
+                    else
+                    {
+                        _344 = _337;
+                    }
+                    bool _345 = !(abs(_325) >= _264);
+                    float2 _353;
+                    if (_345)
+                    {
+                        float2 _352 = _303;
+                        _352.x = _303.x + (_227 * 2.0);
+                        _353 = _352;
+                    }
+                    else
+                    {
+                        _353 = _303;
+                    }
+                    float2 _360;
+                    if (_345)
+                    {
+                        float2 _359 = _353;
+                        _359.y = _353.y + (_229 * 2.0);
+                        _360 = _359;
+                    }
+                    else
+                    {
+                        _360 = _353;
+                    }
+                    float2 _478;
+                    float2 _479;
+                    float _480;
+                    float _481;
+                    if (_330 || _345)
+                    {
+                        float _368;
+                        if (_330)
+                        {
+                            _368 = texture0.sample(sampler0, _344, level(0.0)).y;
+                        }
+                        else
+                        {
+                            _368 = _321;
+                        }
+                        float _374;
+                        if (_345)
+                        {
+                            _374 = texture0.sample(sampler0, _360, level(0.0)).y;
+                        }
+                        else
+                        {
+                            _374 = _325;
+                        }
+                        float _378;
+                        if (_330)
+                        {
+                            _378 = _368 - _265;
+                        }
+                        else
+                        {
+                            _378 = _368;
+                        }
+                        float _382;
+                        if (_345)
+                        {
+                            _382 = _374 - _265;
+                        }
+                        else
+                        {
+                            _382 = _374;
+                        }
+                        bool _387 = !(abs(_378) >= _264);
+                        float2 _394;
+                        if (_387)
+                        {
+                            float2 _393 = _344;
+                            _393.x = _344.x - (_227 * 4.0);
+                            _394 = _393;
+                        }
+                        else
+                        {
+                            _394 = _344;
+                        }
+                        float2 _401;
+                        if (_387)
+                        {
+                            float2 _400 = _394;
+                            _400.y = _394.y - (_229 * 4.0);
+                            _401 = _400;
+                        }
+                        else
+                        {
+                            _401 = _394;
+                        }
+                        bool _402 = !(abs(_382) >= _264);
+                        float2 _410;
+                        if (_402)
+                        {
+                            float2 _409 = _360;
+                            _409.x = _360.x + (_227 * 4.0);
+                            _410 = _409;
+                        }
+                        else
+                        {
+                            _410 = _360;
+                        }
+                        float2 _417;
+                        if (_402)
+                        {
+                            float2 _416 = _410;
+                            _416.y = _410.y + (_229 * 4.0);
+                            _417 = _416;
+                        }
+                        else
+                        {
+                            _417 = _410;
+                        }
+                        float2 _474;
+                        float2 _475;
+                        float _476;
+                        float _477;
+                        if (_387 || _402)
+                        {
+                            float _425;
+                            if (_387)
+                            {
+                                _425 = texture0.sample(sampler0, _401, level(0.0)).y;
+                            }
+                            else
+                            {
+                                _425 = _378;
+                            }
+                            float _431;
+                            if (_402)
+                            {
+                                _431 = texture0.sample(sampler0, _417, level(0.0)).y;
+                            }
+                            else
+                            {
+                                _431 = _382;
+                            }
+                            float _435;
+                            if (_387)
+                            {
+                                _435 = _425 - _265;
+                            }
+                            else
+                            {
+                                _435 = _425;
+                            }
+                            float _439;
+                            if (_402)
+                            {
+                                _439 = _431 - _265;
+                            }
+                            else
+                            {
+                                _439 = _431;
+                            }
+                            bool _444 = !(abs(_435) >= _264);
+                            float2 _451;
+                            if (_444)
+                            {
+                                float2 _450 = _401;
+                                _450.x = _401.x - (_227 * 12.0);
+                                _451 = _450;
+                            }
+                            else
+                            {
+                                _451 = _401;
+                            }
+                            float2 _458;
+                            if (_444)
+                            {
+                                float2 _457 = _451;
+                                _457.y = _451.y - (_229 * 12.0);
+                                _458 = _457;
+                            }
+                            else
+                            {
+                                _458 = _451;
+                            }
+                            bool _459 = !(abs(_439) >= _264);
+                            float2 _466;
+                            if (_459)
+                            {
+                                float2 _465 = _417;
+                                _465.x = _417.x + (_227 * 12.0);
+                                _466 = _465;
+                            }
+                            else
+                            {
+                                _466 = _417;
+                            }
+                            float2 _473;
+                            if (_459)
+                            {
+                                float2 _472 = _466;
+                                _472.y = _466.y + (_229 * 12.0);
+                                _473 = _472;
+                            }
+                            else
+                            {
+                                _473 = _466;
+                            }
+                            _474 = _473;
+                            _475 = _458;
+                            _476 = _439;
+                            _477 = _435;
+                        }
+                        else
+                        {
+                            _474 = _417;
+                            _475 = _401;
+                            _476 = _382;
+                            _477 = _378;
+                        }
+                        _478 = _474;
+                        _479 = _475;
+                        _480 = _476;
+                        _481 = _477;
+                    }
+                    else
+                    {
+                        _478 = _360;
+                        _479 = _344;
+                        _480 = _325;
+                        _481 = _321;
+                    }
+                    _482 = _478;
+                    _483 = _479;
+                    _484 = _480;
+                    _485 = _481;
+                }
+                else
+                {
+                    _482 = _303;
+                    _483 = _288;
+                    _484 = _270;
+                    _485 = _269;
+                }
+                float _494;
+                if (_203)
+                {
+                    _494 = in.in_var_TEXCOORD0.y - _483.y;
+                }
+                else
+                {
+                    _494 = in.in_var_TEXCOORD0.x - _483.x;
+                }
+                float _499;
+                if (_203)
+                {
+                    _499 = _482.y - in.in_var_TEXCOORD0.y;
+                }
+                else
+                {
+                    _499 = _482.x - in.in_var_TEXCOORD0.x;
+                }
+                float _514 = fast::max(((_494 < _499) ? ((_485 < 0.0) != _268) : ((_484 < 0.0) != _268)) ? ((fast::min(_494, _499) * ((-1.0) / (_499 + _494))) + 0.5) : 0.0, (_267 * _267) * 0.75);
+                float2 _520;
+                if (_203)
+                {
+                    float2 _519 = _125;
+                    _519.x = in.in_var_TEXCOORD0.x + (_514 * _223);
+                    _520 = _519;
+                }
+                else
+                {
+                    _520 = _125;
+                }
+                float2 _527;
+                if (_200)
+                {
+                    float2 _526 = _520;
+                    _526.y = _520.y + (_514 * _223);
+                    _527 = _526;
+                }
+                else
+                {
+                    _527 = _520;
+                }
+                _534 = float4(texture0.sample(sampler0, _527, level(0.0)).xyz, _66);
+                break;
+            }
+        }
+        _535 = _534;
+    }
+    out.out_var_SV_Target = float4(mix(float3(dot(_535.xyz, float3(0.2125000059604644775390625, 0.7153999805450439453125, 0.07209999859333038330078125))), _535.xyz, float3(in.in_var_TEXCOORD6)), 1.0);
+    return out;
 }
+

--- a/src/gl/metal/shaders/desktop/postEffectsVertexShader.metal
+++ b/src/gl/metal/shaders/desktop/postEffectsVertexShader.metal
@@ -1,43 +1,43 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct PEVParams
+struct type_u_params
 {
-  float4 u_screenParams;
-  float4 u_saturation;
+    float4 u_screenParams;
+    float4 u_saturation;
 };
 
-struct PEVOutput
+struct main0_out
 {
-  float2 out_var_TEXCOORD0 [[user(locn0)]];
-  float2 out_var_TEXCOORD1 [[user(locn1)]];
-  float2 out_var_TEXCOORD2 [[user(locn2)]];
-  float2 out_var_TEXCOORD3 [[user(locn3)]];
-  float2 out_var_TEXCOORD4 [[user(locn4)]];
-  float2 out_var_TEXCOORD5 [[user(locn5)]];
-  float out_var_TEXCOORD6 [[user(locn6)]];
-  float4 gl_Position [[position]];
+    float2 out_var_TEXCOORD0 [[user(locn0)]];
+    float2 out_var_TEXCOORD1 [[user(locn1)]];
+    float2 out_var_TEXCOORD2 [[user(locn2)]];
+    float2 out_var_TEXCOORD3 [[user(locn3)]];
+    float2 out_var_TEXCOORD4 [[user(locn4)]];
+    float2 out_var_TEXCOORD5 [[user(locn5)]];
+    float out_var_TEXCOORD6 [[user(locn6)]];
+    float4 gl_Position [[position]];
 };
 
-struct PEVInput
+struct main0_in
 {
-  float3 in_var_POSITION [[attribute(0)]];
-  float2 in_var_TEXCOORD0 [[attribute(1)]];
+    float3 in_var_POSITION [[attribute(0)]];
+    float2 in_var_TEXCOORD0 [[attribute(1)]];
 };
 
-vertex PEVOutput main0(PEVInput in [[stage_in]], constant PEVParams& u_params [[buffer(0)]])
+vertex main0_out main0(main0_in in [[stage_in]], constant type_u_params& u_params [[buffer(0)]])
 {
-  PEVOutput out = {};
-  out.gl_Position = float4(in.in_var_POSITION.xy, 0.0, 1.0);
-  out.out_var_TEXCOORD0 = in.in_var_TEXCOORD0;
-  out.out_var_TEXCOORD1 = in.in_var_TEXCOORD0 + u_params.u_screenParams.xy;
-  out.out_var_TEXCOORD2 = in.in_var_TEXCOORD0 - u_params.u_screenParams.xy;
-  out.out_var_TEXCOORD3 = in.in_var_TEXCOORD0 + float2(u_params.u_screenParams.x, -u_params.u_screenParams.y);
-  out.out_var_TEXCOORD4 = in.in_var_TEXCOORD0 + float2(-u_params.u_screenParams.x, u_params.u_screenParams.y);
-  out.out_var_TEXCOORD5 = u_params.u_screenParams.xy;
-  out.out_var_TEXCOORD6 = u_params.u_saturation.x;
-  return out;
+    main0_out out = {};
+    out.gl_Position = float4(in.in_var_POSITION.xy, 0.0, 1.0);
+    out.out_var_TEXCOORD0 = in.in_var_TEXCOORD0;
+    out.out_var_TEXCOORD1 = in.in_var_TEXCOORD0 + u_params.u_screenParams.xy;
+    out.out_var_TEXCOORD2 = in.in_var_TEXCOORD0 - u_params.u_screenParams.xy;
+    out.out_var_TEXCOORD3 = in.in_var_TEXCOORD0 + float2(u_params.u_screenParams.x, -u_params.u_screenParams.y);
+    out.out_var_TEXCOORD4 = in.in_var_TEXCOORD0 + float2(-u_params.u_screenParams.x, u_params.u_screenParams.y);
+    out.out_var_TEXCOORD5 = u_params.u_screenParams.xy;
+    out.out_var_TEXCOORD6 = u_params.u_saturation.x;
+    return out;
 }
+

--- a/src/gl/metal/shaders/desktop/tileFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/tileFragmentShader.metal
@@ -1,19 +1,34 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct PCU
+struct type_u_cameraPlaneParams
 {
-  float4 v_position [[position]];
-  float4 v_color;
-  float2 v_uv;
+    float s_CameraNearPlane;
+    float s_CameraFarPlane;
+    float u_clipZNear;
+    float u_clipZFar;
 };
 
-fragment float4
-main0(PCU in [[stage_in]], texture2d<float, access::sample> TFSimg [[texture(0)]], sampler TFSsampler [[sampler(0)]])
+struct main0_out
 {
-  float4 col = TFSimg.sample(TFSsampler, in.v_uv);
-  return float4(col.xyz * in.v_color.xyz, in.v_color.w);
+    float4 out_var_SV_Target [[color(0)]];
+    float gl_FragDepth [[depth(any)]];
 };
+
+struct main0_in
+{
+    float4 in_var_COLOR0 [[user(locn0)]];
+    float2 in_var_TEXCOORD0 [[user(locn1)]];
+    float2 in_var_TEXCOORD1 [[user(locn2)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], texture2d<float> texture0 [[texture(0)]], sampler sampler0 [[sampler(0)]])
+{
+    main0_out out = {};
+    out.out_var_SV_Target = float4(texture0.sample(sampler0, in.in_var_TEXCOORD0).xyz * in.in_var_COLOR0.xyz, in.in_var_COLOR0.w);
+    out.gl_FragDepth = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    return out;
+}
+

--- a/src/gl/metal/shaders/desktop/tileVertexShader.metal
+++ b/src/gl/metal/shaders/desktop/tileVertexShader.metal
@@ -1,40 +1,41 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-// This should match CPU struct size
-#define VERTEX_COUNT 2
-
-struct TVSInput
+struct type_u_EveryObject
 {
-  float3 a_uv [[attribute(0)]];
+    float4x4 u_projection;
+    float4 u_eyePositions[9];
+    float4 u_colour;
+    float4 u_uvOffsetScale;
 };
 
-struct PCU
+constant float2 _31 = {};
+
+struct main0_out
 {
-  float4 v_position [[position]];
-  float4 v_color;
-  float2 v_uv;
+    float4 out_var_COLOR0 [[user(locn0)]];
+    float2 out_var_TEXCOORD0 [[user(locn1)]];
+    float2 out_var_TEXCOORD1 [[user(locn2)]];
+    float4 gl_Position [[position]];
 };
 
-struct TVSUniforms
+struct main0_in
 {
-  float4x4 u_projection;
-  float4 u_eyePositions[VERTEX_COUNT * VERTEX_COUNT];
-  float4 u_color;
+    float3 in_var_POSITION [[attribute(0)]];
 };
 
-vertex PCU
-main0(TVSInput in [[stage_in]], constant TVSUniforms& uTVS [[buffer(1)]])
+vertex main0_out main0(main0_in in [[stage_in]], constant type_u_EveryObject& u_EveryObject [[buffer(0)]])
 {
-  PCU out;
-  
-  // TODO: could have precision issues on some devices
-  out.v_position = uTVS.u_projection * uTVS.u_eyePositions[int(in.a_uv.z)];
-  
-  out.v_uv = in.a_uv.xy;
-  out.v_color = uTVS.u_color;
-  return out;
+    main0_out out = {};
+    float4 _40 = u_EveryObject.u_projection * u_EveryObject.u_eyePositions[int(in.in_var_POSITION.z)];
+    float2 _52 = _31;
+    _52.x = 1.0 + _40.w;
+    out.gl_Position = _40;
+    out.out_var_COLOR0 = u_EveryObject.u_colour;
+    out.out_var_TEXCOORD0 = u_EveryObject.u_uvOffsetScale.xy + (u_EveryObject.u_uvOffsetScale.zw * in.in_var_POSITION.xy);
+    out.out_var_TEXCOORD1 = _52;
+    return out;
 }
+

--- a/src/gl/metal/shaders/desktop/udFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/udFragmentShader.metal
@@ -1,51 +1,24 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct UDVSOutput
+struct main0_out
 {
-  float4 v_position [[position]];
-  float2 uv;
+    float4 out_var_SV_Target [[color(0)]];
+    float gl_FragDepth [[depth(any)]];
 };
 
-struct UDFSUniforms
+struct main0_in
 {
-  float4 u_screenParams;
-  float4x4 u_inverseViewProjection;
-  float4 u_outlineColor;
-  float4 u_outlineParams;
-  float4 u_colorizeHeightColorMin;
-  float4 u_colorizeHeightColorMax;
-  float4 u_colorizeHeightParams;
-  float4 u_colorizeDepthColor;
-  float4 u_colorizeDepthParams;
-  float4 u_contourColor;
-  float4 u_contourParams;
+    float2 in_var_TEXCOORD0 [[user(locn0)]];
 };
 
-struct UDFSOutput
+fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> texture0 [[texture(0)]], texture2d<float> texture1 [[texture(1)]], sampler sampler0 [[sampler(0)]], sampler sampler1 [[sampler(1)]])
 {
-  float4 out_Color [[color(0)]];
-  float depth [[depth(any)]];
-};
-
-fragment UDFSOutput
-main0(UDVSOutput in [[stage_in]],
-                 constant UDFSUniforms& uUDFS [[buffer(1)]],
-                 texture2d<float, access::sample> UDFStexture [[texture(0)]],
-                 sampler UDFSsampler [[sampler(0)]],
-                 depth2d<float, access::sample> UDFSdepthTexture [[texture(1)]],
-                 sampler UDFSdepthSampler [[sampler(1)]])
-{
-  UDFSOutput out;
-  
-  float4 col = UDFStexture.sample(UDFSsampler, in.uv);
-  float depth = UDFSdepthTexture.sample(UDFSdepthSampler, in.uv);
-  
-  out.out_Color = float4(col.rgb, 1.0);// UD always opaque
-  out.depth = depth;
-  
-  return out;
+    main0_out out = {};
+    out.out_var_SV_Target = float4(texture0.sample(sampler0, in.in_var_TEXCOORD0).xyz, 1.0);
+    out.gl_FragDepth = texture1.sample(sampler1, in.in_var_TEXCOORD0).x;
+    return out;
 }
+

--- a/src/gl/metal/shaders/desktop/udSplatIdFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/udSplatIdFragmentShader.metal
@@ -1,43 +1,41 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct UDVSOutput
-{
-  float4 v_position [[position]];
-  float2 uv;
-};
-
-struct UDSOutput
-{
-    float4 color [[color(0)]];
-    float depth [[depth(any)]];
-};
-
-struct UDSUniforms
+struct type_u_params
 {
     float4 u_idOverride;
 };
 
-bool floatEquals(float a, float b)
+struct main0_out
 {
-    return abs(a - b) <= 0.0015f;
-}
+    float4 out_var_SV_Target [[color(0)]];
+    float gl_FragDepth [[depth(any)]];
+};
 
-fragment UDSOutput
-main0(UDVSOutput in [[stage_in]], constant UDSUniforms& uniforms [[buffer(1)]], texture2d<float, access::sample> UDSimg [[texture(0)]], sampler UDSSampler [[sampler(0)]], depth2d<float, access::sample> UDSimg2 [[texture(1)]], sampler UDSSampler2 [[sampler(1)]])
+struct main0_in
 {
-    UDSOutput out;
-    float4 col = UDSimg.sample(UDSSampler, in.uv);
-    out.depth = UDSimg2.sample(UDSSampler2, in.uv);
-    
-    out.color = float4(0.0, 0.0, 0.0, 0.0);
-    if ((uniforms.u_idOverride.w == 0.0 || floatEquals(uniforms.u_idOverride.w, col.w)))
+    float2 in_var_TEXCOORD0 [[user(locn0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], constant type_u_params& u_params [[buffer(0)]], texture2d<float> texture0 [[texture(0)]], texture2d<float> texture1 [[texture(1)]], sampler sampler0 [[sampler(0)]], sampler sampler1 [[sampler(1)]])
+{
+    main0_out out = {};
+    float4 _42 = texture0.sample(sampler0, in.in_var_TEXCOORD0);
+    float4 _46 = texture1.sample(sampler1, in.in_var_TEXCOORD0);
+    float _51 = _42.w;
+    float4 _59;
+    if ((u_params.u_idOverride.w == 0.0) || (abs(u_params.u_idOverride.w - _51) <= 0.00150000001303851604461669921875))
     {
-        out.color = float4(col.w, 0, 0, 1.0);
+        _59 = float4(_51, 0.0, 0.0, 1.0);
     }
-    
+    else
+    {
+        _59 = float4(0.0);
+    }
+    out.out_var_SV_Target = _59;
+    out.gl_FragDepth = _46.x;
     return out;
 }
+

--- a/src/gl/metal/shaders/desktop/udVertexShader.metal
+++ b/src/gl/metal/shaders/desktop/udVertexShader.metal
@@ -1,26 +1,25 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct UDVSInput
+struct main0_out
 {
-  float3 a_position [[attribute(0)]];
-  float2 a_texCoord [[attribute(1)]];
+    float2 out_var_TEXCOORD0 [[user(locn0)]];
+    float4 gl_Position [[position]];
 };
 
-struct UDVSOutput
+struct main0_in
 {
-  float4 v_position [[position]];
-  float2 uv;
+    float3 in_var_POSITION [[attribute(0)]];
+    float2 in_var_TEXCOORD0 [[attribute(1)]];
 };
 
-vertex UDVSOutput
-main0(UDVSInput in [[stage_in]])
+vertex main0_out main0(main0_in in [[stage_in]])
 {
-  UDVSOutput out;
-  out.v_position = float4(in.a_position.xy, 0.0, 1.0);
-  out.uv = in.a_texCoord;
-  return out;
+    main0_out out = {};
+    out.gl_Position = float4(in.in_var_POSITION.xy, 0.0, 1.0);
+    out.out_var_TEXCOORD0 = in.in_var_TEXCOORD0;
+    return out;
 }
+

--- a/src/gl/metal/shaders/desktop/visualizationVertexShader.metal
+++ b/src/gl/metal/shaders/desktop/visualizationVertexShader.metal
@@ -1,26 +1,44 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct VVSInput
+struct type_u_vertParams
 {
-  float3 a_position [[attribute(0)]];
-  float2 a_texCoord [[attribute(1)]];
+    float4 u_outlineStepSize;
 };
 
-struct VVSOutput
+struct main0_out
 {
-  float4 v_position [[position]];
-  float2 uv;
+    float4 out_var_TEXCOORD0 [[user(locn0)]];
+    float2 out_var_TEXCOORD1 [[user(locn1)]];
+    float2 out_var_TEXCOORD2 [[user(locn2)]];
+    float2 out_var_TEXCOORD3 [[user(locn3)]];
+    float2 out_var_TEXCOORD4 [[user(locn4)]];
+    float2 out_var_TEXCOORD5 [[user(locn5)]];
+    float4 gl_Position [[position]];
 };
 
-vertex VVSOutput
-main0(VVSInput in [[stage_in]])
+struct main0_in
 {
-  VVSOutput out;
-  out.v_position = float4(in.a_position.xy, 0.0, 1.0);
-  out.uv = in.a_texCoord;
-  return out;
+    float3 in_var_POSITION [[attribute(0)]];
+    float2 in_var_TEXCOORD0 [[attribute(1)]];
+};
+
+vertex main0_out main0(main0_in in [[stage_in]], constant type_u_vertParams& u_vertParams [[buffer(0)]])
+{
+    main0_out out = {};
+    float4 _34 = float4(in.in_var_POSITION.xy, 0.0, 1.0);
+    float3 _39 = float3(u_vertParams.u_outlineStepSize.xy, 0.0);
+    float2 _40 = _39.xz;
+    float2 _43 = _39.zy;
+    out.gl_Position = _34;
+    out.out_var_TEXCOORD0 = _34;
+    out.out_var_TEXCOORD1 = in.in_var_TEXCOORD0;
+    out.out_var_TEXCOORD2 = in.in_var_TEXCOORD0 + _40;
+    out.out_var_TEXCOORD3 = in.in_var_TEXCOORD0 - _40;
+    out.out_var_TEXCOORD4 = in.in_var_TEXCOORD0 + _43;
+    out.out_var_TEXCOORD5 = in.in_var_TEXCOORD0 - _43;
+    return out;
 }
+

--- a/src/gl/metal/shaders/desktop/waterFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/waterFragmentShader.metal
@@ -1,63 +1,37 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct WVSOutput
+struct type_u_EveryFrameFrag
 {
-  float4 pos [[position]];
-  float2 uv0;
-  float2 uv1;
-  float4 fragEyePos;
-  float3 color;
+    float4 u_specularDir;
+    float4x4 u_eyeNormalMatrix;
+    float4x4 u_inverseViewMatrix;
 };
 
-// g_WaterFragmentShader
-struct WFSUniforms
+struct main0_out
 {
-  float4 u_specularDir;
-  float4x4 u_eyeNormalMatrix;
-  float4x4 u_inverseViewMatrix;
+    float4 out_var_SV_Target [[color(0)]];
 };
 
-float2 directionToLatLong(float3 dir)
+struct main0_in
 {
-  float2 longlat = float2(atan2(dir.x, dir.y) + M_PI_F, acos(dir.z));
-  return longlat / float2(2.0 * M_PI_F, M_PI_F);
+    float2 in_var_TEXCOORD0 [[user(locn0)]];
+    float2 in_var_TEXCOORD1 [[user(locn1)]];
+    float4 in_var_COLOR0 [[user(locn2)]];
+    float4 in_var_COLOR1 [[user(locn3)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], constant type_u_EveryFrameFrag& u_EveryFrameFrag [[buffer(0)]], texture2d<float> u_normalMap [[texture(0)]], texture2d<float> u_skybox [[texture(1)]], sampler sampler0 [[sampler(0)]], sampler sampler1 [[sampler(1)]])
+{
+    main0_out out = {};
+    float3 _77 = normalize(((u_normalMap.sample(sampler0, in.in_var_TEXCOORD0).xyz * float3(2.0)) - float3(1.0)) + ((u_normalMap.sample(sampler0, in.in_var_TEXCOORD1).xyz * float3(2.0)) - float3(1.0)));
+    float3 _79 = normalize(in.in_var_COLOR0.xyz);
+    float3 _95 = normalize((u_EveryFrameFrag.u_eyeNormalMatrix * float4(_77, 0.0)).xyz);
+    float3 _97 = normalize(reflect(_79, _95));
+    float3 _121 = normalize((u_EveryFrameFrag.u_inverseViewMatrix * float4(_97, 0.0)).xyz);
+    out.out_var_SV_Target = float4(mix(u_skybox.sample(sampler1, (float2(atan2(_121.x, _121.y) + 3.1415927410125732421875, acos(_121.z)) * float2(0.15915493667125701904296875, 0.3183098733425140380859375))).xyz, in.in_var_COLOR1.xyz * mix(float3(1.0, 1.0, 0.60000002384185791015625), float3(0.3499999940395355224609375), float3(pow(fast::max(0.0, _77.z), 5.0))), float3(((dot(_95, _79) * (-0.5)) + 0.5) * 0.75)) + float3(pow(abs(dot(_97, normalize((u_EveryFrameFrag.u_eyeNormalMatrix * float4(normalize(u_EveryFrameFrag.u_specularDir.xyz), 0.0)).xyz))), 50.0) * 0.5), 1.0);
+    return out;
 }
 
-fragment float4
-main0(WVSOutput in [[stage_in]], constant WFSUniforms& uWFS [[buffer(2)]], texture2d<float, access::sample> WFSNormal [[texture(0)]], sampler WFSNsampler [[sampler(0)]], texture2d<float, access::sample> WFSSkybox [[texture(1)]], sampler WFSSBsampler [[sampler(1)]])
-{
-  float3 specularDir = normalize(uWFS.u_specularDir.xyz);
-  
-  float3 normal0 = WFSNormal.sample(WFSNsampler, in.uv0).xyz * float3(2.0) - float3(1.0);
-  float3 normal1 = WFSNormal.sample(WFSNsampler, in.uv1).xyz * float3(2.0) - float3(1.0);
-  float3 normal = normalize((normal0.xyz * normal1.xyz));
-  
-  float3 eyeToFrag = normalize(in.fragEyePos.xyz);
-  float3 eyeSpecularDir = normalize((uWFS.u_eyeNormalMatrix * float4(specularDir, 0.0)).xyz);
-  float3 eyeNormal = normalize((uWFS.u_eyeNormalMatrix * float4(normal, 0.0)).xyz);
-  float3 eyeReflectionDir = normalize(reflect(eyeToFrag, eyeNormal));
-  
-  float nDotS = abs(dot(eyeReflectionDir, eyeSpecularDir));
-  float nDotL = -dot(eyeNormal, eyeToFrag);
-  float fresnel = nDotL * 0.5 + 0.5;
-  
-  float specular = pow(nDotS, 250.0) * 0.5;
-  
-  float3 deepFactor = float3(0.35, 0.35, 0.35);
-  float3 shallowFactor = float3(1.0, 1.0, 0.7);
-  
-  float distanceToShore = 1.0; // maybe TODO
-  float3 refractionColor = in.color.xyz * mix(shallowFactor, deepFactor, distanceToShore);
-  
-  // reflection
-  float4 worldFragPos = uWFS.u_inverseViewMatrix * float4(eyeReflectionDir, 0.0);
-  float4 skybox = WFSSkybox.sample(WFSSBsampler, directionToLatLong(normalize(worldFragPos.xyz)));
-  float3 reflectionColor = skybox.xyz;
-  
-  float3 finalColor = mix(reflectionColor, refractionColor, fresnel * 0.75) + float3(specular);
-  return float4(finalColor, 1.0);
-}

--- a/src/gl/metal/shaders/desktop/waterVertexShader.metal
+++ b/src/gl/metal/shaders/desktop/waterVertexShader.metal
@@ -1,50 +1,44 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct WVSInput
+struct type_u_EveryFrameVert
 {
-  float2 pos [[attribute(0)]];
+    float4 u_time;
 };
 
-struct WVSOutput
+struct type_u_EveryObject
 {
-  float4 pos [[position]];
-  float2 uv0;
-  float2 uv1;
-  float4 fragEyePos;
-  float3 color;
+    float4 u_colourAndSize;
+    float4x4 u_worldViewMatrix;
+    float4x4 u_worldViewProjectionMatrix;
 };
 
-struct WVSUniforms1
+struct main0_out
 {
-  float4 u_time;
+    float2 out_var_TEXCOORD0 [[user(locn0)]];
+    float2 out_var_TEXCOORD1 [[user(locn1)]];
+    float4 out_var_COLOR0 [[user(locn2)]];
+    float3 out_var_COLOR1 [[user(locn3)]];
+    float4 gl_Position [[position]];
 };
 
-struct WVSUniforms2
+struct main0_in
 {
-  float4 u_colorAndSize;
-  float4x4 u_worldViewMatrix;
-  float4x4 u_worldViewProjectionMatrix;
+    float2 in_var_POSITION [[attribute(0)]];
 };
 
-vertex WVSOutput
-main0(WVSInput in [[stage_in]], constant WVSUniforms1& uWVS1 [[buffer(1)]], constant WVSUniforms2& uWVS2 [[buffer(3)]])
+vertex main0_out main0(main0_in in [[stage_in]], constant type_u_EveryFrameVert& u_EveryFrameVert [[buffer(0)]], constant type_u_EveryObject& u_EveryObject [[buffer(1)]])
 {
-  WVSOutput out;
-
-  float uvScaleBodySize = uWVS2.u_colorAndSize.w; // packed here
-
-  // scale the uvs with time
-  float uvOffset = uWVS1.u_time.x * 0.0625;
-  out.uv0 = uvScaleBodySize * in.pos.xy * float2(0.25, 0.25) - float2(uvOffset);
-  out.uv1 = uvScaleBodySize * in.pos.yx * float2(0.50, 0.50) - float2(uvOffset, uvOffset * 0.75);
-
-  out.fragEyePos = uWVS2.u_worldViewMatrix * float4(in.pos, 0.0, 1.0);
-  out.color = uWVS2.u_colorAndSize.xyz;
-  out.pos = uWVS2.u_worldViewProjectionMatrix * float4(in.pos, 0.0, 1.0);
-
-  return out;
+    main0_out out = {};
+    float _48 = u_EveryFrameVert.u_time.x * 0.0625;
+    float4 _63 = float4(in.in_var_POSITION, 0.0, 1.0);
+    out.gl_Position = u_EveryObject.u_worldViewProjectionMatrix * _63;
+    out.out_var_TEXCOORD0 = ((in.in_var_POSITION * u_EveryObject.u_colourAndSize.w) * float2(0.25)) - float2(_48);
+    out.out_var_TEXCOORD1 = ((in.in_var_POSITION.yx * u_EveryObject.u_colourAndSize.w) * float2(0.5)) - float2(_48, u_EveryFrameVert.u_time.x * 0.046875);
+    out.out_var_COLOR0 = u_EveryObject.u_worldViewMatrix * _63;
+    out.out_var_COLOR1 = u_EveryObject.u_colourAndSize.xyz;
+    return out;
 }
+

--- a/src/gl/metal/shaders/mobile/blurFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/blurFragmentShader.metal
@@ -1,27 +1,24 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct BlVSOutput
+struct main0_out
 {
-  float4 pos [[position]];
-  float2 uv0;
-  float2 uv1;
-  float2 uv2;
+    float4 out_var_SV_Target [[color(0)]];
 };
 
-constant static float4 multipliers[3] = {float4(0.0, 0.0, 0.0, 0.27901), float4(1.0, 1.0, 1.0, 0.44198), float4(0.0, 0.0, 0.0, 0.27901)};
-
-fragment float4
-main0(BlVSOutput in [[stage_in]], texture2d<float, access::sample> BlFSimg [[texture(0)]], sampler BlFSSampler [[sampler(0)]])
+struct main0_in
 {
-  float4 color = float4(0.0, 0.0, 0.0, 0.0);
-  
-  color += multipliers[0] * BlFSimg.sample(BlFSSampler, in.uv0);
-  color += multipliers[1] * BlFSimg.sample(BlFSSampler, in.uv1);
-  color += multipliers[2] * BlFSimg.sample(BlFSSampler, in.uv2);
-  
-  return color;
+    float2 in_var_TEXCOORD0 [[user(locn0)]];
+    float2 in_var_TEXCOORD1 [[user(locn1)]];
+    float2 in_var_TEXCOORD2 [[user(locn2)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> texture0 [[texture(0)]], sampler sampler0 [[sampler(0)]])
+{
+    main0_out out = {};
+    out.out_var_SV_Target = ((float4(0.0, 0.0, 0.0, 0.279009997844696044921875) * texture0.sample(sampler0, in.in_var_TEXCOORD0)) + (float4(1.0, 1.0, 1.0, 0.44198000431060791015625) * texture0.sample(sampler0, in.in_var_TEXCOORD1))) + (float4(0.0, 0.0, 0.0, 0.279009997844696044921875) * texture0.sample(sampler0, in.in_var_TEXCOORD2));
+    return out;
 }
+

--- a/src/gl/metal/shaders/mobile/blurVertexShader.metal
+++ b/src/gl/metal/shaders/mobile/blurVertexShader.metal
@@ -1,41 +1,35 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct BlVSInput
+struct type_u_EveryFrame
 {
-  float3 pos [[attribute(0)]];
-  float2 uv [[attribute(1)]];
+    float4 u_stepSize;
 };
 
-struct BlVSOutput
+struct main0_out
 {
-  float4 pos [[position]];
-  float2 uv0;
-  float2 uv1;
-  float2 uv2;
+    float2 out_var_TEXCOORD0 [[user(locn0)]];
+    float2 out_var_TEXCOORD1 [[user(locn1)]];
+    float2 out_var_TEXCOORD2 [[user(locn2)]];
+    float4 gl_Position [[position]];
 };
 
-struct BlVSUniforms
+struct main0_in
 {
-  float4 u_stepSize; // remember: requires 16 byte alignment
+    float3 in_var_POSITION [[attribute(0)]];
+    float2 in_var_TEXCOORD0 [[attribute(1)]];
 };
 
-vertex BlVSOutput
-main0(BlVSInput in [[stage_in]], constant BlVSUniforms& uniforms [[buffer(1)]])
+vertex main0_out main0(main0_in in [[stage_in]], constant type_u_EveryFrame& u_EveryFrame [[buffer(0)]])
 {
-  BlVSOutput out;
-  
-  out.pos = float4(in.pos.x, in.pos.y, 0.0, 1.0);
-  
-  // sample on edges, taking advantage of bilinear sampling
-  float2 sampleOffset = 1.42 * uniforms.u_stepSize.xy;
-  float2 uv = float2(in.uv.x, 1.0 - in.uv.y);
-  out.uv0 = uv - sampleOffset;
-  out.uv1 = uv;
-  out.uv2 = uv + sampleOffset;
-  
-  return out;
+    main0_out out = {};
+    float2 _36 = u_EveryFrame.u_stepSize.xy * 1.41999995708465576171875;
+    out.gl_Position = float4(in.in_var_POSITION.xy, 0.0, 1.0);
+    out.out_var_TEXCOORD0 = in.in_var_TEXCOORD0 - _36;
+    out.out_var_TEXCOORD1 = in.in_var_TEXCOORD0;
+    out.out_var_TEXCOORD2 = in.in_var_TEXCOORD0 + _36;
+    return out;
 }
+

--- a/src/gl/metal/shaders/mobile/compassFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/compassFragmentShader.metal
@@ -1,26 +1,37 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct CVSOutput
+struct type_u_cameraPlaneParams
 {
-  float4 pos [[position]];
-  float4 v_color;
-  float3 v_normal;
-  float4 v_fragClipPosition;
-  float3 v_sunDirection;
+    float s_CameraNearPlane;
+    float s_CameraFarPlane;
+    float u_clipZNear;
+    float u_clipZFar;
 };
 
-fragment float4
-main0(CVSOutput in [[stage_in]])
+struct main0_out
 {
-  float3 fakeEyeVector = normalize(in.v_fragClipPosition.xyz / in.v_fragClipPosition.w);
-  float3 worldNormal = in.v_normal * float3(2.0) - float3(1.0);
-  float ndotl = 0.5 + 0.5 * (-dot(in.v_sunDirection, worldNormal));
-  float edotr = max(0.0, -dot(-fakeEyeVector, worldNormal));
-  edotr = pow(edotr, 60.0);
-  float3 sheenColor = float3(1.0, 1.0, 0.9);
-  return float4(in.v_color.a * (ndotl * in.v_color.rgb + edotr * sheenColor), 1.0);
+    float4 out_var_SV_Target [[color(0)]];
+    float gl_FragDepth [[depth(any)]];
+};
+
+struct main0_in
+{
+    float3 in_var_COLOR0 [[user(locn0)]];
+    float4 in_var_COLOR1 [[user(locn1)]];
+    float3 in_var_COLOR2 [[user(locn2)]];
+    float4 in_var_COLOR3 [[user(locn3)]];
+    float2 in_var_TEXCOORD0 [[user(locn4)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]])
+{
+    main0_out out = {};
+    float3 _50 = (in.in_var_COLOR0 * float3(2.0)) - float3(1.0);
+    out.out_var_SV_Target = float4(((in.in_var_COLOR1.xyz * (0.5 + (dot(in.in_var_COLOR2, _50) * (-0.5)))) + (float3(1.0, 1.0, 0.89999997615814208984375) * pow(fast::max(0.0, -dot(-normalize(in.in_var_COLOR3.xyz / float3(in.in_var_COLOR3.w)), _50)), 60.0))) * in.in_var_COLOR1.w, 1.0);
+    out.gl_FragDepth = log2(in.in_var_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    return out;
 }
+

--- a/src/gl/metal/shaders/mobile/compassVertexShader.metal
+++ b/src/gl/metal/shaders/mobile/compassVertexShader.metal
@@ -1,39 +1,46 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct CVSInput
+struct type_u_EveryObject
 {
-  float3 a_pos [[attribute(0)]];
-  float3 a_normal [[attribute(1)]];
+    float4x4 u_worldViewProjectionMatrix;
+    float4 u_colour;
+    packed_float3 u_sunDirection;
+    float _padding;
 };
 
-struct CVSOutput
+constant float2 _34 = {};
+
+struct main0_out
 {
-  float4 pos [[position]];
-  float4 v_color;
-  float3 v_normal;
-  float4 v_fragClipPosition;
-  float3 v_sunDirection;
+    float3 out_var_COLOR0 [[user(locn0)]];
+    float4 out_var_COLOR1 [[user(locn1)]];
+    float3 out_var_COLOR2 [[user(locn2)]];
+    float4 out_var_COLOR3 [[user(locn3)]];
+    float2 out_var_TEXCOORD0 [[user(locn4)]];
+    float4 gl_Position [[position]];
 };
 
-struct CVSUniforms
+struct main0_in
 {
-  float4x4 u_worldViewProjectionMatrix;
-  float4 u_color;
-  float3 u_sunDirection;
+    float3 in_var_POSITION [[attribute(0)]];
+    float3 in_var_NORMAL [[attribute(1)]];
 };
 
-vertex CVSOutput
-main0(CVSInput in [[stage_in]], constant CVSUniforms& uCVS [[buffer(1)]])
+vertex main0_out main0(main0_in in [[stage_in]], constant type_u_EveryObject& u_EveryObject [[buffer(0)]])
 {
-  CVSOutput out;
-  out.v_fragClipPosition = uCVS.u_worldViewProjectionMatrix * float4(in.a_pos, 1.0);
-  out.pos = out.v_fragClipPosition;
-  out.v_normal = (in.a_normal * 0.5) + 0.5;
-  out.v_color = uCVS.u_color;
-  out.v_sunDirection = uCVS.u_sunDirection;
-  return out;
+    main0_out out = {};
+    float4 _44 = u_EveryObject.u_worldViewProjectionMatrix * float4(in.in_var_POSITION, 1.0);
+    float2 _53 = _34;
+    _53.x = 1.0 + _44.w;
+    out.gl_Position = _44;
+    out.out_var_COLOR0 = (in.in_var_NORMAL * 0.5) + float3(0.5);
+    out.out_var_COLOR1 = u_EveryObject.u_colour;
+    out.out_var_COLOR2 = float3(u_EveryObject.u_sunDirection);
+    out.out_var_COLOR3 = _44;
+    out.out_var_TEXCOORD0 = _53;
+    return out;
 }
+

--- a/src/gl/metal/shaders/mobile/depthOnlyFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/depthOnlyFragmentShader.metal
@@ -1,18 +1,32 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct DOFSInput
+struct type_u_cameraPlaneParams
 {
-  float4 pos [[attribute(0)]];
-  float2 uv [[attribute(1)]];
-  float3 normal [[attribute(2)]];
-  float4 color [[attribute(3)]];
+    float s_CameraNearPlane;
+    float s_CameraFarPlane;
+    float u_clipZNear;
+    float u_clipZFar;
 };
 
-float4 main0(DOFSInput in [[stage_in]])
+struct main0_out
 {
-  return float4(0.0, 0.0, 0.0, 0.0);
+    float4 out_var_SV_Target [[color(0)]];
+    float gl_FragDepth [[depth(any)]];
+};
+
+struct main0_in
+{
+    float2 in_var_TEXCOORD1 [[user(locn3)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]])
+{
+    main0_out out = {};
+    out.out_var_SV_Target = float4(0.0);
+    out.gl_FragDepth = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    return out;
 }
+

--- a/src/gl/metal/shaders/mobile/fenceFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/fenceFragmentShader.metal
@@ -1,18 +1,35 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct PCU
+struct type_u_cameraPlaneParams
 {
-  float4 v_position [[position]];
-  float4 v_color;
-  float2 v_uv;
+    float s_CameraNearPlane;
+    float s_CameraFarPlane;
+    float u_clipZNear;
+    float u_clipZFar;
 };
 
-fragment float4 main0(PCU in [[stage_in]], texture2d<float, access::sample> FFSimg [[texture(0)]], sampler FFSsampler [[sampler(0)]])
+struct main0_out
 {
-  float4 texCol = FFSimg.sample(FFSsampler, in.v_uv);
-  return float4(texCol.xyz * in.v_color.xyz, texCol.w * in.v_color.w);
+    float4 out_var_SV_Target [[color(0)]];
+    float gl_FragDepth [[depth(any)]];
+};
+
+struct main0_in
+{
+    float4 in_var_COLOR0 [[user(locn0)]];
+    float2 in_var_TEXCOORD0 [[user(locn1)]];
+    float2 in_var_TEXCOORD1 [[user(locn2)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], texture2d<float> texture0 [[texture(0)]], sampler sampler0 [[sampler(0)]])
+{
+    main0_out out = {};
+    float4 _40 = texture0.sample(sampler0, in.in_var_TEXCOORD0);
+    out.out_var_SV_Target = float4(_40.xyz * in.in_var_COLOR0.xyz, _40.w * in.in_var_COLOR0.w);
+    out.gl_FragDepth = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    return out;
 }
+

--- a/src/gl/metal/shaders/mobile/fenceVertexShader.metal
+++ b/src/gl/metal/shaders/mobile/fenceVertexShader.metal
@@ -1,52 +1,53 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct FVSUniforms
+struct type_u_EveryFrame
 {
-  float4 u_bottomColor;
-  float4 u_topColor;
-
-  float u_orientation;
-  float u_width;
-  float u_textureRepeatScale;
-  float u_textureScrollSpeed;
-  float u_time;
+    float4 u_bottomColour;
+    float4 u_topColour;
+    float u_orientation;
+    float u_width;
+    float u_textureRepeatScale;
+    float u_textureScrollSpeed;
+    float u_time;
+    float _padding1;
+    float2 _padding2;
 };
 
-struct FVSEveryObject
+struct type_u_EveryObject
 {
-  float4x4 u_worldViewProjectionMatrix;
+    float4x4 u_worldViewProjectionMatrix;
 };
 
-struct FVSInput
+constant float2 _41 = {};
+
+struct main0_out
 {
-  float3 a_position [[attribute(0)]];
-  float2 a_uv [[attribute(1)]];
-  float4 a_ribbonInfo [[attribute(2)]]; // xyz: expand floattor; z: pair id (0 or 1)
+    float4 out_var_COLOR0 [[user(locn0)]];
+    float2 out_var_TEXCOORD0 [[user(locn1)]];
+    float2 out_var_TEXCOORD1 [[user(locn2)]];
+    float4 gl_Position [[position]];
 };
 
-struct PCU
+struct main0_in
 {
-  float4 v_position [[position]];
-  float4 v_color;
-  float2 v_uv;
+    float3 in_var_POSITION [[attribute(0)]];
+    float2 in_var_TEXCOORD0 [[attribute(1)]];
+    float4 in_var_COLOR0 [[attribute(2)]];
 };
 
-vertex PCU
-main0(FVSInput in [[stage_in]], constant FVSUniforms& uFVS [[buffer(1)]], constant FVSEveryObject& uFVSEO [[buffer(2)]])
+vertex main0_out main0(main0_in in [[stage_in]], constant type_u_EveryFrame& u_EveryFrame [[buffer(0)]], constant type_u_EveryObject& u_EveryObject [[buffer(1)]])
 {
-  PCU out;
-
-  // fence horizontal UV pos packed into Y channel
-  out.v_uv = float2(mix(in.a_uv.y, in.a_uv.x, uFVS.u_orientation) * uFVS.u_textureRepeatScale - uFVS.u_time * uFVS.u_textureScrollSpeed, in.a_ribbonInfo.w);
-  out.v_color = mix(uFVS.u_bottomColor, uFVS.u_topColor, in.a_ribbonInfo.w);
-
-  // fence or flat
-  float3 worldPosition = in.a_position + mix(float3(0, 0, in.a_ribbonInfo.w) * uFVS.u_width, in.a_ribbonInfo.xyz, uFVS.u_orientation);
-
-  out.v_position = uFVSEO.u_worldViewProjectionMatrix * float4(worldPosition, 1.0);
-  return out;
+    main0_out out = {};
+    float4 _82 = u_EveryObject.u_worldViewProjectionMatrix * float4(in.in_var_POSITION + mix(float3(0.0, 0.0, in.in_var_COLOR0.w) * u_EveryFrame.u_width, in.in_var_COLOR0.xyz, float3(u_EveryFrame.u_orientation)), 1.0);
+    float2 _85 = _41;
+    _85.x = 1.0 + _82.w;
+    out.gl_Position = _82;
+    out.out_var_COLOR0 = mix(u_EveryFrame.u_bottomColour, u_EveryFrame.u_topColour, float4(in.in_var_COLOR0.w));
+    out.out_var_TEXCOORD0 = float2((mix(in.in_var_TEXCOORD0.y, in.in_var_TEXCOORD0.x, u_EveryFrame.u_orientation) * u_EveryFrame.u_textureRepeatScale) - (u_EveryFrame.u_time * u_EveryFrame.u_textureScrollSpeed), in.in_var_COLOR0.w);
+    out.out_var_TEXCOORD1 = _85;
+    return out;
 }
+

--- a/src/gl/metal/shaders/mobile/flatColourFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/flatColourFragmentShader.metal
@@ -1,18 +1,33 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct FCFSInput
+struct type_u_cameraPlaneParams
 {
-  float4 pos [[attribute(0)]];
-  float2 uv [[attribute(1)]];
-  float3 normal [[attribute(2)]];
-  float4 color [[attribute(3)]];
+    float s_CameraNearPlane;
+    float s_CameraFarPlane;
+    float u_clipZNear;
+    float u_clipZFar;
 };
 
-float4 main0(FCFSInput in [[stage_in]])
+struct main0_out
 {
-  return float4(in.color);
+    float4 out_var_SV_Target [[color(0)]];
+    float gl_FragDepth [[depth(any)]];
+};
+
+struct main0_in
+{
+    float4 in_var_COLOR0 [[user(locn2)]];
+    float2 in_var_TEXCOORD1 [[user(locn3)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]])
+{
+    main0_out out = {};
+    out.out_var_SV_Target = in.in_var_COLOR0;
+    out.gl_FragDepth = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    return out;
 }
+

--- a/src/gl/metal/shaders/mobile/highlightFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/highlightFragmentShader.metal
@@ -1,44 +1,46 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct HFSInput
+struct main0_out
 {
-  float4 pos [[position]];
-  float2 uv0;
-  float2 uv1;
-  float2 uv2;
-  float2 uv3;
-  float2 uv4;
+    float4 out_var_SV_Target [[color(0)]];
 };
 
-struct HVSUniforms
+struct main0_in
 {
-  float4 u_stepSizeThickness; // (stepSize.xy, outline thickness, inner overlay strength)
-  float4 u_color;
+    float2 in_var_TEXCOORD0 [[user(locn0)]];
+    float2 in_var_TEXCOORD1 [[user(locn1)]];
+    float2 in_var_TEXCOORD2 [[user(locn2)]];
+    float2 in_var_TEXCOORD3 [[user(locn3)]];
+    float2 in_var_TEXCOORD4 [[user(locn4)]];
+    float4 in_var_COLOR0 [[user(locn5)]];
+    float4 in_var_COLOR1 [[user(locn6)]];
 };
 
-fragment float4
-main0(HFSInput in [[stage_in]], constant HVSUniforms& uniforms [[buffer(1)]], texture2d<float, access::sample> HFSimg [[texture(0)]], sampler HFSSampler [[sampler(0)]])
+fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> u_texture [[texture(0)]], sampler sampler0 [[sampler(0)]])
 {
-  float4 middle = HFSimg.sample(HFSSampler, in.uv0);
-  float result = middle.w;
-  
-  // 'outside' the geometry, just use the blurred 'distance'
-  if (middle.x == 0.0)
-      return float4(uniforms.u_color.xyz, result * uniforms.u_stepSizeThickness.z * uniforms.u_color.a);
-  
-  result = 1.0 - result;
-  
-  // look for an edge, setting to full color if found
-  float softenEdge = 0.15 * uniforms.u_color.a;
-  result += softenEdge * step(HFSimg.sample(HFSSampler, in.uv1).x - middle.x, -0.00001);
-  result += softenEdge * step(HFSimg.sample(HFSSampler, in.uv2).x - middle.x, -0.00001);
-  result += softenEdge * step(HFSimg.sample(HFSSampler, in.uv3).x - middle.x, -0.00001);
-  result += softenEdge * step(HFSimg.sample(HFSSampler, in.uv4).x - middle.x, -0.00001);
-  
-  result = max(uniforms.u_stepSizeThickness.w, result) * uniforms.u_color.w; // overlay color
-  return float4(uniforms.u_color.xyz, result);
+    main0_out out = {};
+    float4 _99;
+    switch (0u)
+    {
+        default:
+        {
+            float4 _47 = u_texture.sample(sampler0, in.in_var_TEXCOORD0);
+            float _48 = _47.w;
+            float _49 = _47.x;
+            if (_49 == 0.0)
+            {
+                _99 = float4(in.in_var_COLOR0.xyz, (_48 * in.in_var_COLOR1.z) * in.in_var_COLOR0.w);
+                break;
+            }
+            float _63 = 0.1500000059604644775390625 * in.in_var_COLOR0.w;
+            _99 = float4(in.in_var_COLOR0.xyz, fast::max(in.in_var_COLOR1.w, ((((1.0 - _48) + (_63 * step(u_texture.sample(sampler0, in.in_var_TEXCOORD1).x - _49, -9.9999997473787516355514526367188e-06))) + (_63 * step(u_texture.sample(sampler0, in.in_var_TEXCOORD2).x - _49, -9.9999997473787516355514526367188e-06))) + (_63 * step(u_texture.sample(sampler0, in.in_var_TEXCOORD3).x - _49, -9.9999997473787516355514526367188e-06))) + (_63 * step(u_texture.sample(sampler0, in.in_var_TEXCOORD4).x - _49, -9.9999997473787516355514526367188e-06))) * in.in_var_COLOR0.w);
+            break;
+        }
+    }
+    out.out_var_SV_Target = _99;
+    return out;
 }
+

--- a/src/gl/metal/shaders/mobile/highlightVertexShader.metal
+++ b/src/gl/metal/shaders/mobile/highlightVertexShader.metal
@@ -1,45 +1,43 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct HVSInput
+struct type_u_EveryFrame
 {
-  float3 pos [[attribute(0)]];
-  float2 uv [[attribute(1)]];
+    float4 u_stepSizeThickness;
+    float4 u_colour;
 };
 
-struct HFSInput
+struct main0_out
 {
-  float4 pos [[position]];
-  float2 uv0;
-  float2 uv1;
-  float2 uv2;
-  float2 uv3;
-  float2 uv4;
+    float2 out_var_TEXCOORD0 [[user(locn0)]];
+    float2 out_var_TEXCOORD1 [[user(locn1)]];
+    float2 out_var_TEXCOORD2 [[user(locn2)]];
+    float2 out_var_TEXCOORD3 [[user(locn3)]];
+    float2 out_var_TEXCOORD4 [[user(locn4)]];
+    float4 out_var_COLOR0 [[user(locn5)]];
+    float4 out_var_COLOR1 [[user(locn6)]];
+    float4 gl_Position [[position]];
 };
 
-constant static float2 searchKernel[4] = {float2(-1, -1), float2(1, -1), float2(-1,  1), float2(1, 1)};
-
-struct HVSUniforms
+struct main0_in
 {
-  float4 u_stepSizeThickness; // (stepSize.xy, outline thickness, inner overlay strength)
-  float4 u_color;
+    float3 in_var_POSITION [[attribute(0)]];
+    float2 in_var_TEXCOORD0 [[attribute(1)]];
 };
 
-vertex HFSInput
-main0(HVSInput in [[stage_in]], constant HVSUniforms& uniforms [[buffer(1)]])
+vertex main0_out main0(main0_in in [[stage_in]], constant type_u_EveryFrame& u_EveryFrame [[buffer(0)]])
 {
-  HFSInput out;
-  
-  out.pos = float4(in.pos.x, in.pos.y, 0.0, 1.0);
-  
-  out.uv0 = in.uv;
-  out.uv1 = in.uv + uniforms.u_stepSizeThickness.xy * searchKernel[0];
-  out.uv2 = in.uv + uniforms.u_stepSizeThickness.xy * searchKernel[1];
-  out.uv3 = in.uv + uniforms.u_stepSizeThickness.xy * searchKernel[2];
-  out.uv4 = in.uv + uniforms.u_stepSizeThickness.xy * searchKernel[3];
-  
-  return out;
+    main0_out out = {};
+    out.gl_Position = float4(in.in_var_POSITION.xy, 0.0, 1.0);
+    out.out_var_TEXCOORD0 = in.in_var_TEXCOORD0;
+    out.out_var_TEXCOORD1 = in.in_var_TEXCOORD0 + (u_EveryFrame.u_stepSizeThickness.xy * float2(-1.0));
+    out.out_var_TEXCOORD2 = in.in_var_TEXCOORD0 + (u_EveryFrame.u_stepSizeThickness.xy * float2(1.0, -1.0));
+    out.out_var_TEXCOORD3 = in.in_var_TEXCOORD0 + (u_EveryFrame.u_stepSizeThickness.xy * float2(-1.0, 1.0));
+    out.out_var_TEXCOORD4 = in.in_var_TEXCOORD0 + u_EveryFrame.u_stepSizeThickness.xy;
+    out.out_var_COLOR0 = u_EveryFrame.u_colour;
+    out.out_var_COLOR1 = u_EveryFrame.u_stepSizeThickness;
+    return out;
 }
+

--- a/src/gl/metal/shaders/mobile/imageColourSkyboxFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/imageColourSkyboxFragmentShader.metal
@@ -1,25 +1,25 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct SVSOutput
+struct main0_out
 {
-  float4 position [[position]];
-  float2 v_texCoord;
+    float4 out_var_SV_Target [[color(0)]];
 };
 
-struct SFSTCUniforms
+struct main0_in
 {
-  float4 u_tintColor; //0 is full color, 1 is full image
-  float4 u_imageSize; //For purposes of tiling/stretching
+    float2 in_var_TEXCOORD0 [[user(locn0)]];
+    float4 in_var_COLOR0 [[user(locn1)]];
 };
 
-fragment float4
-main0(SVSOutput in [[stage_in]], constant SFSTCUniforms& uSFS [[buffer(1)]], texture2d<float, access::sample> SFSimg [[texture(0)]], sampler SFSsampler [[sampler(0)]])
+fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> u_texture [[texture(0)]], sampler sampler0 [[sampler(0)]])
 {
-  float4 color = SFSimg.sample(SFSsampler, in.v_texCoord / uSFS.u_imageSize.xy);
-  float effectiveAlpha = min(color.a, uSFS.u_tintColor.a);
-  return float4((color.rgb * effectiveAlpha) + (uSFS.u_tintColor.rgb * (1 - effectiveAlpha)), 1);
+    main0_out out = {};
+    float4 _30 = u_texture.sample(sampler0, in.in_var_TEXCOORD0);
+    float _33 = fast::min(_30.w, in.in_var_COLOR0.w);
+    out.out_var_SV_Target = float4((_30.xyz * _33) + (in.in_var_COLOR0.xyz * (1.0 - _33)), 1.0);
+    return out;
 }
+

--- a/src/gl/metal/shaders/mobile/imageColourSkyboxVertexShader.metal
+++ b/src/gl/metal/shaders/mobile/imageColourSkyboxVertexShader.metal
@@ -1,27 +1,33 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct SVSInput
+struct type_u_EveryFrame
 {
-  float3 a_position [[attribute(0)]];
-  float2 a_texCoord [[attribute(1)]];
+    float4 u_tintColour;
+    float4 u_imageSize;
 };
 
-struct SVSOutput
+struct main0_out
 {
-  float4 position [[position]];
-  float2 v_texCoord;
+    float2 out_var_TEXCOORD0 [[user(locn0)]];
+    float4 out_var_COLOR0 [[user(locn1)]];
+    float4 gl_Position [[position]];
 };
 
-vertex SVSOutput
-main0(SVSInput in [[stage_in]])
+struct main0_in
 {
-  SVSOutput out;
-  out.position = float4(in.a_position.xy, 0.0, 1.0);
-  out.v_texCoord = float2(in.a_texCoord.x, 1.0 - in.a_texCoord.y);
-  return out;
+    float3 in_var_POSITION [[attribute(0)]];
+    float2 in_var_TEXCOORD0 [[attribute(1)]];
+};
+
+vertex main0_out main0(main0_in in [[stage_in]], constant type_u_EveryFrame& u_EveryFrame [[buffer(0)]])
+{
+    main0_out out = {};
+    out.gl_Position = float4(in.in_var_POSITION.xy, 0.0, 1.0);
+    out.out_var_TEXCOORD0 = in.in_var_TEXCOORD0 / u_EveryFrame.u_imageSize.xy;
+    out.out_var_COLOR0 = u_EveryFrame.u_tintColour;
+    return out;
 }
 

--- a/src/gl/metal/shaders/mobile/imageRendererBillboardVertexShader.metal
+++ b/src/gl/metal/shaders/mobile/imageRendererBillboardVertexShader.metal
@@ -1,39 +1,43 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct PUC
+struct type_u_EveryObject
 {
-  float4 pos [[position]];
-  float2 uv;
-  float4 color;
+    float4x4 u_worldViewProjectionMatrix;
+    float4 u_colour;
+    float4 u_screenSize;
 };
 
-struct IRBVSInput
+constant float2 _32 = {};
+
+struct main0_out
 {
-  float3 pos [[attribute(0)]];
-  float2 uv [[attribute(1)]];
+    float2 out_var_TEXCOORD0 [[user(locn0)]];
+    float4 out_var_COLOR0 [[user(locn1)]];
+    float2 out_var_TEXCOORD1 [[user(locn2)]];
+    float4 gl_Position [[position]];
 };
 
-struct IRBVSUniforms
+struct main0_in
 {
-  float4x4 u_worldViewProjectionMatrix;
-  float4 u_color;
-  float4 u_screenSize;
+    float3 in_var_POSITION [[attribute(0)]];
+    float2 in_var_TEXCOORD0 [[attribute(1)]];
 };
 
-vertex PUC
-main0(IRBVSInput in [[stage_in]], constant IRBVSUniforms& uniforms [[buffer(1)]])
+vertex main0_out main0(main0_in in [[stage_in]], constant type_u_EveryObject& u_EveryObject [[buffer(0)]])
 {
-  PUC out;
-  
-  out.pos = uniforms.u_worldViewProjectionMatrix * float4(in.pos, 1.0);
-  out.pos.xy += uniforms.u_screenSize.z * out.pos.w * uniforms.u_screenSize.xy * float2(in.uv.x * 2.0 - 1.0, in.uv.y * 2.0 - 1.0); // expand billboard
-  out.uv = float2(in.uv.x, 1.0 - in.uv.y);
-  
-  out.color = uniforms.u_color;
-  
-  return out;
+    main0_out out = {};
+    float4 _38 = u_EveryObject.u_worldViewProjectionMatrix * float4(0.0, 0.0, 0.0, 1.0);
+    float _44 = _38.w;
+    float2 _50 = _38.xy + ((u_EveryObject.u_screenSize.xy * (u_EveryObject.u_screenSize.z * _44)) * in.in_var_POSITION.xy);
+    float2 _55 = _32;
+    _55.x = 1.0 + _44;
+    out.gl_Position = float4(_50.x, _50.y, _38.z, _38.w);
+    out.out_var_TEXCOORD0 = in.in_var_TEXCOORD0;
+    out.out_var_COLOR0 = u_EveryObject.u_colour;
+    out.out_var_TEXCOORD1 = _55;
+    return out;
 }
+

--- a/src/gl/metal/shaders/mobile/imageRendererFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/imageRendererFragmentShader.metal
@@ -1,19 +1,34 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct PUC
+struct type_u_cameraPlaneParams
 {
-  float4 pos [[position]];
-  float2 uv;
-  float4 color;
+    float s_CameraNearPlane;
+    float s_CameraFarPlane;
+    float u_clipZNear;
+    float u_clipZFar;
 };
 
-fragment float4
-main0(PUC in [[stage_in]], texture2d<float, access::sample> IRFSimg [[texture(0)]], sampler IRFSsampler [[sampler(0)]])
+struct main0_out
 {
-  float4 col = IRFSimg.sample(IRFSsampler, in.uv);
-  return col * in.color;
+    float4 out_var_SV_Target [[color(0)]];
+    float gl_FragDepth [[depth(any)]];
+};
+
+struct main0_in
+{
+    float2 in_var_TEXCOORD0 [[user(locn0)]];
+    float4 in_var_COLOR0 [[user(locn1)]];
+    float2 in_var_TEXCOORD1 [[user(locn2)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], texture2d<float> texture0 [[texture(0)]], sampler sampler0 [[sampler(0)]])
+{
+    main0_out out = {};
+    out.out_var_SV_Target = texture0.sample(sampler0, in.in_var_TEXCOORD0) * in.in_var_COLOR0;
+    out.gl_FragDepth = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    return out;
 }
+

--- a/src/gl/metal/shaders/mobile/imageRendererMeshVertexShader.metal
+++ b/src/gl/metal/shaders/mobile/imageRendererMeshVertexShader.metal
@@ -1,38 +1,41 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct PUC
+struct type_u_EveryObject
 {
-  float4 pos [[position]];
-  float2 uv;
-  float4 color;
+    float4x4 u_worldViewProjectionMatrix;
+    float4 u_colour;
+    float4 u_screenSize;
 };
 
-struct PNUVVSInput
+constant float2 _29 = {};
+
+struct main0_out
 {
-  float3 pos [[attribute(0)]];
-  float3 normal [[attribute(1)]]; // unused
-  float2 uv [[attribute(2)]];
+    float2 out_var_TEXCOORD0 [[user(locn0)]];
+    float4 out_var_COLOR0 [[user(locn1)]];
+    float2 out_var_TEXCOORD1 [[user(locn2)]];
+    float4 gl_Position [[position]];
 };
 
-struct IRMVSUniforms
+struct main0_in
 {
-  float4x4 u_worldViewProjectionMatrix;
-  float4 u_color;
-  float4 u_screenSize; // unused
+    float3 in_var_POSITION [[attribute(0)]];
+    float2 in_var_TEXCOORD0 [[attribute(2)]];
 };
 
-vertex PUC
-main0(PNUVVSInput in [[stage_in]], constant IRMVSUniforms& uniforms [[buffer(1)]])
+vertex main0_out main0(main0_in in [[stage_in]], constant type_u_EveryObject& u_EveryObject [[buffer(0)]])
 {
-  PUC out;
-  
-  out.pos = uniforms.u_worldViewProjectionMatrix * float4(in.pos, 1.0);
-  out.uv = float2(in.uv[0], 1.0 - in.uv[1]);
-  out.color = uniforms.u_color;
-  
-  return out;
+    main0_out out = {};
+    float4 _39 = u_EveryObject.u_worldViewProjectionMatrix * float4(in.in_var_POSITION, 1.0);
+    float2 _44 = _29;
+    _44.x = 1.0 + _39.w;
+    out.gl_Position = _39;
+    out.out_var_TEXCOORD0 = in.in_var_TEXCOORD0;
+    out.out_var_COLOR0 = u_EveryObject.u_colour;
+    out.out_var_TEXCOORD1 = _44;
+    return out;
 }
+

--- a/src/gl/metal/shaders/mobile/imgui3DVertexShader.metal
+++ b/src/gl/metal/shaders/mobile/imgui3DVertexShader.metal
@@ -1,30 +1,36 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct Uniforms {
-  float4x4 projectionMatrix;
-};
-
-struct VertexIn {
-  float2 position  [[attribute(0)]];
-  float2 texCoords [[attribute(1)]];
-  float4 color     [[attribute(2)]];
-};
-
-struct VertexOut {
-  float4 position [[position]];
-  float2 texCoords;
-  float4 color;
-};
-
-vertex VertexOut main0(VertexIn in [[stage_in]], constant Uniforms& uIMGUI [[buffer(1)]])
+struct type_u_EveryObject
 {
-  VertexOut out;
-  out.position = uIMGUI.projectionMatrix * float4(in.position, 0, 1);
-  out.texCoords = in.texCoords;
-  out.color = in.color;
-  return out;
+    float4x4 u_worldViewProjectionMatrix;
+    float4 u_screenSize;
+};
+
+struct main0_out
+{
+    float4 out_var_COLOR0 [[user(locn0)]];
+    float2 out_var_TEXCOORD0 [[user(locn1)]];
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float2 in_var_POSITION [[attribute(0)]];
+    float2 in_var_TEXCOORD0 [[attribute(1)]];
+    float4 in_var_COLOR0 [[attribute(2)]];
+};
+
+vertex main0_out main0(main0_in in [[stage_in]], constant type_u_EveryObject& u_EveryObject [[buffer(0)]])
+{
+    main0_out out = {};
+    float4 _35 = u_EveryObject.u_worldViewProjectionMatrix * float4(0.0, 0.0, 0.0, 1.0);
+    float2 _43 = _35.xy + ((u_EveryObject.u_screenSize.xy * in.in_var_POSITION) * _35.w);
+    out.gl_Position = float4(_43.x, _43.y, _35.z, _35.w);
+    out.out_var_COLOR0 = in.in_var_COLOR0;
+    out.out_var_TEXCOORD0 = in.in_var_TEXCOORD0;
+    return out;
 }
+

--- a/src/gl/metal/shaders/mobile/imguiFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/imguiFragmentShader.metal
@@ -1,17 +1,23 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct VertexOut {
-  float4 position [[position]];
-  float2 texCoords;
-  float4 color;
+struct main0_out
+{
+    float4 out_var_SV_Target [[color(0)]];
 };
 
-fragment half4 main0(VertexOut in [[stage_in]], texture2d<half, access::sample> IMtexture [[texture(0)]], sampler imguiSampler [[sampler(0)]])
+struct main0_in
 {
-  half4 texColor = IMtexture.sample(imguiSampler, in.texCoords);
-  return half4(in.color) * texColor;
+    float4 in_var_COLOR0 [[user(locn0)]];
+    float2 in_var_TEXCOORD0 [[user(locn1)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> texture0 [[texture(0)]], sampler sampler0 [[sampler(0)]])
+{
+    main0_out out = {};
+    out.out_var_SV_Target = in.in_var_COLOR0 * texture0.sample(sampler0, in.in_var_TEXCOORD0);
+    return out;
 }
+

--- a/src/gl/metal/shaders/mobile/imguiVertexShader.metal
+++ b/src/gl/metal/shaders/mobile/imguiVertexShader.metal
@@ -1,30 +1,33 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct Uniforms {
-  float4x4 projectionMatrix;
-};
-
-struct VertexIn {
-  float2 position  [[attribute(0)]];
-  float2 texCoords [[attribute(1)]];
-  float4 color     [[attribute(2)]];
-};
-
-struct VertexOut {
-  float4 position [[position]];
-  float2 texCoords;
-  float4 color;
-};
-
-vertex VertexOut main0(VertexIn in [[stage_in]], constant Uniforms& uIMGUI [[buffer(1)]])
+struct type_u_EveryFrame
 {
-  VertexOut out;
-  out.position = uIMGUI.projectionMatrix * float4(in.position, 0, 1);
-  out.texCoords = in.texCoords;
-  out.color = in.color;
-  return out;
+    float4x4 ProjectionMatrix;
+};
+
+struct main0_out
+{
+    float4 out_var_COLOR0 [[user(locn0)]];
+    float2 out_var_TEXCOORD0 [[user(locn1)]];
+    float4 gl_Position [[position]];
+};
+
+struct main0_in
+{
+    float2 in_var_POSITION [[attribute(0)]];
+    float2 in_var_TEXCOORD0 [[attribute(1)]];
+    float4 in_var_COLOR0 [[attribute(2)]];
+};
+
+vertex main0_out main0(main0_in in [[stage_in]], constant type_u_EveryFrame& u_EveryFrame [[buffer(0)]])
+{
+    main0_out out = {};
+    out.gl_Position = u_EveryFrame.ProjectionMatrix * float4(in.in_var_POSITION, 0.0, 1.0);
+    out.out_var_COLOR0 = in.in_var_COLOR0;
+    out.out_var_TEXCOORD0 = in.in_var_TEXCOORD0;
+    return out;
 }
+

--- a/src/gl/metal/shaders/mobile/panoramaSkyboxFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/panoramaSkyboxFragmentShader.metal
@@ -1,26 +1,29 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct SVSOutput
+struct type_u_EveryFrame
 {
-  float4 position [[position]];
-  float2 v_texCoord;
+    float4x4 u_inverseViewProjection;
 };
 
-struct SFSPUniforms
+struct main0_out
 {
-  float4x4 u_inverseViewProjection;
+    float4 out_var_SV_Target [[color(0)]];
 };
 
-fragment float4
-main0(SVSOutput in [[stage_in]], constant SFSPUniforms& uSFS [[buffer(1)]], texture2d<float, access::sample> SFSimg [[texture(0)]], sampler SFSsampler [[sampler(0)]])
+struct main0_in
 {
-  // work out 3D point
-  float4 point3D = uSFS.u_inverseViewProjection * float4(in.v_texCoord * float2(2.0) - float2(1.0), 1.0, 1.0);
-  point3D.xyz = normalize(point3D.xyz / point3D.w);
-  float2 longlat = float2(atan2(point3D.x, point3D.y) + M_PI_F, acos(point3D.z));
-  return SFSimg.sample(SFSsampler, longlat / float2(2.0 * M_PI_F, M_PI_F));
+    float4 in_var_TEXCOORD0 [[user(locn0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], constant type_u_EveryFrame& u_EveryFrame [[buffer(0)]], texture2d<float> u_texture [[texture(0)]], sampler sampler0 [[sampler(0)]])
+{
+    main0_out out = {};
+    float4 _40 = u_EveryFrame.u_inverseViewProjection * float4(in.in_var_TEXCOORD0.xy, 1.0, 1.0);
+    float3 _45 = normalize(_40.xyz / float3(_40.w));
+    out.out_var_SV_Target = u_texture.sample(sampler0, (float2(atan2(_45.x, _45.y) + 3.1415927410125732421875, acos(_45.z)) * float2(0.15915493667125701904296875, 0.3183098733425140380859375)));
+    return out;
 }
+

--- a/src/gl/metal/shaders/mobile/panoramaSkyboxVertexShader.metal
+++ b/src/gl/metal/shaders/mobile/panoramaSkyboxVertexShader.metal
@@ -1,26 +1,25 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct SVSInput
+struct main0_out
 {
-  float3 a_position [[attribute(0)]];
-  float2 a_texCoord [[attribute(1)]];
+    float4 out_var_TEXCOORD0 [[user(locn0)]];
+    float4 gl_Position [[position]];
 };
 
-struct SVSOutput
+struct main0_in
 {
-  float4 position [[position]];
-  float2 v_texCoord;
+    float3 in_var_POSITION [[attribute(0)]];
 };
 
-vertex SVSOutput
-main0(SVSInput in [[stage_in]])
+vertex main0_out main0(main0_in in [[stage_in]])
 {
-  SVSOutput out;
-  out.position = float4(in.a_position.xy, 0.0, 1.0);
-  out.v_texCoord = float2(in.a_texCoord.x, 1.0 - in.a_texCoord.y);
-  return out;
+    main0_out out = {};
+    float4 _21 = float4(in.in_var_POSITION.xy, 0.0, 1.0);
+    out.gl_Position = _21;
+    out.out_var_TEXCOORD0 = _21;
+    return out;
 }
+

--- a/src/gl/metal/shaders/mobile/polygonP3N3UV2FragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/polygonP3N3UV2FragmentShader.metal
@@ -1,27 +1,36 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct PNUVSOutput
+struct type_u_cameraPlaneParams
 {
-  float4 pos [[position]];
-  float2 uv;
-  float3 normal;
-  float4 color;
+    float s_CameraNearPlane;
+    float s_CameraFarPlane;
+    float u_clipZNear;
+    float u_clipZFar;
 };
 
-fragment float4
-main0(PNUVSOutput in [[stage_in]], texture2d<float, access::sample> PNUFSimg [[texture(0)]], sampler PNUFSsampler [[sampler(0)]])
+struct main0_out
 {
-    float4 col = PNUFSimg.sample(PNUFSsampler, in.uv);
-    float4 diffuseColour = col * in.color;
+    float4 out_var_SV_Target [[color(0)]];
+    float gl_FragDepth [[depth(any)]];
+};
 
-    // some fixed lighting
-    float3 lightDirection = normalize(float3(0.85, 0.15, 0.5));
-    float ndotl = dot(in.normal, lightDirection) * 0.5 + 0.5;
-    float3 diffuse = diffuseColour.xyz * ndotl;
+struct main0_in
+{
+    float2 in_var_TEXCOORD0 [[user(locn0)]];
+    float3 in_var_NORMAL [[user(locn1)]];
+    float4 in_var_COLOR0 [[user(locn2)]];
+    float2 in_var_TEXCOORD1 [[user(locn3)]];
+};
 
-    return float4(diffuse, diffuseColour.a);
+fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], texture2d<float> texture0 [[texture(0)]], sampler sampler0 [[sampler(0)]])
+{
+    main0_out out = {};
+    float4 _48 = texture0.sample(sampler0, in.in_var_TEXCOORD0) * in.in_var_COLOR0;
+    out.out_var_SV_Target = float4(_48.xyz * ((dot(in.in_var_NORMAL, normalize(float3(0.85000002384185791015625, 0.1500000059604644775390625, 0.5))) * 0.5) + 0.5), _48.w);
+    out.gl_FragDepth = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    return out;
 }
+

--- a/src/gl/metal/shaders/mobile/polygonP3N3UV2VertexShader.metal
+++ b/src/gl/metal/shaders/mobile/polygonP3N3UV2VertexShader.metal
@@ -1,43 +1,44 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct PNUVSInput
+struct type_u_EveryObject
 {
-  float3 pos [[attribute(0)]];
-  float3 normal [[attribute(1)]];
-  float2 uv [[attribute(2)]];
+    float4x4 u_worldViewProjectionMatrix;
+    float4x4 u_worldMatrix;
+    float4 u_colour;
 };
 
-struct PNUVSOutput
+constant float2 _34 = {};
+
+struct main0_out
 {
-  float4 pos [[position]];
-  float2 uv;
-  float3 normal;
-  float4 color;
+    float2 out_var_TEXCOORD0 [[user(locn0)]];
+    float3 out_var_NORMAL [[user(locn1)]];
+    float4 out_var_COLOR0 [[user(locn2)]];
+    float2 out_var_TEXCOORD1 [[user(locn3)]];
+    float4 gl_Position [[position]];
 };
 
-struct PNUVSUniforms1
+struct main0_in
 {
-  float4x4 u_worldViewProjectionMatrix;
-  float4x4 u_worldMatrix;
-  float4 u_color;
+    float3 in_var_POSITION [[attribute(0)]];
+    float3 in_var_NORMAL [[attribute(1)]];
+    float2 in_var_TEXCOORD0 [[attribute(2)]];
 };
 
-vertex PNUVSOutput
-main0(PNUVSInput in [[stage_in]], constant PNUVSUniforms1& PNUVS1 [[buffer(1)]])
+vertex main0_out main0(main0_in in [[stage_in]], constant type_u_EveryObject& u_EveryObject [[buffer(0)]])
 {
-  PNUVSOutput out;
-
-  // making the assumption that the model matrix won't contain non-uniform scale
-  float3 worldNormal = normalize((PNUVS1.u_worldMatrix * float4(in.normal, 0.0)).xyz);
-
-  out.pos = PNUVS1.u_worldViewProjectionMatrix * float4(in.pos, 1.0);
-  out.uv = in.uv;
-  out.normal = worldNormal;
-  out.color = PNUVS1.u_color;
-  
-  return out;
+    main0_out out = {};
+    float4 _54 = u_EveryObject.u_worldViewProjectionMatrix * float4(in.in_var_POSITION, 1.0);
+    float2 _59 = _34;
+    _59.x = 1.0 + _54.w;
+    out.gl_Position = _54;
+    out.out_var_TEXCOORD0 = in.in_var_TEXCOORD0;
+    out.out_var_NORMAL = normalize((u_EveryObject.u_worldMatrix * float4(in.in_var_NORMAL, 0.0)).xyz);
+    out.out_var_COLOR0 = u_EveryObject.u_colour;
+    out.out_var_TEXCOORD1 = _59;
+    return out;
 }
+

--- a/src/gl/metal/shaders/mobile/postEffectsFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/postEffectsFragmentShader.metal
@@ -1,539 +1,539 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
 constant float _66 = {};
 constant float2 _67 = {};
 constant float2 _68 = {};
 
-struct PEFOutput
+struct main0_out
 {
-  float4 out_var_SV_Target [[color(0)]];
+    float4 out_var_SV_Target [[color(0)]];
 };
 
-struct PEFInput
+struct main0_in
 {
-  float2 in_var_TEXCOORD0 [[user(locn0)]];
-  float2 in_var_TEXCOORD1 [[user(locn1)]];
-  float2 in_var_TEXCOORD2 [[user(locn2)]];
-  float2 in_var_TEXCOORD3 [[user(locn3)]];
-  float2 in_var_TEXCOORD4 [[user(locn4)]];
-  float2 in_var_TEXCOORD5 [[user(locn5)]];
-  float in_var_TEXCOORD6 [[user(locn6)]];
+    float2 in_var_TEXCOORD0 [[user(locn0)]];
+    float2 in_var_TEXCOORD1 [[user(locn1)]];
+    float2 in_var_TEXCOORD2 [[user(locn2)]];
+    float2 in_var_TEXCOORD3 [[user(locn3)]];
+    float2 in_var_TEXCOORD4 [[user(locn4)]];
+    float2 in_var_TEXCOORD5 [[user(locn5)]];
+    float in_var_TEXCOORD6 [[user(locn6)]];
 };
 
-fragment PEFOutput main0(PEFInput in [[stage_in]], texture2d<float> texture0 [[texture(0)]], texture2d<float> texture1 [[texture(1)]], sampler sampler0 [[sampler(0)]], sampler sampler1 [[sampler(1)]])
+fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> texture0 [[texture(0)]], texture2d<float> texture1 [[texture(1)]], sampler sampler0 [[sampler(0)]], sampler sampler1 [[sampler(1)]])
 {
-  PEFOutput out = {};
-  float4 _80 = texture1.sample(sampler1, in.in_var_TEXCOORD0);
-  float _81 = _80.x;
-  float4 _535;
-  if ((1.0 - (((step(abs(texture1.sample(sampler1, in.in_var_TEXCOORD1).x - _81), 0.0030000000260770320892333984375) * step(abs(texture1.sample(sampler1, in.in_var_TEXCOORD2).x - _81), 0.0030000000260770320892333984375)) * step(abs(texture1.sample(sampler1, in.in_var_TEXCOORD3).x - _81), 0.0030000000260770320892333984375)) * step(abs(texture1.sample(sampler1, in.in_var_TEXCOORD4).x - _81), 0.0030000000260770320892333984375))) == 0.0)
-  {
-    _535 = texture0.sample(sampler0, in.in_var_TEXCOORD0);
-  }
-  else
-  {
-    float4 _534;
-    switch (0u)
+    main0_out out = {};
+    float4 _80 = texture1.sample(sampler1, in.in_var_TEXCOORD0);
+    float _81 = _80.x;
+    float4 _535;
+    if ((1.0 - (((step(abs(texture1.sample(sampler1, in.in_var_TEXCOORD1).x - _81), 0.0030000000260770320892333984375) * step(abs(texture1.sample(sampler1, in.in_var_TEXCOORD2).x - _81), 0.0030000000260770320892333984375)) * step(abs(texture1.sample(sampler1, in.in_var_TEXCOORD3).x - _81), 0.0030000000260770320892333984375)) * step(abs(texture1.sample(sampler1, in.in_var_TEXCOORD4).x - _81), 0.0030000000260770320892333984375))) == 0.0)
     {
-      default:
-      {
-        float2 _123 = _67;
-        _123.x = in.in_var_TEXCOORD0.x;
-        float2 _125 = _123;
-        _125.y = in.in_var_TEXCOORD0.y;
-        float4 _127 = texture0.sample(sampler0, _125, level(0.0));
-        float4 _129 = texture0.sample(sampler0, _125, level(0.0), int2(0, 1));
-        float _130 = _129.y;
-        float4 _132 = texture0.sample(sampler0, _125, level(0.0), int2(1, 0));
-        float _133 = _132.y;
-        float4 _135 = texture0.sample(sampler0, _125, level(0.0), int2(0, -1));
-        float _136 = _135.y;
-        float4 _138 = texture0.sample(sampler0, _125, level(0.0), int2(-1, 0));
-        float _139 = _138.y;
-        float _140 = _127.y;
-        float _147 = fast::max(fast::max(_136, _139), fast::max(_133, fast::max(_130, _140)));
-        float _150 = _147 - fast::min(fast::min(_136, _139), fast::min(_133, fast::min(_130, _140)));
-        if (_150 < fast::max(0.0, _147 * 0.125))
-        {
-          _534 = _127;
-          break;
-        }
-        float4 _156 = texture0.sample(sampler0, _125, level(0.0), int2(-1));
-        float _157 = _156.y;
-        float4 _159 = texture0.sample(sampler0, _125, level(0.0), int2(1));
-        float _160 = _159.y;
-        float4 _162 = texture0.sample(sampler0, _125, level(0.0), int2(1, -1));
-        float _163 = _162.y;
-        float4 _165 = texture0.sample(sampler0, _125, level(0.0), int2(-1, 1));
-        float _166 = _165.y;
-        float _167 = _136 + _130;
-        float _168 = _139 + _133;
-        float _171 = (-2.0) * _140;
-        float _174 = _163 + _160;
-        float _180 = _157 + _166;
-        bool _200 = (abs(((-2.0) * _139) + _180) + ((abs(_171 + _167) * 2.0) + abs(((-2.0) * _133) + _174))) >= (abs(((-2.0) * _130) + (_166 + _160)) + ((abs(_171 + _168) * 2.0) + abs(((-2.0) * _136) + (_157 + _163))));
-        bool _203 = !_200;
-        float _204 = _203 ? _139 : _136;
-        float _205 = _203 ? _133 : _130;
-        float _209;
-        if (_200)
-        {
-          _209 = in.in_var_TEXCOORD5.y;
-        }
-        else
-        {
-          _209 = in.in_var_TEXCOORD5.x;
-        }
-        float _216 = abs(_204 - _140);
-        float _217 = abs(_205 - _140);
-        bool _218 = _216 >= _217;
-        float _223;
-        if (_218)
-        {
-          _223 = -_209;
-        }
-        else
-        {
-          _223 = _209;
-        }
-        float _226 = fast::clamp(abs(((((_167 + _168) * 2.0) + (_180 + _174)) * 0.083333335816860198974609375) - _140) * (1.0 / _150), 0.0, 1.0);
-        float _227 = _203 ? 0.0 : in.in_var_TEXCOORD5.x;
-        float _229 = _200 ? 0.0 : in.in_var_TEXCOORD5.y;
-        float2 _235;
-        if (_203)
-        {
-          float2 _234 = _125;
-          _234.x = in.in_var_TEXCOORD0.x + (_223 * 0.5);
-          _235 = _234;
-        }
-        else
-        {
-          _235 = _125;
-        }
-        float2 _242;
-        if (_200)
-        {
-          float2 _241 = _235;
-          _241.y = _235.y + (_223 * 0.5);
-          _242 = _241;
-        }
-        else
-        {
-          _242 = _235;
-        }
-        float _244 = _242.x - _227;
-        float2 _245 = _67;
-        _245.x = _244;
-        float2 _248 = _245;
-        _248.y = _242.y - _229;
-        float _249 = _242.x + _227;
-        float2 _250 = _67;
-        _250.x = _249;
-        float2 _252 = _250;
-        _252.y = _242.y + _229;
-        float _264 = fast::max(_216, _217) * 0.25;
-        float _265 = ((!_218) ? (_205 + _140) : (_204 + _140)) * 0.5;
-        float _267 = (((-2.0) * _226) + 3.0) * (_226 * _226);
-        bool _268 = (_140 - _265) < 0.0;
-        float _269 = texture0.sample(sampler0, _248, level(0.0)).y - _265;
-        float _270 = texture0.sample(sampler0, _252, level(0.0)).y - _265;
-        bool _275 = !(abs(_269) >= _264);
-        float2 _281;
-        if (_275)
-        {
-          float2 _280 = _248;
-          _280.x = _244 - (_227 * 1.5);
-          _281 = _280;
-        }
-        else
-        {
-          _281 = _248;
-        }
-        float2 _288;
-        if (_275)
-        {
-          float2 _287 = _281;
-          _287.y = _281.y - (_229 * 1.5);
-          _288 = _287;
-        }
-        else
-        {
-          _288 = _281;
-        }
-        bool _289 = !(abs(_270) >= _264);
-        float2 _296;
-        if (_289)
-        {
-          float2 _295 = _252;
-          _295.x = _249 + (_227 * 1.5);
-          _296 = _295;
-        }
-        else
-        {
-          _296 = _252;
-        }
-        float2 _303;
-        if (_289)
-        {
-          float2 _302 = _296;
-          _302.y = _296.y + (_229 * 1.5);
-          _303 = _302;
-        }
-        else
-        {
-          _303 = _296;
-        }
-        float2 _482;
-        float2 _483;
-        float _484;
-        float _485;
-        if (_275 || _289)
-        {
-          float _311;
-          if (_275)
-          {
-            _311 = texture0.sample(sampler0, _288, level(0.0)).y;
-          }
-          else
-          {
-            _311 = _269;
-          }
-          float _317;
-          if (_289)
-          {
-            _317 = texture0.sample(sampler0, _303, level(0.0)).y;
-          }
-          else
-          {
-            _317 = _270;
-          }
-          float _321;
-          if (_275)
-          {
-            _321 = _311 - _265;
-          }
-          else
-          {
-            _321 = _311;
-          }
-          float _325;
-          if (_289)
-          {
-            _325 = _317 - _265;
-          }
-          else
-          {
-            _325 = _317;
-          }
-          bool _330 = !(abs(_321) >= _264);
-          float2 _337;
-          if (_330)
-          {
-            float2 _336 = _288;
-            _336.x = _288.x - (_227 * 2.0);
-            _337 = _336;
-          }
-          else
-          {
-            _337 = _288;
-          }
-          float2 _344;
-          if (_330)
-          {
-            float2 _343 = _337;
-            _343.y = _337.y - (_229 * 2.0);
-            _344 = _343;
-          }
-          else
-          {
-            _344 = _337;
-          }
-          bool _345 = !(abs(_325) >= _264);
-          float2 _353;
-          if (_345)
-          {
-            float2 _352 = _303;
-            _352.x = _303.x + (_227 * 2.0);
-            _353 = _352;
-          }
-          else
-          {
-            _353 = _303;
-          }
-          float2 _360;
-          if (_345)
-          {
-            float2 _359 = _353;
-            _359.y = _353.y + (_229 * 2.0);
-            _360 = _359;
-          }
-          else
-          {
-            _360 = _353;
-          }
-          float2 _478;
-          float2 _479;
-          float _480;
-          float _481;
-          if (_330 || _345)
-          {
-            float _368;
-            if (_330)
-            {
-              _368 = texture0.sample(sampler0, _344, level(0.0)).y;
-            }
-            else
-            {
-              _368 = _321;
-            }
-            float _374;
-            if (_345)
-            {
-              _374 = texture0.sample(sampler0, _360, level(0.0)).y;
-            }
-            else
-            {
-              _374 = _325;
-            }
-            float _378;
-            if (_330)
-            {
-              _378 = _368 - _265;
-            }
-            else
-            {
-              _378 = _368;
-            }
-            float _382;
-            if (_345)
-            {
-              _382 = _374 - _265;
-            }
-            else
-            {
-              _382 = _374;
-            }
-            bool _387 = !(abs(_378) >= _264);
-            float2 _394;
-            if (_387)
-            {
-              float2 _393 = _344;
-              _393.x = _344.x - (_227 * 4.0);
-              _394 = _393;
-            }
-            else
-            {
-              _394 = _344;
-            }
-            float2 _401;
-            if (_387)
-            {
-              float2 _400 = _394;
-              _400.y = _394.y - (_229 * 4.0);
-              _401 = _400;
-            }
-            else
-            {
-              _401 = _394;
-            }
-            bool _402 = !(abs(_382) >= _264);
-            float2 _410;
-            if (_402)
-            {
-              float2 _409 = _360;
-              _409.x = _360.x + (_227 * 4.0);
-              _410 = _409;
-            }
-            else
-            {
-              _410 = _360;
-            }
-            float2 _417;
-            if (_402)
-            {
-              float2 _416 = _410;
-              _416.y = _410.y + (_229 * 4.0);
-              _417 = _416;
-            }
-            else
-            {
-              _417 = _410;
-            }
-            float2 _474;
-            float2 _475;
-            float _476;
-            float _477;
-            if (_387 || _402)
-            {
-              float _425;
-              if (_387)
-              {
-                _425 = texture0.sample(sampler0, _401, level(0.0)).y;
-              }
-              else
-              {
-                _425 = _378;
-              }
-              float _431;
-              if (_402)
-              {
-                _431 = texture0.sample(sampler0, _417, level(0.0)).y;
-              }
-              else
-              {
-                _431 = _382;
-              }
-              float _435;
-              if (_387)
-              {
-                _435 = _425 - _265;
-              }
-              else
-              {
-                _435 = _425;
-              }
-              float _439;
-              if (_402)
-              {
-                _439 = _431 - _265;
-              }
-              else
-              {
-                _439 = _431;
-              }
-              bool _444 = !(abs(_435) >= _264);
-              float2 _451;
-              if (_444)
-              {
-                float2 _450 = _401;
-                _450.x = _401.x - (_227 * 12.0);
-                _451 = _450;
-              }
-              else
-              {
-                _451 = _401;
-              }
-              float2 _458;
-              if (_444)
-              {
-                float2 _457 = _451;
-                _457.y = _451.y - (_229 * 12.0);
-                _458 = _457;
-              }
-              else
-              {
-                _458 = _451;
-              }
-              bool _459 = !(abs(_439) >= _264);
-              float2 _466;
-              if (_459)
-              {
-                float2 _465 = _417;
-                _465.x = _417.x + (_227 * 12.0);
-                _466 = _465;
-              }
-              else
-              {
-                _466 = _417;
-              }
-              float2 _473;
-              if (_459)
-              {
-                float2 _472 = _466;
-                _472.y = _466.y + (_229 * 12.0);
-                _473 = _472;
-              }
-              else
-              {
-                _473 = _466;
-              }
-              _474 = _473;
-              _475 = _458;
-              _476 = _439;
-              _477 = _435;
-            }
-            else
-            {
-              _474 = _417;
-              _475 = _401;
-              _476 = _382;
-              _477 = _378;
-            }
-            _478 = _474;
-            _479 = _475;
-            _480 = _476;
-            _481 = _477;
-          }
-          else
-          {
-            _478 = _360;
-            _479 = _344;
-            _480 = _325;
-            _481 = _321;
-          }
-          _482 = _478;
-          _483 = _479;
-          _484 = _480;
-          _485 = _481;
-        }
-        else
-        {
-          _482 = _303;
-          _483 = _288;
-          _484 = _270;
-          _485 = _269;
-        }
-        float _494;
-        if (_203)
-        {
-          _494 = in.in_var_TEXCOORD0.y - _483.y;
-        }
-        else
-        {
-          _494 = in.in_var_TEXCOORD0.x - _483.x;
-        }
-        float _499;
-        if (_203)
-        {
-          _499 = _482.y - in.in_var_TEXCOORD0.y;
-        }
-        else
-        {
-          _499 = _482.x - in.in_var_TEXCOORD0.x;
-        }
-        float _514 = fast::max(((_494 < _499) ? ((_485 < 0.0) != _268) : ((_484 < 0.0) != _268)) ? ((fast::min(_494, _499) * ((-1.0) / (_499 + _494))) + 0.5) : 0.0, (_267 * _267) * 0.75);
-        float2 _520;
-        if (_203)
-        {
-          float2 _519 = _125;
-          _519.x = in.in_var_TEXCOORD0.x + (_514 * _223);
-          _520 = _519;
-        }
-        else
-        {
-          _520 = _125;
-        }
-        float2 _527;
-        if (_200)
-        {
-          float2 _526 = _520;
-          _526.y = _520.y + (_514 * _223);
-          _527 = _526;
-        }
-        else
-        {
-          _527 = _520;
-        }
-        _534 = float4(texture0.sample(sampler0, _527, level(0.0)).xyz, _66);
-        break;
-      }
+        _535 = texture0.sample(sampler0, in.in_var_TEXCOORD0);
     }
-    _535 = _534;
-  }
-  out.out_var_SV_Target = float4(mix(float3(dot(_535.xyz, float3(0.2125000059604644775390625, 0.7153999805450439453125, 0.07209999859333038330078125))), _535.xyz, float3(in.in_var_TEXCOORD6)), 1.0);
-  return out;
+    else
+    {
+        float4 _534;
+        switch (0u)
+        {
+            default:
+            {
+                float2 _123 = _67;
+                _123.x = in.in_var_TEXCOORD0.x;
+                float2 _125 = _123;
+                _125.y = in.in_var_TEXCOORD0.y;
+                float4 _127 = texture0.sample(sampler0, _125, level(0.0));
+                float4 _129 = texture0.sample(sampler0, _125, level(0.0), int2(0, 1));
+                float _130 = _129.y;
+                float4 _132 = texture0.sample(sampler0, _125, level(0.0), int2(1, 0));
+                float _133 = _132.y;
+                float4 _135 = texture0.sample(sampler0, _125, level(0.0), int2(0, -1));
+                float _136 = _135.y;
+                float4 _138 = texture0.sample(sampler0, _125, level(0.0), int2(-1, 0));
+                float _139 = _138.y;
+                float _140 = _127.y;
+                float _147 = fast::max(fast::max(_136, _139), fast::max(_133, fast::max(_130, _140)));
+                float _150 = _147 - fast::min(fast::min(_136, _139), fast::min(_133, fast::min(_130, _140)));
+                if (_150 < fast::max(0.0, _147 * 0.125))
+                {
+                    _534 = _127;
+                    break;
+                }
+                float4 _156 = texture0.sample(sampler0, _125, level(0.0), int2(-1));
+                float _157 = _156.y;
+                float4 _159 = texture0.sample(sampler0, _125, level(0.0), int2(1));
+                float _160 = _159.y;
+                float4 _162 = texture0.sample(sampler0, _125, level(0.0), int2(1, -1));
+                float _163 = _162.y;
+                float4 _165 = texture0.sample(sampler0, _125, level(0.0), int2(-1, 1));
+                float _166 = _165.y;
+                float _167 = _136 + _130;
+                float _168 = _139 + _133;
+                float _171 = (-2.0) * _140;
+                float _174 = _163 + _160;
+                float _180 = _157 + _166;
+                bool _200 = (abs(((-2.0) * _139) + _180) + ((abs(_171 + _167) * 2.0) + abs(((-2.0) * _133) + _174))) >= (abs(((-2.0) * _130) + (_166 + _160)) + ((abs(_171 + _168) * 2.0) + abs(((-2.0) * _136) + (_157 + _163))));
+                bool _203 = !_200;
+                float _204 = _203 ? _139 : _136;
+                float _205 = _203 ? _133 : _130;
+                float _209;
+                if (_200)
+                {
+                    _209 = in.in_var_TEXCOORD5.y;
+                }
+                else
+                {
+                    _209 = in.in_var_TEXCOORD5.x;
+                }
+                float _216 = abs(_204 - _140);
+                float _217 = abs(_205 - _140);
+                bool _218 = _216 >= _217;
+                float _223;
+                if (_218)
+                {
+                    _223 = -_209;
+                }
+                else
+                {
+                    _223 = _209;
+                }
+                float _226 = fast::clamp(abs(((((_167 + _168) * 2.0) + (_180 + _174)) * 0.083333335816860198974609375) - _140) * (1.0 / _150), 0.0, 1.0);
+                float _227 = _203 ? 0.0 : in.in_var_TEXCOORD5.x;
+                float _229 = _200 ? 0.0 : in.in_var_TEXCOORD5.y;
+                float2 _235;
+                if (_203)
+                {
+                    float2 _234 = _125;
+                    _234.x = in.in_var_TEXCOORD0.x + (_223 * 0.5);
+                    _235 = _234;
+                }
+                else
+                {
+                    _235 = _125;
+                }
+                float2 _242;
+                if (_200)
+                {
+                    float2 _241 = _235;
+                    _241.y = _235.y + (_223 * 0.5);
+                    _242 = _241;
+                }
+                else
+                {
+                    _242 = _235;
+                }
+                float _244 = _242.x - _227;
+                float2 _245 = _67;
+                _245.x = _244;
+                float2 _248 = _245;
+                _248.y = _242.y - _229;
+                float _249 = _242.x + _227;
+                float2 _250 = _67;
+                _250.x = _249;
+                float2 _252 = _250;
+                _252.y = _242.y + _229;
+                float _264 = fast::max(_216, _217) * 0.25;
+                float _265 = ((!_218) ? (_205 + _140) : (_204 + _140)) * 0.5;
+                float _267 = (((-2.0) * _226) + 3.0) * (_226 * _226);
+                bool _268 = (_140 - _265) < 0.0;
+                float _269 = texture0.sample(sampler0, _248, level(0.0)).y - _265;
+                float _270 = texture0.sample(sampler0, _252, level(0.0)).y - _265;
+                bool _275 = !(abs(_269) >= _264);
+                float2 _281;
+                if (_275)
+                {
+                    float2 _280 = _248;
+                    _280.x = _244 - (_227 * 1.5);
+                    _281 = _280;
+                }
+                else
+                {
+                    _281 = _248;
+                }
+                float2 _288;
+                if (_275)
+                {
+                    float2 _287 = _281;
+                    _287.y = _281.y - (_229 * 1.5);
+                    _288 = _287;
+                }
+                else
+                {
+                    _288 = _281;
+                }
+                bool _289 = !(abs(_270) >= _264);
+                float2 _296;
+                if (_289)
+                {
+                    float2 _295 = _252;
+                    _295.x = _249 + (_227 * 1.5);
+                    _296 = _295;
+                }
+                else
+                {
+                    _296 = _252;
+                }
+                float2 _303;
+                if (_289)
+                {
+                    float2 _302 = _296;
+                    _302.y = _296.y + (_229 * 1.5);
+                    _303 = _302;
+                }
+                else
+                {
+                    _303 = _296;
+                }
+                float2 _482;
+                float2 _483;
+                float _484;
+                float _485;
+                if (_275 || _289)
+                {
+                    float _311;
+                    if (_275)
+                    {
+                        _311 = texture0.sample(sampler0, _288, level(0.0)).y;
+                    }
+                    else
+                    {
+                        _311 = _269;
+                    }
+                    float _317;
+                    if (_289)
+                    {
+                        _317 = texture0.sample(sampler0, _303, level(0.0)).y;
+                    }
+                    else
+                    {
+                        _317 = _270;
+                    }
+                    float _321;
+                    if (_275)
+                    {
+                        _321 = _311 - _265;
+                    }
+                    else
+                    {
+                        _321 = _311;
+                    }
+                    float _325;
+                    if (_289)
+                    {
+                        _325 = _317 - _265;
+                    }
+                    else
+                    {
+                        _325 = _317;
+                    }
+                    bool _330 = !(abs(_321) >= _264);
+                    float2 _337;
+                    if (_330)
+                    {
+                        float2 _336 = _288;
+                        _336.x = _288.x - (_227 * 2.0);
+                        _337 = _336;
+                    }
+                    else
+                    {
+                        _337 = _288;
+                    }
+                    float2 _344;
+                    if (_330)
+                    {
+                        float2 _343 = _337;
+                        _343.y = _337.y - (_229 * 2.0);
+                        _344 = _343;
+                    }
+                    else
+                    {
+                        _344 = _337;
+                    }
+                    bool _345 = !(abs(_325) >= _264);
+                    float2 _353;
+                    if (_345)
+                    {
+                        float2 _352 = _303;
+                        _352.x = _303.x + (_227 * 2.0);
+                        _353 = _352;
+                    }
+                    else
+                    {
+                        _353 = _303;
+                    }
+                    float2 _360;
+                    if (_345)
+                    {
+                        float2 _359 = _353;
+                        _359.y = _353.y + (_229 * 2.0);
+                        _360 = _359;
+                    }
+                    else
+                    {
+                        _360 = _353;
+                    }
+                    float2 _478;
+                    float2 _479;
+                    float _480;
+                    float _481;
+                    if (_330 || _345)
+                    {
+                        float _368;
+                        if (_330)
+                        {
+                            _368 = texture0.sample(sampler0, _344, level(0.0)).y;
+                        }
+                        else
+                        {
+                            _368 = _321;
+                        }
+                        float _374;
+                        if (_345)
+                        {
+                            _374 = texture0.sample(sampler0, _360, level(0.0)).y;
+                        }
+                        else
+                        {
+                            _374 = _325;
+                        }
+                        float _378;
+                        if (_330)
+                        {
+                            _378 = _368 - _265;
+                        }
+                        else
+                        {
+                            _378 = _368;
+                        }
+                        float _382;
+                        if (_345)
+                        {
+                            _382 = _374 - _265;
+                        }
+                        else
+                        {
+                            _382 = _374;
+                        }
+                        bool _387 = !(abs(_378) >= _264);
+                        float2 _394;
+                        if (_387)
+                        {
+                            float2 _393 = _344;
+                            _393.x = _344.x - (_227 * 4.0);
+                            _394 = _393;
+                        }
+                        else
+                        {
+                            _394 = _344;
+                        }
+                        float2 _401;
+                        if (_387)
+                        {
+                            float2 _400 = _394;
+                            _400.y = _394.y - (_229 * 4.0);
+                            _401 = _400;
+                        }
+                        else
+                        {
+                            _401 = _394;
+                        }
+                        bool _402 = !(abs(_382) >= _264);
+                        float2 _410;
+                        if (_402)
+                        {
+                            float2 _409 = _360;
+                            _409.x = _360.x + (_227 * 4.0);
+                            _410 = _409;
+                        }
+                        else
+                        {
+                            _410 = _360;
+                        }
+                        float2 _417;
+                        if (_402)
+                        {
+                            float2 _416 = _410;
+                            _416.y = _410.y + (_229 * 4.0);
+                            _417 = _416;
+                        }
+                        else
+                        {
+                            _417 = _410;
+                        }
+                        float2 _474;
+                        float2 _475;
+                        float _476;
+                        float _477;
+                        if (_387 || _402)
+                        {
+                            float _425;
+                            if (_387)
+                            {
+                                _425 = texture0.sample(sampler0, _401, level(0.0)).y;
+                            }
+                            else
+                            {
+                                _425 = _378;
+                            }
+                            float _431;
+                            if (_402)
+                            {
+                                _431 = texture0.sample(sampler0, _417, level(0.0)).y;
+                            }
+                            else
+                            {
+                                _431 = _382;
+                            }
+                            float _435;
+                            if (_387)
+                            {
+                                _435 = _425 - _265;
+                            }
+                            else
+                            {
+                                _435 = _425;
+                            }
+                            float _439;
+                            if (_402)
+                            {
+                                _439 = _431 - _265;
+                            }
+                            else
+                            {
+                                _439 = _431;
+                            }
+                            bool _444 = !(abs(_435) >= _264);
+                            float2 _451;
+                            if (_444)
+                            {
+                                float2 _450 = _401;
+                                _450.x = _401.x - (_227 * 12.0);
+                                _451 = _450;
+                            }
+                            else
+                            {
+                                _451 = _401;
+                            }
+                            float2 _458;
+                            if (_444)
+                            {
+                                float2 _457 = _451;
+                                _457.y = _451.y - (_229 * 12.0);
+                                _458 = _457;
+                            }
+                            else
+                            {
+                                _458 = _451;
+                            }
+                            bool _459 = !(abs(_439) >= _264);
+                            float2 _466;
+                            if (_459)
+                            {
+                                float2 _465 = _417;
+                                _465.x = _417.x + (_227 * 12.0);
+                                _466 = _465;
+                            }
+                            else
+                            {
+                                _466 = _417;
+                            }
+                            float2 _473;
+                            if (_459)
+                            {
+                                float2 _472 = _466;
+                                _472.y = _466.y + (_229 * 12.0);
+                                _473 = _472;
+                            }
+                            else
+                            {
+                                _473 = _466;
+                            }
+                            _474 = _473;
+                            _475 = _458;
+                            _476 = _439;
+                            _477 = _435;
+                        }
+                        else
+                        {
+                            _474 = _417;
+                            _475 = _401;
+                            _476 = _382;
+                            _477 = _378;
+                        }
+                        _478 = _474;
+                        _479 = _475;
+                        _480 = _476;
+                        _481 = _477;
+                    }
+                    else
+                    {
+                        _478 = _360;
+                        _479 = _344;
+                        _480 = _325;
+                        _481 = _321;
+                    }
+                    _482 = _478;
+                    _483 = _479;
+                    _484 = _480;
+                    _485 = _481;
+                }
+                else
+                {
+                    _482 = _303;
+                    _483 = _288;
+                    _484 = _270;
+                    _485 = _269;
+                }
+                float _494;
+                if (_203)
+                {
+                    _494 = in.in_var_TEXCOORD0.y - _483.y;
+                }
+                else
+                {
+                    _494 = in.in_var_TEXCOORD0.x - _483.x;
+                }
+                float _499;
+                if (_203)
+                {
+                    _499 = _482.y - in.in_var_TEXCOORD0.y;
+                }
+                else
+                {
+                    _499 = _482.x - in.in_var_TEXCOORD0.x;
+                }
+                float _514 = fast::max(((_494 < _499) ? ((_485 < 0.0) != _268) : ((_484 < 0.0) != _268)) ? ((fast::min(_494, _499) * ((-1.0) / (_499 + _494))) + 0.5) : 0.0, (_267 * _267) * 0.75);
+                float2 _520;
+                if (_203)
+                {
+                    float2 _519 = _125;
+                    _519.x = in.in_var_TEXCOORD0.x + (_514 * _223);
+                    _520 = _519;
+                }
+                else
+                {
+                    _520 = _125;
+                }
+                float2 _527;
+                if (_200)
+                {
+                    float2 _526 = _520;
+                    _526.y = _520.y + (_514 * _223);
+                    _527 = _526;
+                }
+                else
+                {
+                    _527 = _520;
+                }
+                _534 = float4(texture0.sample(sampler0, _527, level(0.0)).xyz, _66);
+                break;
+            }
+        }
+        _535 = _534;
+    }
+    out.out_var_SV_Target = float4(mix(float3(dot(_535.xyz, float3(0.2125000059604644775390625, 0.7153999805450439453125, 0.07209999859333038330078125))), _535.xyz, float3(in.in_var_TEXCOORD6)), 1.0);
+    return out;
 }
+

--- a/src/gl/metal/shaders/mobile/postEffectsVertexShader.metal
+++ b/src/gl/metal/shaders/mobile/postEffectsVertexShader.metal
@@ -1,43 +1,43 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct PEVParams
+struct type_u_params
 {
-  float4 u_screenParams;
-  float4 u_saturation;
+    float4 u_screenParams;
+    float4 u_saturation;
 };
 
-struct PEVOutput
+struct main0_out
 {
-  float2 out_var_TEXCOORD0 [[user(locn0)]];
-  float2 out_var_TEXCOORD1 [[user(locn1)]];
-  float2 out_var_TEXCOORD2 [[user(locn2)]];
-  float2 out_var_TEXCOORD3 [[user(locn3)]];
-  float2 out_var_TEXCOORD4 [[user(locn4)]];
-  float2 out_var_TEXCOORD5 [[user(locn5)]];
-  float out_var_TEXCOORD6 [[user(locn6)]];
-  float4 gl_Position [[position]];
+    float2 out_var_TEXCOORD0 [[user(locn0)]];
+    float2 out_var_TEXCOORD1 [[user(locn1)]];
+    float2 out_var_TEXCOORD2 [[user(locn2)]];
+    float2 out_var_TEXCOORD3 [[user(locn3)]];
+    float2 out_var_TEXCOORD4 [[user(locn4)]];
+    float2 out_var_TEXCOORD5 [[user(locn5)]];
+    float out_var_TEXCOORD6 [[user(locn6)]];
+    float4 gl_Position [[position]];
 };
 
-struct PEVInput
+struct main0_in
 {
-  float3 in_var_POSITION [[attribute(0)]];
-  float2 in_var_TEXCOORD0 [[attribute(1)]];
+    float3 in_var_POSITION [[attribute(0)]];
+    float2 in_var_TEXCOORD0 [[attribute(1)]];
 };
 
-vertex PEVOutput main0(PEVInput in [[stage_in]], constant PEVParams& u_params [[buffer(0)]])
+vertex main0_out main0(main0_in in [[stage_in]], constant type_u_params& u_params [[buffer(0)]])
 {
-  PEVOutput out = {};
-  out.gl_Position = float4(in.in_var_POSITION.xy, 0.0, 1.0);
-  out.out_var_TEXCOORD0 = in.in_var_TEXCOORD0;
-  out.out_var_TEXCOORD1 = in.in_var_TEXCOORD0 + u_params.u_screenParams.xy;
-  out.out_var_TEXCOORD2 = in.in_var_TEXCOORD0 - u_params.u_screenParams.xy;
-  out.out_var_TEXCOORD3 = in.in_var_TEXCOORD0 + float2(u_params.u_screenParams.x, -u_params.u_screenParams.y);
-  out.out_var_TEXCOORD4 = in.in_var_TEXCOORD0 + float2(-u_params.u_screenParams.x, u_params.u_screenParams.y);
-  out.out_var_TEXCOORD5 = u_params.u_screenParams.xy;
-  out.out_var_TEXCOORD6 = u_params.u_saturation.x;
-  return out;
+    main0_out out = {};
+    out.gl_Position = float4(in.in_var_POSITION.xy, 0.0, 1.0);
+    out.out_var_TEXCOORD0 = in.in_var_TEXCOORD0;
+    out.out_var_TEXCOORD1 = in.in_var_TEXCOORD0 + u_params.u_screenParams.xy;
+    out.out_var_TEXCOORD2 = in.in_var_TEXCOORD0 - u_params.u_screenParams.xy;
+    out.out_var_TEXCOORD3 = in.in_var_TEXCOORD0 + float2(u_params.u_screenParams.x, -u_params.u_screenParams.y);
+    out.out_var_TEXCOORD4 = in.in_var_TEXCOORD0 + float2(-u_params.u_screenParams.x, u_params.u_screenParams.y);
+    out.out_var_TEXCOORD5 = u_params.u_screenParams.xy;
+    out.out_var_TEXCOORD6 = u_params.u_saturation.x;
+    return out;
 }
+

--- a/src/gl/metal/shaders/mobile/tileFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/tileFragmentShader.metal
@@ -1,19 +1,34 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct PCU
+struct type_u_cameraPlaneParams
 {
-  float4 v_position [[position]];
-  float4 v_color;
-  float2 v_uv;
+    float s_CameraNearPlane;
+    float s_CameraFarPlane;
+    float u_clipZNear;
+    float u_clipZFar;
 };
 
-fragment float4
-main0(PCU in [[stage_in]], texture2d<float, access::sample> TFSimg [[texture(0)]], sampler TFSsampler [[sampler(0)]])
+struct main0_out
 {
-  float4 col = TFSimg.sample(TFSsampler, in.v_uv);
-  return float4(col.xyz * in.v_color.xyz, in.v_color.w);
+    float4 out_var_SV_Target [[color(0)]];
+    float gl_FragDepth [[depth(any)]];
 };
+
+struct main0_in
+{
+    float4 in_var_COLOR0 [[user(locn0)]];
+    float2 in_var_TEXCOORD0 [[user(locn1)]];
+    float2 in_var_TEXCOORD1 [[user(locn2)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], texture2d<float> texture0 [[texture(0)]], sampler sampler0 [[sampler(0)]])
+{
+    main0_out out = {};
+    out.out_var_SV_Target = float4(texture0.sample(sampler0, in.in_var_TEXCOORD0).xyz * in.in_var_COLOR0.xyz, in.in_var_COLOR0.w);
+    out.gl_FragDepth = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    return out;
+}
+

--- a/src/gl/metal/shaders/mobile/tileVertexShader.metal
+++ b/src/gl/metal/shaders/mobile/tileVertexShader.metal
@@ -1,40 +1,41 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-// This should match CPU struct size
-#define VERTEX_COUNT 2
-
-struct TVSInput
+struct type_u_EveryObject
 {
-  float3 a_uv [[attribute(0)]];
+    float4x4 u_projection;
+    float4 u_eyePositions[9];
+    float4 u_colour;
+    float4 u_uvOffsetScale;
 };
 
-struct PCU
+constant float2 _31 = {};
+
+struct main0_out
 {
-  float4 v_position [[position]];
-  float4 v_color;
-  float2 v_uv;
+    float4 out_var_COLOR0 [[user(locn0)]];
+    float2 out_var_TEXCOORD0 [[user(locn1)]];
+    float2 out_var_TEXCOORD1 [[user(locn2)]];
+    float4 gl_Position [[position]];
 };
 
-struct TVSUniforms
+struct main0_in
 {
-  float4x4 u_projection;
-  float4 u_eyePositions[VERTEX_COUNT * VERTEX_COUNT];
-  float4 u_color;
+    float3 in_var_POSITION [[attribute(0)]];
 };
 
-vertex PCU
-main0(TVSInput in [[stage_in]], constant TVSUniforms& uTVS [[buffer(1)]])
+vertex main0_out main0(main0_in in [[stage_in]], constant type_u_EveryObject& u_EveryObject [[buffer(0)]])
 {
-  PCU out;
-  
-  // TODO: could have precision issues on some devices
-  out.v_position = uTVS.u_projection * uTVS.u_eyePositions[int(in.a_uv.z)];
-  
-  out.v_uv = in.a_uv.xy;
-  out.v_color = uTVS.u_color;
-  return out;
+    main0_out out = {};
+    float4 _40 = u_EveryObject.u_projection * u_EveryObject.u_eyePositions[int(in.in_var_POSITION.z)];
+    float2 _52 = _31;
+    _52.x = 1.0 + _40.w;
+    out.gl_Position = _40;
+    out.out_var_COLOR0 = u_EveryObject.u_colour;
+    out.out_var_TEXCOORD0 = u_EveryObject.u_uvOffsetScale.xy + (u_EveryObject.u_uvOffsetScale.zw * in.in_var_POSITION.xy);
+    out.out_var_TEXCOORD1 = _52;
+    return out;
 }
+

--- a/src/gl/metal/shaders/mobile/udFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/udFragmentShader.metal
@@ -1,51 +1,24 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct UDVSOutput
+struct main0_out
 {
-  float4 v_position [[position]];
-  float2 uv;
+    float4 out_var_SV_Target [[color(0)]];
+    float gl_FragDepth [[depth(any)]];
 };
 
-struct UDFSUniforms
+struct main0_in
 {
-  float4 u_screenParams;
-  float4x4 u_inverseViewProjection;
-  float4 u_outlineColor;
-  float4 u_outlineParams;
-  float4 u_colorizeHeightColorMin;
-  float4 u_colorizeHeightColorMax;
-  float4 u_colorizeHeightParams;
-  float4 u_colorizeDepthColor;
-  float4 u_colorizeDepthParams;
-  float4 u_contourColor;
-  float4 u_contourParams;
+    float2 in_var_TEXCOORD0 [[user(locn0)]];
 };
 
-struct UDFSOutput
+fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> texture0 [[texture(0)]], texture2d<float> texture1 [[texture(1)]], sampler sampler0 [[sampler(0)]], sampler sampler1 [[sampler(1)]])
 {
-  float4 out_Color [[color(0)]];
-  float depth [[depth(any)]];
-};
-
-fragment UDFSOutput
-main0(UDVSOutput in [[stage_in]],
-                 constant UDFSUniforms& uUDFS [[buffer(1)]],
-                 texture2d<float, access::sample> UDFStexture [[texture(0)]],
-                 sampler UDFSsampler [[sampler(0)]],
-                 depth2d<float, access::sample> UDFSdepthTexture [[texture(1)]],
-                 sampler UDFSdepthSampler [[sampler(1)]])
-{
-  UDFSOutput out;
-  
-  float4 col = UDFStexture.sample(UDFSsampler, in.uv);
-  float depth = UDFSdepthTexture.sample(UDFSdepthSampler, in.uv);
-  
-  out.out_Color = float4(col.rgb, 1.0);// UD always opaque
-  out.depth = depth;
-  
-  return out;
+    main0_out out = {};
+    out.out_var_SV_Target = float4(texture0.sample(sampler0, in.in_var_TEXCOORD0).xyz, 1.0);
+    out.gl_FragDepth = texture1.sample(sampler1, in.in_var_TEXCOORD0).x;
+    return out;
 }
+

--- a/src/gl/metal/shaders/mobile/udSplatIdFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/udSplatIdFragmentShader.metal
@@ -1,43 +1,41 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct UDVSOutput
-{
-  float4 v_position [[position]];
-  float2 uv;
-};
-
-struct UDSOutput
-{
-    float4 color [[color(0)]];
-    float depth [[depth(any)]];
-};
-
-struct UDSUniforms
+struct type_u_params
 {
     float4 u_idOverride;
 };
 
-bool floatEquals(float a, float b)
+struct main0_out
 {
-    return abs(a - b) <= 0.0015f;
-}
+    float4 out_var_SV_Target [[color(0)]];
+    float gl_FragDepth [[depth(any)]];
+};
 
-fragment UDSOutput
-main0(UDVSOutput in [[stage_in]], constant UDSUniforms& uniforms [[buffer(1)]], texture2d<float, access::sample> UDSimg [[texture(0)]], sampler UDSSampler [[sampler(0)]], depth2d<float, access::sample> UDSimg2 [[texture(1)]], sampler UDSSampler2 [[sampler(1)]])
+struct main0_in
 {
-    UDSOutput out;
-    float4 col = UDSimg.sample(UDSSampler, in.uv);
-    out.depth = UDSimg2.sample(UDSSampler2, in.uv);
-    
-    out.color = float4(0.0, 0.0, 0.0, 0.0);
-    if ((uniforms.u_idOverride.w == 0.0 || floatEquals(uniforms.u_idOverride.w, col.w)))
+    float2 in_var_TEXCOORD0 [[user(locn0)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], constant type_u_params& u_params [[buffer(0)]], texture2d<float> texture0 [[texture(0)]], texture2d<float> texture1 [[texture(1)]], sampler sampler0 [[sampler(0)]], sampler sampler1 [[sampler(1)]])
+{
+    main0_out out = {};
+    float4 _42 = texture0.sample(sampler0, in.in_var_TEXCOORD0);
+    float4 _46 = texture1.sample(sampler1, in.in_var_TEXCOORD0);
+    float _51 = _42.w;
+    float4 _59;
+    if ((u_params.u_idOverride.w == 0.0) || (abs(u_params.u_idOverride.w - _51) <= 0.00150000001303851604461669921875))
     {
-        out.color = float4(col.w, 0, 0, 1.0);
+        _59 = float4(_51, 0.0, 0.0, 1.0);
     }
-    
+    else
+    {
+        _59 = float4(0.0);
+    }
+    out.out_var_SV_Target = _59;
+    out.gl_FragDepth = _46.x;
     return out;
 }
+

--- a/src/gl/metal/shaders/mobile/udVertexShader.metal
+++ b/src/gl/metal/shaders/mobile/udVertexShader.metal
@@ -1,26 +1,25 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct UDVSInput
+struct main0_out
 {
-  float3 a_position [[attribute(0)]];
-  float2 a_texCoord [[attribute(1)]];
+    float2 out_var_TEXCOORD0 [[user(locn0)]];
+    float4 gl_Position [[position]];
 };
 
-struct UDVSOutput
+struct main0_in
 {
-  float4 v_position [[position]];
-  float2 uv;
+    float3 in_var_POSITION [[attribute(0)]];
+    float2 in_var_TEXCOORD0 [[attribute(1)]];
 };
 
-vertex UDVSOutput
-main0(UDVSInput in [[stage_in]])
+vertex main0_out main0(main0_in in [[stage_in]])
 {
-  UDVSOutput out;
-  out.v_position = float4(in.a_position.xy, 0.0, 1.0);
-  out.uv = in.a_texCoord;
-  return out;
+    main0_out out = {};
+    out.gl_Position = float4(in.in_var_POSITION.xy, 0.0, 1.0);
+    out.out_var_TEXCOORD0 = in.in_var_TEXCOORD0;
+    return out;
 }
+

--- a/src/gl/metal/shaders/mobile/visualizationVertexShader.metal
+++ b/src/gl/metal/shaders/mobile/visualizationVertexShader.metal
@@ -1,26 +1,44 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct VVSInput
+struct type_u_vertParams
 {
-  float3 a_position [[attribute(0)]];
-  float2 a_texCoord [[attribute(1)]];
+    float4 u_outlineStepSize;
 };
 
-struct VVSOutput
+struct main0_out
 {
-  float4 v_position [[position]];
-  float2 uv;
+    float4 out_var_TEXCOORD0 [[user(locn0)]];
+    float2 out_var_TEXCOORD1 [[user(locn1)]];
+    float2 out_var_TEXCOORD2 [[user(locn2)]];
+    float2 out_var_TEXCOORD3 [[user(locn3)]];
+    float2 out_var_TEXCOORD4 [[user(locn4)]];
+    float2 out_var_TEXCOORD5 [[user(locn5)]];
+    float4 gl_Position [[position]];
 };
 
-vertex VVSOutput
-main0(VVSInput in [[stage_in]])
+struct main0_in
 {
-  VVSOutput out;
-  out.v_position = float4(in.a_position.xy, 0.0, 1.0);
-  out.uv = in.a_texCoord;
-  return out;
+    float3 in_var_POSITION [[attribute(0)]];
+    float2 in_var_TEXCOORD0 [[attribute(1)]];
+};
+
+vertex main0_out main0(main0_in in [[stage_in]], constant type_u_vertParams& u_vertParams [[buffer(0)]])
+{
+    main0_out out = {};
+    float4 _34 = float4(in.in_var_POSITION.xy, 0.0, 1.0);
+    float3 _39 = float3(u_vertParams.u_outlineStepSize.xy, 0.0);
+    float2 _40 = _39.xz;
+    float2 _43 = _39.zy;
+    out.gl_Position = _34;
+    out.out_var_TEXCOORD0 = _34;
+    out.out_var_TEXCOORD1 = in.in_var_TEXCOORD0;
+    out.out_var_TEXCOORD2 = in.in_var_TEXCOORD0 + _40;
+    out.out_var_TEXCOORD3 = in.in_var_TEXCOORD0 - _40;
+    out.out_var_TEXCOORD4 = in.in_var_TEXCOORD0 + _43;
+    out.out_var_TEXCOORD5 = in.in_var_TEXCOORD0 - _43;
+    return out;
 }
+

--- a/src/gl/metal/shaders/mobile/waterFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/waterFragmentShader.metal
@@ -1,63 +1,37 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct WVSOutput
+struct type_u_EveryFrameFrag
 {
-  float4 pos [[position]];
-  float2 uv0;
-  float2 uv1;
-  float4 fragEyePos;
-  float3 color;
+    float4 u_specularDir;
+    float4x4 u_eyeNormalMatrix;
+    float4x4 u_inverseViewMatrix;
 };
 
-// g_WaterFragmentShader
-struct WFSUniforms
+struct main0_out
 {
-  float4 u_specularDir;
-  float4x4 u_eyeNormalMatrix;
-  float4x4 u_inverseViewMatrix;
+    float4 out_var_SV_Target [[color(0)]];
 };
 
-float2 directionToLatLong(float3 dir)
+struct main0_in
 {
-  float2 longlat = float2(atan2(dir.x, dir.y) + M_PI_F, acos(dir.z));
-  return longlat / float2(2.0 * M_PI_F, M_PI_F);
+    float2 in_var_TEXCOORD0 [[user(locn0)]];
+    float2 in_var_TEXCOORD1 [[user(locn1)]];
+    float4 in_var_COLOR0 [[user(locn2)]];
+    float4 in_var_COLOR1 [[user(locn3)]];
+};
+
+fragment main0_out main0(main0_in in [[stage_in]], constant type_u_EveryFrameFrag& u_EveryFrameFrag [[buffer(0)]], texture2d<float> u_normalMap [[texture(0)]], texture2d<float> u_skybox [[texture(1)]], sampler sampler0 [[sampler(0)]], sampler sampler1 [[sampler(1)]])
+{
+    main0_out out = {};
+    float3 _77 = normalize(((u_normalMap.sample(sampler0, in.in_var_TEXCOORD0).xyz * float3(2.0)) - float3(1.0)) + ((u_normalMap.sample(sampler0, in.in_var_TEXCOORD1).xyz * float3(2.0)) - float3(1.0)));
+    float3 _79 = normalize(in.in_var_COLOR0.xyz);
+    float3 _95 = normalize((u_EveryFrameFrag.u_eyeNormalMatrix * float4(_77, 0.0)).xyz);
+    float3 _97 = normalize(reflect(_79, _95));
+    float3 _121 = normalize((u_EveryFrameFrag.u_inverseViewMatrix * float4(_97, 0.0)).xyz);
+    out.out_var_SV_Target = float4(mix(u_skybox.sample(sampler1, (float2(atan2(_121.x, _121.y) + 3.1415927410125732421875, acos(_121.z)) * float2(0.15915493667125701904296875, 0.3183098733425140380859375))).xyz, in.in_var_COLOR1.xyz * mix(float3(1.0, 1.0, 0.60000002384185791015625), float3(0.3499999940395355224609375), float3(pow(fast::max(0.0, _77.z), 5.0))), float3(((dot(_95, _79) * (-0.5)) + 0.5) * 0.75)) + float3(pow(abs(dot(_97, normalize((u_EveryFrameFrag.u_eyeNormalMatrix * float4(normalize(u_EveryFrameFrag.u_specularDir.xyz), 0.0)).xyz))), 50.0) * 0.5), 1.0);
+    return out;
 }
 
-fragment float4
-main0(WVSOutput in [[stage_in]], constant WFSUniforms& uWFS [[buffer(2)]], texture2d<float, access::sample> WFSNormal [[texture(0)]], sampler WFSNsampler [[sampler(0)]], texture2d<float, access::sample> WFSSkybox [[texture(1)]], sampler WFSSBsampler [[sampler(1)]])
-{
-  float3 specularDir = normalize(uWFS.u_specularDir.xyz);
-  
-  float3 normal0 = WFSNormal.sample(WFSNsampler, in.uv0).xyz * float3(2.0) - float3(1.0);
-  float3 normal1 = WFSNormal.sample(WFSNsampler, in.uv1).xyz * float3(2.0) - float3(1.0);
-  float3 normal = normalize((normal0.xyz * normal1.xyz));
-  
-  float3 eyeToFrag = normalize(in.fragEyePos.xyz);
-  float3 eyeSpecularDir = normalize((uWFS.u_eyeNormalMatrix * float4(specularDir, 0.0)).xyz);
-  float3 eyeNormal = normalize((uWFS.u_eyeNormalMatrix * float4(normal, 0.0)).xyz);
-  float3 eyeReflectionDir = normalize(reflect(eyeToFrag, eyeNormal));
-  
-  float nDotS = abs(dot(eyeReflectionDir, eyeSpecularDir));
-  float nDotL = -dot(eyeNormal, eyeToFrag);
-  float fresnel = nDotL * 0.5 + 0.5;
-  
-  float specular = pow(nDotS, 250.0) * 0.5;
-  
-  float3 deepFactor = float3(0.35, 0.35, 0.35);
-  float3 shallowFactor = float3(1.0, 1.0, 0.7);
-  
-  float distanceToShore = 1.0; // maybe TODO
-  float3 refractionColor = in.color.xyz * mix(shallowFactor, deepFactor, distanceToShore);
-  
-  // reflection
-  float4 worldFragPos = uWFS.u_inverseViewMatrix * float4(eyeReflectionDir, 0.0);
-  float4 skybox = WFSSkybox.sample(WFSSBsampler, directionToLatLong(normalize(worldFragPos.xyz)));
-  float3 reflectionColor = skybox.xyz;
-  
-  float3 finalColor = mix(reflectionColor, refractionColor, fresnel * 0.75) + float3(specular);
-  return float4(finalColor, 1.0);
-}

--- a/src/gl/metal/shaders/mobile/waterVertexShader.metal
+++ b/src/gl/metal/shaders/mobile/waterVertexShader.metal
@@ -1,50 +1,44 @@
 #include <metal_stdlib>
-#include <metal_matrix>
-#include <metal_uniform>
-#include <metal_texture>
+#include <simd/simd.h>
+
 using namespace metal;
 
-struct WVSInput
+struct type_u_EveryFrameVert
 {
-  float2 pos [[attribute(0)]];
+    float4 u_time;
 };
 
-struct WVSOutput
+struct type_u_EveryObject
 {
-  float4 pos [[position]];
-  float2 uv0;
-  float2 uv1;
-  float4 fragEyePos;
-  float3 color;
+    float4 u_colourAndSize;
+    float4x4 u_worldViewMatrix;
+    float4x4 u_worldViewProjectionMatrix;
 };
 
-struct WVSUniforms1
+struct main0_out
 {
-  float4 u_time;
+    float2 out_var_TEXCOORD0 [[user(locn0)]];
+    float2 out_var_TEXCOORD1 [[user(locn1)]];
+    float4 out_var_COLOR0 [[user(locn2)]];
+    float3 out_var_COLOR1 [[user(locn3)]];
+    float4 gl_Position [[position]];
 };
 
-struct WVSUniforms2
+struct main0_in
 {
-  float4 u_colorAndSize;
-  float4x4 u_worldViewMatrix;
-  float4x4 u_worldViewProjectionMatrix;
+    float2 in_var_POSITION [[attribute(0)]];
 };
 
-vertex WVSOutput
-main0(WVSInput in [[stage_in]], constant WVSUniforms1& uWVS1 [[buffer(1)]], constant WVSUniforms2& uWVS2 [[buffer(3)]])
+vertex main0_out main0(main0_in in [[stage_in]], constant type_u_EveryFrameVert& u_EveryFrameVert [[buffer(0)]], constant type_u_EveryObject& u_EveryObject [[buffer(1)]])
 {
-  WVSOutput out;
-
-  float uvScaleBodySize = uWVS2.u_colorAndSize.w; // packed here
-
-  // scale the uvs with time
-  float uvOffset = uWVS1.u_time.x * 0.0625;
-  out.uv0 = uvScaleBodySize * in.pos.xy * float2(0.25, 0.25) - float2(uvOffset);
-  out.uv1 = uvScaleBodySize * in.pos.yx * float2(0.50, 0.50) - float2(uvOffset, uvOffset * 0.75);
-
-  out.fragEyePos = uWVS2.u_worldViewMatrix * float4(in.pos, 0.0, 1.0);
-  out.color = uWVS2.u_colorAndSize.xyz;
-  out.pos = uWVS2.u_worldViewProjectionMatrix * float4(in.pos, 0.0, 1.0);
-
-  return out;
+    main0_out out = {};
+    float _48 = u_EveryFrameVert.u_time.x * 0.0625;
+    float4 _63 = float4(in.in_var_POSITION, 0.0, 1.0);
+    out.gl_Position = u_EveryObject.u_worldViewProjectionMatrix * _63;
+    out.out_var_TEXCOORD0 = ((in.in_var_POSITION * u_EveryObject.u_colourAndSize.w) * float2(0.25)) - float2(_48);
+    out.out_var_TEXCOORD1 = ((in.in_var_POSITION.yx * u_EveryObject.u_colourAndSize.w) * float2(0.5)) - float2(_48, u_EveryFrameVert.u_time.x * 0.046875);
+    out.out_var_COLOR0 = u_EveryObject.u_worldViewMatrix * _63;
+    out.out_var_COLOR1 = u_EveryObject.u_colourAndSize.xyz;
+    return out;
 }
+

--- a/src/gl/metal/vcMetal.h
+++ b/src/gl/metal/vcMetal.h
@@ -55,9 +55,13 @@ struct vcFramebuffer
 
 struct vcShaderConstantBuffer
 {
-  const void *pCB;
   char name[32];
   size_t expectedSize;
+  struct
+  {
+    int index;
+    const void *pCB;
+  } buffers[2]; // 0 for Vertex shader, 1 for Fragment shader
 };
 
 struct vcShaderSampler

--- a/src/gl/metal/vcRenderer.h
+++ b/src/gl/metal/vcRenderer.h
@@ -67,7 +67,6 @@
 - (void)setFramebuffer:(nullable struct vcFramebuffer*)pFramebuffer;
 - (void)destroyFramebuffer:(nonnull struct vcFramebuffer*)pFramebuffer;
 - (void)bindViewport:(MTLViewport)vp;
-- (void)buildBlendPipelines:(nonnull MTLRenderPipelineDescriptor*)pDesc;
 - (void)bindVB:(nonnull vcShaderConstantBuffer*)pBuffer index:(uint8_t)index;
 @end
 


### PR DESCRIPTION
- Metal now uses reflection for constant buffers instead of guessing
- Metal: Mapped vertex buffer to buffer index 30 instead of 0
- Metal: Moved code from vcRenderer to vcShader

Resolves [AB#1207](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1207)