### PR TITLE
Fixed profile loading crash of user defined classification labels and…

### DIFF
--- a/src/vcSettings.cpp
+++ b/src/vcSettings.cpp
@@ -96,8 +96,10 @@ void vcSettings_Cleanup_CustomClassificationColorLabels(vcSettings *pSettings)
 {
   size_t lenth = udLengthOf(pSettings->visualization.customClassificationColorLabels);
   for (size_t i = 0; i < lenth; ++i)
+  {
     if (pSettings->visualization.customClassificationColorLabels[i] != nullptr)
       udFree(pSettings->visualization.customClassificationColorLabels[i]);
+  }
 }
 
 bool vcSettings_ApplyConnectionSettings(vcSettings *pSettings)

--- a/src/vcSettingsUI.cpp
+++ b/src/vcSettingsUI.cpp
@@ -814,9 +814,11 @@ void vcSettingsUI_VisualizationSettings(vcState *pProgramState, vcVisualizationS
       if (ImGui::Button(udTempStr("%s##RestoreClassificationColors", vcString::Get("settingsRestoreDefaults"))))
       {
         memcpy(pProgramState->settings.visualization.customClassificationColors, GeoverseClassificationColours, sizeof(pProgramState->settings.visualization.customClassificationColors));
-        for(int i = vcLASClassifications_FirstUserDefined; i <= vcLASClassifications_LastClassification; i ++)
+        for (int i = vcLASClassifications_FirstUserDefined; i <= vcLASClassifications_LastClassification; i++)
+        {
           if (pVisualizationSettings->customClassificationColorLabels[i] != nullptr)
             udFree(pVisualizationSettings->customClassificationColorLabels[i]);
+        }
       }
 
       for (uint8_t i = 0; i < vcLASClassifications_FirstReserved; ++i)

--- a/src/vcSettingsUI.cpp
+++ b/src/vcSettingsUI.cpp
@@ -812,7 +812,12 @@ void vcSettingsUI_VisualizationSettings(vcState *pProgramState, vcVisualizationS
       ImGui::SameLine();
       ImGui::SameLine();
       if (ImGui::Button(udTempStr("%s##RestoreClassificationColors", vcString::Get("settingsRestoreDefaults"))))
+      {
         memcpy(pProgramState->settings.visualization.customClassificationColors, GeoverseClassificationColours, sizeof(pProgramState->settings.visualization.customClassificationColors));
+        for(int i = vcLASClassifications_FirstUserDefined; i <= vcLASClassifications_LastClassification; i ++)
+          if (pVisualizationSettings->customClassificationColorLabels[i] != nullptr)
+            udFree(pVisualizationSettings->customClassificationColorLabels[i]);
+      }
 
       for (uint8_t i = 0; i < vcLASClassifications_FirstReserved; ++i)
         vcIGSW_ColorPickerU32(vcSettingsUI_GetClassificationName(pProgramState, i), &pProgramState->settings.visualization.customClassificationColors[i], ImGuiColorEditFlags_NoAlpha);


### PR DESCRIPTION
Resolve [AB#1009](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1009).

Also fixed:
1. An extra crash when loading the user defined name.
2. Reset cache labels when reloading profile.