### PR TITLE
Fixed some crashes in Metal

### DIFF
--- a/src/gl/metal/vcMetal.h
+++ b/src/gl/metal/vcMetal.h
@@ -13,7 +13,7 @@
 #import <Cocoa/Cocoa.h>
 #import "vcRenderer.h"
 
-#define BUFFER_COUNT 6
+#define BUFFER_COUNT 10
 #define DRAWABLES 1
 
 extern id<MTLDevice> _device;
@@ -80,7 +80,7 @@ struct vcShader
   bool inititalised;
   id<MTLLibrary> vertexLibrary;
   id<MTLLibrary> fragmentLibrary;
-  id<MTLRenderPipelineState> pipelines[vcGLSBM_Count];
+  id<MTLRenderPipelineState> pipelines[vcGLSBM_Count * 2];
 
   vcShaderConstantBuffer bufferObjects[16];
   int numBufferObjects;

--- a/src/gl/metal/vcRenderer.mm
+++ b/src/gl/metal/vcRenderer.mm
@@ -124,7 +124,7 @@
 {
   blendMode = newMode;
   if (pCurrShader != nullptr && pCurrFramebuffer != nullptr)
-    [pCurrFramebuffer->encoder setRenderPipelineState:pCurrShader->pipelines[newMode]];
+    [pCurrFramebuffer->encoder setRenderPipelineState:pCurrShader->pipelines[newMode + (pCurrFramebuffer->pDepth != nullptr ? 0 : vcGLSBM_Count)]];
 }
 
 - (void)flush:(uint32_t)i

--- a/src/gl/metal/vcTexture.mm
+++ b/src/gl/metal/vcTexture.mm
@@ -355,8 +355,11 @@ bool vcTexture_BeginReadPixels(vcTexture *pTexture, uint32_t x, uint32_t y, uint
     {
       pTexture->blitBuffer = [_device newBufferWithLength:4 * pTexture->width * pTexture->height options:MTLResourceStorageModeShared];
     }
-    
-    [_renderer.blitEncoder copyFromTexture:pTexture->texture sourceSlice:0 sourceLevel:0 sourceOrigin:MTLOriginMake(0, 0, 0) sourceSize:MTLSizeMake(pTexture->width, pTexture->height, 1) toBuffer:pTexture->blitBuffer destinationOffset:0 destinationBytesPerRow:4 * pTexture->width destinationBytesPerImage:4 * pTexture->width * pTexture->height];
+
+    if (pTexture->format == vcTextureFormat_D24S8)
+      [_renderer.blitEncoder copyFromTexture:pTexture->texture sourceSlice:0 sourceLevel:0 sourceOrigin:MTLOriginMake(0, 0, 0) sourceSize:MTLSizeMake(pTexture->width, pTexture->height, 1) toBuffer:pTexture->blitBuffer destinationOffset:0 destinationBytesPerRow:4 * pTexture->width destinationBytesPerImage:4 * pTexture->width * pTexture->height options:MTLBlitOptionDepthFromDepthStencil];
+    else
+      [_renderer.blitEncoder copyFromTexture:pTexture->texture sourceSlice:0 sourceLevel:0 sourceOrigin:MTLOriginMake(0, 0, 0) sourceSize:MTLSizeMake(pTexture->width, pTexture->height, 1) toBuffer:pTexture->blitBuffer destinationOffset:0 destinationBytesPerRow:4 * pTexture->width destinationBytesPerImage:4 * pTexture->width * pTexture->height];
   
     [_renderer flushBlit];
   }

--- a/src/rendering/vcPolygonModel.cpp
+++ b/src/rendering/vcPolygonModel.cpp
@@ -575,15 +575,18 @@ udResult vcPolygonModel_CreateShaders()
 
   pPolygonShader = &gShaders[vcPMST_P3N3UV2_Opaque];
   UD_ERROR_IF(!vcShader_CreateFromFile(&pPolygonShader->pShader, "asset://assets/shaders/polygonP3N3UV2VertexShader", "asset://assets/shaders/polygonP3N3UV2FragmentShader", vcP3N3UV2VertexLayout), udR_InternalError);
+  UD_ERROR_IF(!vcShader_Bind(pPolygonShader->pShader), udR_InternalError);
   UD_ERROR_IF(!vcShader_GetConstantBuffer(&pPolygonShader->pEveryObjectConstantBuffer, pPolygonShader->pShader, "u_EveryObject", sizeof(vcPolygonModelShader::everyObject)), udR_InternalError);
   UD_ERROR_IF(!vcShader_GetSamplerIndex(&pPolygonShader->pDiffuseSampler, pPolygonShader->pShader, "u_texture"), udR_InternalError);
 
   pPolygonShader = &gShaders[vcPMST_P3N3UV2_FlatColour];
   UD_ERROR_IF(!vcShader_CreateFromFile(&pPolygonShader->pShader, "asset://assets/shaders/polygonP3N3UV2VertexShader", "asset://assets/shaders/flatColourFragmentShader", vcP3N3UV2VertexLayout), udR_InternalError);
+  UD_ERROR_IF(!vcShader_Bind(pPolygonShader->pShader), udR_InternalError);
   UD_ERROR_IF(!vcShader_GetConstantBuffer(&pPolygonShader->pEveryObjectConstantBuffer, pPolygonShader->pShader, "u_EveryObject", sizeof(vcPolygonModelShader::everyObject)), udR_InternalError);
 
   pPolygonShader = &gShaders[vcPMST_P3N3UV2_DepthOnly];
   UD_ERROR_IF(!vcShader_CreateFromFile(&pPolygonShader->pShader, "asset://assets/shaders/polygonP3N3UV2VertexShader", "asset://assets/shaders/depthOnlyFragmentShader", vcP3N3UV2VertexLayout), udR_InternalError);
+  UD_ERROR_IF(!vcShader_Bind(pPolygonShader->pShader), udR_InternalError);
   UD_ERROR_IF(!vcShader_GetConstantBuffer(&pPolygonShader->pEveryObjectConstantBuffer, pPolygonShader->pShader, "u_EveryObject", sizeof(vcPolygonModelShader::everyObject)), udR_InternalError);
 
   UD_ERROR_CHECK(vcTexture_Create(&pWhiteTexture, 1, 1, &WhitePixel));


### PR DESCRIPTION
- Metal: Increased BUFFER_COUNT to fix issues with framebuffers not being bound correctly
- Metal: Shader pipelines now have second dimension for depth target configurations
- Metal: Moved shader pipeline creation into a function to reduce complexity
- Metal: Fixed issue with reading depth textures that have a stencil
- Metal: Fixed issue with comparing shader filenames for config changes
- vcPolygonModel now binds shaders after creation for consistency, fixes issues in Metal