### PR TITLE
Moved various things out of vcRenderer

### DIFF
--- a/src/gl/directx11/vcGLState.cpp
+++ b/src/gl/directx11/vcGLState.cpp
@@ -288,6 +288,9 @@ bool vcGLState_SetDepthStencilMode(vcGLStateDepthMode depthReadMode, bool doDept
     case vcGLSDM_Always:
       desc.DepthFunc = D3D11_COMPARISON_ALWAYS;
       break;
+    case vcGLSDM_Total:
+      desc.DepthFunc = D3D11_COMPARISON_NEVER;
+      break;
     }
 
     if (doDepthWrite)

--- a/src/gl/metal/vcFramebuffer.mm
+++ b/src/gl/metal/vcFramebuffer.mm
@@ -60,8 +60,8 @@ bool vcFramebuffer_Bind(vcFramebuffer *pFramebuffer, const vcFramebufferClearOpe
   {
     udFloat4 col = udFloat4::create(((clearColour >> 16) & 0xFF) / 255.f, ((clearColour >> 8) & 0xFF) / 255.f, (clearColour & 0xFF) / 255.f, ((clearColour >> 24) & 0xFF) / 255.f);
 
-    _renderer.renderPasses[pFramebuffer->ID].colorAttachments[0].clearColor = MTLClearColorMake(col.x,col.y,col.z,col.w);
-    _renderer.renderPasses[pFramebuffer->ID].depthAttachment.clearDepth = 1.0;
+    pFramebuffer->pRenderPass.colorAttachments[0].clearColor = MTLClearColorMake(col.x,col.y,col.z,col.w);
+    pFramebuffer->pRenderPass.depthAttachment.clearDepth = 1.0;
   }
 
   return true;

--- a/src/gl/metal/vcGLState.mm
+++ b/src/gl/metal/vcGLState.mm
@@ -57,28 +57,31 @@ MTLCompareFunction mapDepthMode[] =
   MTLCompareFunctionAlways
 };
 
