### PR TITLE
awu/export point cloud file name

### DIFF
--- a/src/imgui_ex/vcFileDialog.h
+++ b/src/imgui_ex/vcFileDialog.h
@@ -18,7 +18,6 @@ static const char *SupportedFileTypes_ProjectsImport[] = { ".json", ".udp" };
 
 static const char *SupportedTileTypes_ConvertExport[] = { ".uds" };
 static const char *SupportedTileTypes_QueryExport[] = { ".uds", ".las" };
-static const char *SupportedTileTypes_ExportDefault = ".las";
 static const char *SupportedFileTypes_ConvertImport[] = { ".uds", ".ssf", ".udg", ".las", ".laz", ".e57", ".txt", ".csv", ".asc", ".pts", ".ptx", ".xyz", ".obj"
 #ifdef FBXSDK_ON
   , ".fbx"
@@ -62,7 +61,6 @@ template <size_t N, size_t M> inline void vcFileDialog_Open(vcState *pProgramSta
   udUnused(SupportedTileTypes_ConvertExport);
   udUnused(SupportedTileTypes_QueryExport);
   udUnused(SupportedFileTypes_ConvertImport);
-  udUnused(SupportedTileTypes_ExportDefault);
 }
 
 void vcFileDialog_ShowModal(vcState *pProgramState);

--- a/src/imgui_ex/vcFileDialog.h
+++ b/src/imgui_ex/vcFileDialog.h
@@ -62,6 +62,7 @@ template <size_t N, size_t M> inline void vcFileDialog_Open(vcState *pProgramSta
   udUnused(SupportedTileTypes_ConvertExport);
   udUnused(SupportedTileTypes_QueryExport);
   udUnused(SupportedFileTypes_ConvertImport);
+  udUnused(SupportedTileTypes_ExportDefault);
 }
 
 void vcFileDialog_ShowModal(vcState *pProgramState);

--- a/src/imgui_ex/vcFileDialog.h
+++ b/src/imgui_ex/vcFileDialog.h
@@ -18,6 +18,7 @@ static const char *SupportedFileTypes_ProjectsImport[] = { ".json", ".udp" };
 
 static const char *SupportedTileTypes_ConvertExport[] = { ".uds" };
 static const char *SupportedTileTypes_QueryExport[] = { ".uds", ".las" };
+static const char *SupportedTileTypes_ExportDefault = ".las";
 static const char *SupportedFileTypes_ConvertImport[] = { ".uds", ".ssf", ".udg", ".las", ".laz", ".e57", ".txt", ".csv", ".asc", ".pts", ".ptx", ".xyz", ".obj"
 #ifdef FBXSDK_ON
   , ".fbx"

--- a/src/scene/vcModel.cpp
+++ b/src/scene/vcModel.cpp
@@ -509,7 +509,21 @@ void vcModel::HandleContextMenu(vcState *pProgramState)
       static vcQueryNode *s_pQuery = nullptr;
 
       if (ImGui::IsWindowAppearing())
+      {
         s_pQuery = nullptr;
+
+        // Set a default file name to be exported if there isn't.
+        if (udStrlen(pProgramState->modelPath) == 0)
+        {
+          size_t fileNameLength = 0;
+          if (udStrchr(pProgramState->sceneExplorer.clickedItem.pItem->pName, ".", &fileNameLength))
+          {
+            memset(pProgramState->modelPath, 0, sizeof(pProgramState->modelPath));
+            udStrncpy(pProgramState->modelPath, pProgramState->sceneExplorer.clickedItem.pItem->pName, fileNameLength);
+            udStrncpy(pProgramState->modelPath + fileNameLength, sizeof(pProgramState->modelPath), SupportedTileTypes_ExportDefault, udStrlen(SupportedTileTypes_ExportDefault));
+          }
+        }
+      }
 
       if (ImGui::BeginCombo(vcString::Get("sceneExplorerExportQueryFilter"), (s_pQuery == nullptr ? vcString::Get("sceneExplorerExportEntireModel") : s_pQuery->m_pNode->pName)))
       {
@@ -526,6 +540,13 @@ void vcModel::HandleContextMenu(vcState *pProgramState)
       {
         if (udFileExists(pProgramState->modelPath) != udR_Success || vcModals_OverwriteExistingFile(pProgramState->modelPath))
         {
+          if (!udStrchr(pProgramState->modelPath, "."))
+          {
+            // Adding a default externsion
+            size_t modelPathLength = udStrlen(pProgramState->modelPath);
+            udStrncpy(pProgramState->modelPath + modelPathLength, sizeof(pProgramState->modelPath), SupportedTileTypes_ExportDefault, udStrlen(SupportedTileTypes_ExportDefault));
+          }
+
           vdkQueryFilter *pFilter = ((s_pQuery == nullptr) ? nullptr : s_pQuery->m_pFilter);
           vdkPointCloud *pCloud = m_pPointCloud;
 
@@ -571,7 +592,6 @@ void vcModel::HandleContextMenu(vcState *pProgramState)
           };
 
           // Add post callback
-
           udWorkerPool_AddTask(pProgramState->pWorkerPool, callback, nullptr, false);
           ImGui::CloseCurrentPopup();
         }

--- a/src/scene/vcModel.cpp
+++ b/src/scene/vcModel.cpp
@@ -520,7 +520,7 @@ void vcModel::HandleContextMenu(vcState *pProgramState)
           {
             memset(pProgramState->modelPath, 0, sizeof(pProgramState->modelPath));
             udStrncpy(pProgramState->modelPath, pProgramState->sceneExplorer.clickedItem.pItem->pName, fileNameLength);
-            udStrncpy(pProgramState->modelPath + fileNameLength, sizeof(pProgramState->modelPath), SupportedTileTypes_ExportDefault, udStrlen(SupportedTileTypes_ExportDefault));
+            udStrcat(pProgramState->modelPath, SupportedTileTypes_QueryExport[0]);
           }
         }
       }
@@ -541,11 +541,7 @@ void vcModel::HandleContextMenu(vcState *pProgramState)
         if (udFileExists(pProgramState->modelPath) != udR_Success || vcModals_OverwriteExistingFile(pProgramState->modelPath))
         {
           if (!udStrchr(pProgramState->modelPath, "."))
-          {
-            // Adding a default externsion
-            size_t modelPathLength = udStrlen(pProgramState->modelPath);
-            udStrncpy(pProgramState->modelPath + modelPathLength, sizeof(pProgramState->modelPath), SupportedTileTypes_ExportDefault, udStrlen(SupportedTileTypes_ExportDefault));
-          }
+            udStrcat(pProgramState->modelPath, SupportedTileTypes_QueryExport[0]);
 
           vdkQueryFilter *pFilter = ((s_pQuery == nullptr) ? nullptr : s_pQuery->m_pFilter);
           vdkPointCloud *pCloud = m_pPointCloud;


### PR DESCRIPTION
Fixed [AB#1112](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1112).

Set a default file name to be exported if there isn't and added ".las" if no extension when user clicking export button.