+static id<MTLDepthStencilState> s_depthStates[vcGLSDM_Total * 2];
+
 void vcGLState_BuildDepthStates()
 {
   MTLDepthStencilDescriptor *depthStencilDesc = [[MTLDepthStencilDescriptor alloc]init];
   id<MTLDepthStencilState> dsState;
 
-  for (int i = 0 ; i <= vcGLSDM_Always; ++i)
+  for (int i = 0 ; i < vcGLSDM_Total; ++i)
   {
     int j = i * 2;
     depthStencilDesc.depthWriteEnabled = false;
     depthStencilDesc.depthCompareFunction = mapDepthMode[i];
     dsState = [_device newDepthStencilStateWithDescriptor:depthStencilDesc];
-    _renderer.depthStates[j] = dsState;
+    s_depthStates[j] = dsState;
 
     depthStencilDesc.depthWriteEnabled = true;
     dsState = [_device newDepthStencilStateWithDescriptor:depthStencilDesc];
-    _renderer.depthStates[j+1] = dsState;
+    s_depthStates[j+1] = dsState;
   }
 }
 
 bool vcGLState_Init(SDL_Window *pWindow, vcFramebuffer **ppDefaultFramebuffer)
 {
   _device = MTLCreateSystemDefaultDevice();
+  _queue = [_device newCommandQueue];
 
   if (_device == nullptr)
   {
@@ -212,7 +215,7 @@ bool vcGLState_SetDepthStencilMode(vcGLStateDepthMode depthReadMode, bool doDept
     {
       if (!enableStencil)
       {
-        [_renderer bindDepthStencil:_renderer.depthStates[((int)depthReadMode) * 2 + doDepthWrite] settings:nullptr];
+        [_renderer bindDepthStencil:s_depthStates[((int)depthReadMode) * 2 + doDepthWrite] settings:nullptr];
         return true;
       }
 

--- a/src/gl/metal/vcMetal.h
+++ b/src/gl/metal/vcMetal.h
@@ -17,6 +17,7 @@
 #define DRAWABLES 1
 
 extern id<MTLDevice> _device;
+extern id<MTLCommandQueue> _queue;
 
 enum vcRendererFramebufferActions
 {
@@ -35,13 +36,13 @@ enum vcRendererFlushOption
 
 struct vcTexture
 {
-  uint32_t ID;
-  char samplerID[32];
+  id<MTLTexture> texture;
+  id<MTLSamplerState> sampler;
   uint32_t width;
   uint32_t height;
   vcTextureFormat format;
   vcTextureCreationFlags flags;
-  uint32_t blitTarget;
+  id<MTLBuffer> blitBuffer;
 };
 
 struct vcFramebuffer
@@ -51,6 +52,9 @@ struct vcFramebuffer
   vcTexture *pDepth;
   uint32_t clear;
   int actions;
+  MTLRenderPassDescriptor *pRenderPass;
+  id<MTLCommandBuffer> commandBuffer;
+  id<MTLRenderCommandEncoder> encoder;
 };
 
 struct vcShaderConstantBuffer
@@ -76,20 +80,23 @@ struct vcShader
   bool inititalised;
   id<MTLLibrary> vertexLibrary;
   id<MTLLibrary> fragmentLibrary;
+  id<MTLRenderPipelineState> pipelines[vcGLSBM_Count];
 
   vcShaderConstantBuffer bufferObjects[16];
   int numBufferObjects;
+
+  vcShaderConstantBuffer *pCameraPlaneParams;
 
   vcRendererFlushOption flush;
 };
 
 struct vcMesh
 {
-  char vBufferIndex[32];
+  id<MTLBuffer> vBuffer;
   uint32_t vertexCount;
   uint32_t vertexBytes;
 
-  char iBufferIndex[32];
+  id<MTLBuffer> iBuffer;
   MTLIndexType indexType;
   uint32_t indexCount;
   uint32_t indexBytes;

--- a/src/gl/metal/vcRenderer.h
+++ b/src/gl/metal/vcRenderer.h
@@ -20,32 +20,9 @@
 
 @interface vcRenderer : NSObject
 
-@property(nonatomic,strong,nonnull) id<MTLCommandQueue> queue;
-
 // Blitting
 @property(nonatomic,strong,nonnull) id<MTLCommandBuffer> blitBuffer;
 @property(nonatomic,strong,nonnull) id<MTLBlitCommandEncoder> blitEncoder;
-
-// Compute
-@property(nonatomic,strong,nonnull) id<MTLCommandBuffer> computeBuffer;
-@property(nonatomic,strong,nonnull) id<MTLComputeCommandEncoder> computeEncoder;
-
-@property(nonatomic,strong,nonnull) NSMutableArray<id<MTLRenderPipelineState>> *pipelines;
-
-@property(nonatomic,strong,nonnull) NSMutableDictionary<NSString*, id<MTLBuffer>> *vertBuffers;
-@property(nonatomic,strong,nonnull) NSMutableDictionary<NSString*, id<MTLBuffer>> *indexBuffers;
-@property(nonatomic,strong,nonnull) NSMutableDictionary<NSString*, id<MTLTexture>> *textures;
-
-@property(nonatomic,strong,nonnull) NSMutableArray<id<MTLBuffer>> *blitBuffers;
-
-// Permutables
-@property(nonatomic,strong,nonnull) NSMutableArray<id<MTLDepthStencilState>> *depthStates;
-@property(nonatomic,strong,nonnull) NSMutableDictionary<NSString*, id<MTLSamplerState>> *samplers;
-
-// Per buffer objects
-@property(nonatomic,strong,nonnull) NSMutableArray<MTLRenderPassDescriptor*> *renderPasses;
-@property(nonatomic,strong,nonnull) NSMutableArray<id<MTLCommandBuffer>> *commandBuffers;
-@property(nonatomic,strong,nonnull) NSMutableArray<id<MTLRenderCommandEncoder>> *encoders;
 
 - (void)initWithView:(nonnull PlatformView*)view;
 - (nullable CAMetalLayer*)makeBackingLayer;

--- a/src/gl/metal/vcTexture.mm
+++ b/src/gl/metal/vcTexture.mm
@@ -11,9 +11,6 @@
 
 #include "stb_image.h"
 
-uint32_t g_textureIndex = 0;
-uint32_t g_blitTargetID = 0;
-
 void vcTexture_GetFormatAndPixelSize(const vcTextureFormat format, int *pPixelSize = nullptr, MTLPixelFormat *pPixelFormat = nullptr, MTLStorageMode *pStorageMode = nullptr, MTLTextureUsage *pUsage = nullptr)
 {
   // defaults
@@ -145,18 +142,17 @@ udResult vcTexture_CreateAdv(vcTexture **ppTexture, vcTextureType type, uint32_t
     pText->width = (uint32_t)pTextureDesc.width;
     pText->height = (uint32_t)pTextureDesc.height;
     pText->format = format;
-    pText->ID = g_textureIndex;
     pText->flags = flags;
 
     int count = (flags & vcTCF_RenderTarget) || (flags & vcTCF_Dynamic) ? DRAWABLES : 1;
     
     for (int i = 0; i < count; ++i)
     {
-      id<MTLTexture> texture = [_device newTextureWithDescriptor:pTextureDesc];
+      pText->texture = [_device newTextureWithDescriptor:pTextureDesc];
       
       if ((pTextureDesc.pixelFormat == MTLPixelFormatRGBA8Unorm) && (pTextureDesc.usage & MTLTextureUsageRenderTarget))
       {
-        texture = [texture newTextureViewWithPixelFormat:MTLPixelFormatBGRA8Unorm];
+        pText->texture = [pText->texture newTextureViewWithPixelFormat:MTLPixelFormatBGRA8Unorm];
         pTextureDesc.pixelFormat = MTLPixelFormatBGRA8Unorm;
         pText->format = vcTextureFormat_BGRA8;
       }
@@ -166,69 +162,54 @@ udResult vcTexture_CreateAdv(vcTexture **ppTexture, vcTextureType type, uint32_t
       
       if (pPixels && (pTextureDesc.storageMode != MTLStorageModePrivate))
       {
-        [texture replaceRegion:region mipmapLevel:0 withBytes:pPixels bytesPerRow:row];
+        [pText->texture replaceRegion:region mipmapLevel:0 withBytes:pPixels bytesPerRow:row];
   #if UDPLATFORM_OSX
-        [_renderer.blitEncoder synchronizeTexture:texture slice:0 level:0];
+        [_renderer.blitEncoder synchronizeTexture:pText->texture slice:0 level:0];
   #endif
       }
       else if (pPixels)
       {
         id<MTLBuffer> temp = [_device newBufferWithBytes:pPixels length:len options:MTLStorageModeShared];
-        [_renderer.blitEncoder copyFromBuffer:temp sourceOffset:0 sourceBytesPerRow:row sourceBytesPerImage:len sourceSize:MTLSizeMake(width, height, 1) toTexture:texture destinationSlice:0 destinationLevel:0 destinationOrigin:MTLOriginMake(0, 0, 0)];
+        [_renderer.blitEncoder copyFromBuffer:temp sourceOffset:0 sourceBytesPerRow:row sourceBytesPerImage:len sourceSize:MTLSizeMake(width, height, 1) toTexture:pText->texture destinationSlice:0 destinationLevel:0 destinationOrigin:MTLOriginMake(0, 0, 0)];
       }
-      
-      [_renderer.textures setObject:texture forKey:[NSString stringWithFormat:@"%u",g_textureIndex++]];
     }
   }
   
   // Sampler
-  NSString *key = [NSString stringWithFormat:@"%@%@", (filterMode == vcTFM_Nearest ? @"N" : @"L"), (wrapMode == vcTWM_Repeat ? @"R" : @"C")];
-  id<MTLSamplerState> savedSampler = [_renderer.samplers valueForKey:key];
+  MTLSamplerDescriptor *pSamplerDesc = [MTLSamplerDescriptor new];
 
-  if (savedSampler)
+  if (filterMode == vcTFM_Nearest)
   {
-    udStrcpy(pText->samplerID, key.UTF8String);
+    pSamplerDesc.mipFilter = MTLSamplerMipFilterNearest;
+    pSamplerDesc.minFilter = MTLSamplerMinMagFilterNearest;
+    pSamplerDesc.magFilter = MTLSamplerMinMagFilterNearest;
   }
   else
   {
-    MTLSamplerDescriptor *pSamplerDesc = [MTLSamplerDescriptor new];
-
-    if (filterMode == vcTFM_Nearest)
-    {
-      pSamplerDesc.mipFilter = MTLSamplerMipFilterNearest;
-      pSamplerDesc.minFilter = MTLSamplerMinMagFilterNearest;
-      pSamplerDesc.magFilter = MTLSamplerMinMagFilterNearest;
-    }
-    else
-    {
-      pSamplerDesc.mipFilter = MTLSamplerMipFilterLinear;
-      pSamplerDesc.minFilter = MTLSamplerMinMagFilterLinear;
-      pSamplerDesc.magFilter = MTLSamplerMinMagFilterLinear;
-    }
-
-    if (wrapMode == vcTWM_Repeat)
-    {
-      pSamplerDesc.rAddressMode = MTLSamplerAddressModeRepeat;
-      pSamplerDesc.sAddressMode = MTLSamplerAddressModeRepeat;
-      pSamplerDesc.tAddressMode = MTLSamplerAddressModeRepeat;
-    }
-    else
-    {
-      pSamplerDesc.rAddressMode = MTLSamplerAddressModeClampToEdge;
-      pSamplerDesc.sAddressMode = MTLSamplerAddressModeClampToEdge;
-      pSamplerDesc.tAddressMode = MTLSamplerAddressModeClampToEdge;
-    }
-
-    if (aniFilter > 0)
-      pSamplerDesc.maxAnisotropy = aniFilter;
-    else
-      pSamplerDesc.maxAnisotropy = 1;
-
-    id<MTLSamplerState> sampler = [_device newSamplerStateWithDescriptor:pSamplerDesc];
-
-    udStrcpy(pText->samplerID, key.UTF8String);
-    [_renderer.samplers setObject:sampler forKey:key];
+    pSamplerDesc.mipFilter = MTLSamplerMipFilterLinear;
+    pSamplerDesc.minFilter = MTLSamplerMinMagFilterLinear;
+    pSamplerDesc.magFilter = MTLSamplerMinMagFilterLinear;
   }
+
+  if (wrapMode == vcTWM_Repeat)
+  {
+    pSamplerDesc.rAddressMode = MTLSamplerAddressModeRepeat;
+    pSamplerDesc.sAddressMode = MTLSamplerAddressModeRepeat;
+    pSamplerDesc.tAddressMode = MTLSamplerAddressModeRepeat;
+  }
+  else
+  {
+    pSamplerDesc.rAddressMode = MTLSamplerAddressModeClampToEdge;
+    pSamplerDesc.sAddressMode = MTLSamplerAddressModeClampToEdge;
+    pSamplerDesc.tAddressMode = MTLSamplerAddressModeClampToEdge;
+  }
+
+  if (aniFilter > 0)
+    pSamplerDesc.maxAnisotropy = aniFilter;
+  else
+    pSamplerDesc.maxAnisotropy = 1;
+
+  pText->sampler = [_device newSamplerStateWithDescriptor:pSamplerDesc];
 
   vcGLState_ReportGPUWork(0, 0, pText->width * pText->height * pixelBytes);
   *ppTexture = pText;
@@ -295,10 +276,10 @@ udResult vcTexture_UploadPixels(struct vcTexture *pTexture, const void *pPixels,
   {
     id<MTLBuffer> pData = [_device newBufferWithBytes:pPixels length:width * height * pixelBytes options:MTLStorageModeShared];
 
-    [_renderer.blitEncoder copyFromBuffer:pData sourceOffset:0 sourceBytesPerRow:width * pixelBytes sourceBytesPerImage:width * height * 4 sourceSize:MTLSizeMake(width, height, 1) toTexture:_renderer.textures[[NSString stringWithFormat:@"%u",pTexture->ID]] destinationSlice:0 destinationLevel:0 destinationOrigin:MTLOriginMake(0, 0, 0)];
+    [_renderer.blitEncoder copyFromBuffer:pData sourceOffset:0 sourceBytesPerRow:width * pixelBytes sourceBytesPerImage:width * height * 4 sourceSize:MTLSizeMake(width, height, 1) toTexture:pTexture->texture destinationSlice:0 destinationLevel:0 destinationOrigin:MTLOriginMake(0, 0, 0)];
 #if UDPLATFORM_OSX
-    if (_renderer.textures[[NSString stringWithFormat:@"%u",pTexture->ID]].storageMode != MTLStorageModePrivate)
-      [_renderer.blitEncoder synchronizeTexture:_renderer.textures[[NSString stringWithFormat:@"%u",pTexture->ID]] slice:0 level:0];
+    if (pTexture->texture.storageMode != MTLStorageModePrivate)
+      [_renderer.blitEncoder synchronizeTexture:pTexture->texture slice:0 level:0];
 #endif
     result = udR_Success;
   }
@@ -313,12 +294,12 @@ udResult vcTexture_UploadPixels(struct vcTexture *pTexture, const void *pPixels,
 
 void vcTexture_Destroy(struct vcTexture **ppTexture)
 {
-  if (ppTexture == nullptr || *ppTexture == nullptr || !_renderer.textures[[NSString stringWithFormat:@"%u",(*ppTexture)->ID]])
+  if (ppTexture == nullptr || *ppTexture == nullptr || !(*ppTexture)->texture)
     return;
 
   @autoreleasepool
   {
-    [_renderer.textures removeObjectForKey:[NSString stringWithFormat:@"%u",(*ppTexture)->ID]];
+    (*ppTexture)->texture = nil;
   }
 
   udFree(*ppTexture);
@@ -355,19 +336,17 @@ bool vcTexture_BeginReadPixels(vcTexture *pTexture, uint32_t x, uint32_t y, uint
 
   @autoreleasepool
   {
-    if (pTexture->blitTarget == 0)
+    if (pTexture->blitBuffer == nil)
     {
-      [_renderer.blitBuffers addObject:[_device newBufferWithLength:pixelBytes * pTexture->width * pTexture->height options:MTLResourceStorageModeShared]];
-      
-      pTexture->blitTarget = ++g_blitTargetID;
+      pTexture->blitBuffer = [_device newBufferWithLength:pixelBytes * pTexture->width * pTexture->height options:MTLResourceStorageModeShared];
       pFramebuffer->actions |= vcRFA_Blit;
     }
-    else if (_renderer.blitBuffers[pTexture->blitTarget - 1].length < 4 * pTexture->width * pTexture->height)
+    else if (pTexture->blitBuffer.length < 4 * pTexture->width * pTexture->height)
     {
-      [_renderer.blitBuffers replaceObjectAtIndex:pTexture->blitTarget - 1 withObject:[_device newBufferWithLength:4 * pTexture->width * pTexture->height options:MTLResourceStorageModeShared]];
+      pTexture->blitBuffer = [_device newBufferWithLength:4 * pTexture->width * pTexture->height options:MTLResourceStorageModeShared];
     }
     
-    [_renderer.blitEncoder copyFromTexture:_renderer.textures[[NSString stringWithFormat:@"%u",pTexture->ID]] sourceSlice:0 sourceLevel:0 sourceOrigin:MTLOriginMake(0, 0, 0) sourceSize:MTLSizeMake(pTexture->width, pTexture->height, 1) toBuffer:_renderer.blitBuffers[pTexture->blitTarget - 1] destinationOffset:0 destinationBytesPerRow:4 * pTexture->width destinationBytesPerImage:4 * pTexture->width * pTexture->height];
+    [_renderer.blitEncoder copyFromTexture:pTexture->texture sourceSlice:0 sourceLevel:0 sourceOrigin:MTLOriginMake(0, 0, 0) sourceSize:MTLSizeMake(pTexture->width, pTexture->height, 1) toBuffer:pTexture->blitBuffer destinationOffset:0 destinationBytesPerRow:4 * pTexture->width destinationBytesPerImage:4 * pTexture->width * pTexture->height];
   
     [_renderer flushBlit];
   }
@@ -380,14 +359,14 @@ bool vcTexture_EndReadPixels(vcTexture *pTexture, uint32_t x, uint32_t y, uint32
   if (pTexture == nullptr || pPixels == nullptr || (x + width) > pTexture->width || (y + height) > pTexture->height)
     return false;
 
-  if (pTexture->format == vcTextureFormat_Unknown || pTexture->format == vcTextureFormat_Count || pTexture->blitTarget == 0)
+  if (pTexture->format == vcTextureFormat_Unknown || pTexture->format == vcTextureFormat_Count || pTexture->blitBuffer == nil)
     return false;
 
   udResult result = udR_Success;
   int pixelBytes = 0;
   vcTexture_GetFormatAndPixelSize(pTexture->format, &pixelBytes);
 
-  uint32_t *pSource = (uint32_t*)[_renderer.blitBuffers[pTexture->blitTarget - 1] contents];
+  uint32_t *pSource = (uint32_t*)[pTexture->blitBuffer contents];
   pSource += ((y * pTexture->width) + x);
   
   uint32_t rowBytes = pixelBytes * width;

--- a/src/gl/opengl/vcGLState.cpp
+++ b/src/gl/opengl/vcGLState.cpp
@@ -214,6 +214,8 @@ bool vcGLState_SetDepthStencilMode(vcGLStateDepthMode depthReadMode, bool doDept
     case vcGLSDM_Always:
       glDepthFunc(GL_ALWAYS);
       break;
+    case vcGLSDM_Total:
+      break;
     }
 
     s_internalState.depthReadMode = depthReadMode;

--- a/src/gl/vcGLState.h
+++ b/src/gl/vcGLState.h
@@ -59,7 +59,9 @@ enum vcGLStateDepthMode
   vcGLSDM_Greater,
 
   vcGLSDM_NotEqual,
-  vcGLSDM_Always
+  vcGLSDM_Always,
+
+  vcGLSDM_Total
 };
 
 enum vcGLStateStencilFunc


### PR DESCRIPTION
- Metal: Added missing camera plane uniform upload
- Metal: Moved pipelines out of vcRenderer into vcShader
- Metal: Moved textures out of vcRenderer into vcTexture
- Metal: Moved samplers out of vcRenderer into vcTexture
- Metal: Moved blit buffers out of vcRenderer into vcTexture
- Metal: Moved render passes out of vcRenderer into vcFramebuffer
- Metal: Moved command buffer out of vcRenderer into vcFramebuffer
- Metal: Moved command encoder out of vcRenderer into vcFramebuffer
- Metal: Moved index buffers out of vcRenderer into vcMesh
- Metal: Moved vertex buffers out of vcRenderer into vcMesh
- Metal: Moved depth states out of vcRenderer into vcGLState
- Metal: Removed command queue in vcRenderer in favour of unused queue in vcGLState
- Metal: Removed unused compute variables in vcRenderer