### PR TITLE
Fixed issues with Emscripten builds

### DIFF
--- a/buildscripts/compile-shaders.sh
+++ b/buildscripts/compile-shaders.sh
@@ -42,3 +42,7 @@ for SrcName in ${SrcFolder}/*.hlsl; do
 	# Generate Metal iOS shader
 	GenerateShader ${SrcName} "../src/gl/metal/shaders/mobile" msl_ios "" metal metal
 done
+
+# Modify ESSL shaders
+sed -i 's/out_var_/varying_/g' ../src/gl/opengl/shaders/mobile/*.vert
+sed -i 's/in_var_/varying_/g' ../src/gl/opengl/shaders/mobile/*.frag

--- a/src/gl/opengl/shaders/mobile/blurFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/blurFragmentShader.frag
@@ -4,13 +4,13 @@ precision highp int;
 
 uniform highp sampler2D SPIRV_Cross_Combinedtexture0sampler0;
 
-in highp vec2 in_var_TEXCOORD0;
-in highp vec2 in_var_TEXCOORD1;
-in highp vec2 in_var_TEXCOORD2;
+in highp vec2 varying_TEXCOORD0;
+in highp vec2 varying_TEXCOORD1;
+in highp vec2 varying_TEXCOORD2;
 layout(location = 0) out highp vec4 out_var_SV_Target;
 
 void main()
 {
-    out_var_SV_Target = ((vec4(0.0, 0.0, 0.0, 0.279009997844696044921875) * texture(SPIRV_Cross_Combinedtexture0sampler0, in_var_TEXCOORD0)) + (vec4(1.0, 1.0, 1.0, 0.44198000431060791015625) * texture(SPIRV_Cross_Combinedtexture0sampler0, in_var_TEXCOORD1))) + (vec4(0.0, 0.0, 0.0, 0.279009997844696044921875) * texture(SPIRV_Cross_Combinedtexture0sampler0, in_var_TEXCOORD2));
+    out_var_SV_Target = ((vec4(0.0, 0.0, 0.0, 0.279009997844696044921875) * texture(SPIRV_Cross_Combinedtexture0sampler0, varying_TEXCOORD0)) + (vec4(1.0, 1.0, 1.0, 0.44198000431060791015625) * texture(SPIRV_Cross_Combinedtexture0sampler0, varying_TEXCOORD1))) + (vec4(0.0, 0.0, 0.0, 0.279009997844696044921875) * texture(SPIRV_Cross_Combinedtexture0sampler0, varying_TEXCOORD2));
 }
 

--- a/src/gl/opengl/shaders/mobile/blurVertexShader.vert
+++ b/src/gl/opengl/shaders/mobile/blurVertexShader.vert
@@ -7,16 +7,16 @@ layout(std140) uniform type_u_EveryFrame
 
 layout(location = 0) in vec3 in_var_POSITION;
 layout(location = 1) in vec2 in_var_TEXCOORD0;
-out vec2 out_var_TEXCOORD0;
-out vec2 out_var_TEXCOORD1;
-out vec2 out_var_TEXCOORD2;
+out vec2 varying_TEXCOORD0;
+out vec2 varying_TEXCOORD1;
+out vec2 varying_TEXCOORD2;
 
 void main()
 {
     vec2 _36 = u_EveryFrame.u_stepSize.xy * 1.41999995708465576171875;
     gl_Position = vec4(in_var_POSITION.xy, 0.0, 1.0);
-    out_var_TEXCOORD0 = in_var_TEXCOORD0 - _36;
-    out_var_TEXCOORD1 = in_var_TEXCOORD0;
-    out_var_TEXCOORD2 = in_var_TEXCOORD0 + _36;
+    varying_TEXCOORD0 = in_var_TEXCOORD0 - _36;
+    varying_TEXCOORD1 = in_var_TEXCOORD0;
+    varying_TEXCOORD2 = in_var_TEXCOORD0 + _36;
 }
 

--- a/src/gl/opengl/shaders/mobile/compassFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/compassFragmentShader.frag
@@ -10,17 +10,17 @@ layout(std140) uniform type_u_cameraPlaneParams
     highp float u_clipZFar;
 } u_cameraPlaneParams;
 
-in highp vec3 in_var_COLOR0;
-in highp vec4 in_var_COLOR1;
-in highp vec3 in_var_COLOR2;
-in highp vec4 in_var_COLOR3;
-in highp vec2 in_var_TEXCOORD0;
+in highp vec3 varying_COLOR0;
+in highp vec4 varying_COLOR1;
+in highp vec3 varying_COLOR2;
+in highp vec4 varying_COLOR3;
+in highp vec2 varying_TEXCOORD0;
 layout(location = 0) out highp vec4 out_var_SV_Target;
 
 void main()
 {
-    highp vec3 _50 = (in_var_COLOR0 * vec3(2.0)) - vec3(1.0);
-    out_var_SV_Target = vec4(((in_var_COLOR1.xyz * (0.5 + (dot(in_var_COLOR2, _50) * (-0.5)))) + (vec3(1.0, 1.0, 0.89999997615814208984375) * pow(max(0.0, -dot(-normalize(in_var_COLOR3.xyz / vec3(in_var_COLOR3.w)), _50)), 60.0))) * in_var_COLOR1.w, 1.0);
-    gl_FragDepth = log2(in_var_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    highp vec3 _50 = (varying_COLOR0 * vec3(2.0)) - vec3(1.0);
+    out_var_SV_Target = vec4(((varying_COLOR1.xyz * (0.5 + (dot(varying_COLOR2, _50) * (-0.5)))) + (vec3(1.0, 1.0, 0.89999997615814208984375) * pow(max(0.0, -dot(-normalize(varying_COLOR3.xyz / vec3(varying_COLOR3.w)), _50)), 60.0))) * varying_COLOR1.w, 1.0);
+    gl_FragDepth = log2(varying_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
 }
 

--- a/src/gl/opengl/shaders/mobile/compassVertexShader.vert
+++ b/src/gl/opengl/shaders/mobile/compassVertexShader.vert
@@ -10,11 +10,11 @@ layout(std140) uniform type_u_EveryObject
 
 layout(location = 0) in vec3 in_var_POSITION;
 layout(location = 1) in vec3 in_var_NORMAL;
-out vec3 out_var_COLOR0;
-out vec4 out_var_COLOR1;
-out vec3 out_var_COLOR2;
-out vec4 out_var_COLOR3;
-out vec2 out_var_TEXCOORD0;
+out vec3 varying_COLOR0;
+out vec4 varying_COLOR1;
+out vec3 varying_COLOR2;
+out vec4 varying_COLOR3;
+out vec2 varying_TEXCOORD0;
 
 vec2 _34;
 
@@ -24,10 +24,10 @@ void main()
     vec2 _53 = _34;
     _53.x = 1.0 + _44.w;
     gl_Position = _44;
-    out_var_COLOR0 = (in_var_NORMAL * 0.5) + vec3(0.5);
-    out_var_COLOR1 = u_EveryObject.u_colour;
-    out_var_COLOR2 = u_EveryObject.u_sunDirection;
-    out_var_COLOR3 = _44;
-    out_var_TEXCOORD0 = _53;
+    varying_COLOR0 = (in_var_NORMAL * 0.5) + vec3(0.5);
+    varying_COLOR1 = u_EveryObject.u_colour;
+    varying_COLOR2 = u_EveryObject.u_sunDirection;
+    varying_COLOR3 = _44;
+    varying_TEXCOORD0 = _53;
 }
 

--- a/src/gl/opengl/shaders/mobile/depthOnlyFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/depthOnlyFragmentShader.frag
@@ -10,15 +10,15 @@ layout(std140) uniform type_u_cameraPlaneParams
     highp float u_clipZFar;
 } u_cameraPlaneParams;
 
-in highp vec2 in_var_TEXCOORD0;
-in highp vec3 in_var_NORMAL;
-in highp vec4 in_var_COLOR0;
-in highp vec2 in_var_TEXCOORD1;
+in highp vec2 varying_TEXCOORD0;
+in highp vec3 varying_NORMAL;
+in highp vec4 varying_COLOR0;
+in highp vec2 varying_TEXCOORD1;
 layout(location = 0) out highp vec4 out_var_SV_Target;
 
 void main()
 {
     out_var_SV_Target = vec4(0.0);
-    gl_FragDepth = log2(in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    gl_FragDepth = log2(varying_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
 }
 

--- a/src/gl/opengl/shaders/mobile/fenceFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/fenceFragmentShader.frag
@@ -12,15 +12,15 @@ layout(std140) uniform type_u_cameraPlaneParams
 
 uniform highp sampler2D SPIRV_Cross_Combinedtexture0sampler0;
 
-in highp vec4 in_var_COLOR0;
-in highp vec2 in_var_TEXCOORD0;
-in highp vec2 in_var_TEXCOORD1;
+in highp vec4 varying_COLOR0;
+in highp vec2 varying_TEXCOORD0;
+in highp vec2 varying_TEXCOORD1;
 layout(location = 0) out highp vec4 out_var_SV_Target;
 
 void main()
 {
-    highp vec4 _40 = texture(SPIRV_Cross_Combinedtexture0sampler0, in_var_TEXCOORD0);
-    out_var_SV_Target = vec4(_40.xyz * in_var_COLOR0.xyz, _40.w * in_var_COLOR0.w);
-    gl_FragDepth = log2(in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    highp vec4 _40 = texture(SPIRV_Cross_Combinedtexture0sampler0, varying_TEXCOORD0);
+    out_var_SV_Target = vec4(_40.xyz * varying_COLOR0.xyz, _40.w * varying_COLOR0.w);
+    gl_FragDepth = log2(varying_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
 }
 

--- a/src/gl/opengl/shaders/mobile/fenceVertexShader.vert
+++ b/src/gl/opengl/shaders/mobile/fenceVertexShader.vert
@@ -21,9 +21,9 @@ layout(std140) uniform type_u_EveryObject
 layout(location = 0) in vec3 in_var_POSITION;
 layout(location = 1) in vec2 in_var_TEXCOORD0;
 layout(location = 2) in vec4 in_var_COLOR0;
-out vec4 out_var_COLOR0;
-out vec2 out_var_TEXCOORD0;
-out vec2 out_var_TEXCOORD1;
+out vec4 varying_COLOR0;
+out vec2 varying_TEXCOORD0;
+out vec2 varying_TEXCOORD1;
 
 vec2 _41;
 
@@ -33,8 +33,8 @@ void main()
     vec2 _85 = _41;
     _85.x = 1.0 + _82.w;
     gl_Position = _82;
-    out_var_COLOR0 = mix(u_EveryFrame.u_bottomColour, u_EveryFrame.u_topColour, vec4(in_var_COLOR0.w));
-    out_var_TEXCOORD0 = vec2((mix(in_var_TEXCOORD0.y, in_var_TEXCOORD0.x, u_EveryFrame.u_orientation) * u_EveryFrame.u_textureRepeatScale) - (u_EveryFrame.u_time * u_EveryFrame.u_textureScrollSpeed), in_var_COLOR0.w);
-    out_var_TEXCOORD1 = _85;
+    varying_COLOR0 = mix(u_EveryFrame.u_bottomColour, u_EveryFrame.u_topColour, vec4(in_var_COLOR0.w));
+    varying_TEXCOORD0 = vec2((mix(in_var_TEXCOORD0.y, in_var_TEXCOORD0.x, u_EveryFrame.u_orientation) * u_EveryFrame.u_textureRepeatScale) - (u_EveryFrame.u_time * u_EveryFrame.u_textureScrollSpeed), in_var_COLOR0.w);
+    varying_TEXCOORD1 = _85;
 }
 

--- a/src/gl/opengl/shaders/mobile/flatColourFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/flatColourFragmentShader.frag
@@ -10,15 +10,15 @@ layout(std140) uniform type_u_cameraPlaneParams
     highp float u_clipZFar;
 } u_cameraPlaneParams;
 
-in highp vec2 in_var_TEXCOORD0;
-in highp vec3 in_var_NORMAL;
-in highp vec4 in_var_COLOR0;
-in highp vec2 in_var_TEXCOORD1;
+in highp vec2 varying_TEXCOORD0;
+in highp vec3 varying_NORMAL;
+in highp vec4 varying_COLOR0;
+in highp vec2 varying_TEXCOORD1;
 layout(location = 0) out highp vec4 out_var_SV_Target;
 
 void main()
 {
-    out_var_SV_Target = in_var_COLOR0;
-    gl_FragDepth = log2(in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    out_var_SV_Target = varying_COLOR0;
+    gl_FragDepth = log2(varying_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
 }
 

--- a/src/gl/opengl/shaders/mobile/highlightFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/highlightFragmentShader.frag
@@ -4,13 +4,13 @@ precision highp int;
 
 uniform highp sampler2D SPIRV_Cross_Combinedu_texturesampler0;
 
-in highp vec2 in_var_TEXCOORD0;
-in highp vec2 in_var_TEXCOORD1;
-in highp vec2 in_var_TEXCOORD2;
-in highp vec2 in_var_TEXCOORD3;
-in highp vec2 in_var_TEXCOORD4;
-in highp vec4 in_var_COLOR0;
-in highp vec4 in_var_COLOR1;
+in highp vec2 varying_TEXCOORD0;
+in highp vec2 varying_TEXCOORD1;
+in highp vec2 varying_TEXCOORD2;
+in highp vec2 varying_TEXCOORD3;
+in highp vec2 varying_TEXCOORD4;
+in highp vec4 varying_COLOR0;
+in highp vec4 varying_COLOR1;
 layout(location = 0) out highp vec4 out_var_SV_Target;
 
 void main()
@@ -20,16 +20,16 @@ void main()
     {
         default:
         {
-            highp vec4 _47 = texture(SPIRV_Cross_Combinedu_texturesampler0, in_var_TEXCOORD0);
+            highp vec4 _47 = texture(SPIRV_Cross_Combinedu_texturesampler0, varying_TEXCOORD0);
             highp float _48 = _47.w;
             highp float _49 = _47.x;
             if (_49 == 0.0)
             {
-                _99 = vec4(in_var_COLOR0.xyz, (_48 * in_var_COLOR1.z) * in_var_COLOR0.w);
+                _99 = vec4(varying_COLOR0.xyz, (_48 * varying_COLOR1.z) * varying_COLOR0.w);
                 break;
             }
-            highp float _63 = 0.1500000059604644775390625 * in_var_COLOR0.w;
-            _99 = vec4(in_var_COLOR0.xyz, max(in_var_COLOR1.w, ((((1.0 - _48) + (_63 * step(texture(SPIRV_Cross_Combinedu_texturesampler0, in_var_TEXCOORD1).x - _49, -9.9999997473787516355514526367188e-06))) + (_63 * step(texture(SPIRV_Cross_Combinedu_texturesampler0, in_var_TEXCOORD2).x - _49, -9.9999997473787516355514526367188e-06))) + (_63 * step(texture(SPIRV_Cross_Combinedu_texturesampler0, in_var_TEXCOORD3).x - _49, -9.9999997473787516355514526367188e-06))) + (_63 * step(texture(SPIRV_Cross_Combinedu_texturesampler0, in_var_TEXCOORD4).x - _49, -9.9999997473787516355514526367188e-06))) * in_var_COLOR0.w);
+            highp float _63 = 0.1500000059604644775390625 * varying_COLOR0.w;
+            _99 = vec4(varying_COLOR0.xyz, max(varying_COLOR1.w, ((((1.0 - _48) + (_63 * step(texture(SPIRV_Cross_Combinedu_texturesampler0, varying_TEXCOORD1).x - _49, -9.9999997473787516355514526367188e-06))) + (_63 * step(texture(SPIRV_Cross_Combinedu_texturesampler0, varying_TEXCOORD2).x - _49, -9.9999997473787516355514526367188e-06))) + (_63 * step(texture(SPIRV_Cross_Combinedu_texturesampler0, varying_TEXCOORD3).x - _49, -9.9999997473787516355514526367188e-06))) + (_63 * step(texture(SPIRV_Cross_Combinedu_texturesampler0, varying_TEXCOORD4).x - _49, -9.9999997473787516355514526367188e-06))) * varying_COLOR0.w);
             break;
         }
     }

--- a/src/gl/opengl/shaders/mobile/highlightVertexShader.vert
+++ b/src/gl/opengl/shaders/mobile/highlightVertexShader.vert
@@ -8,23 +8,23 @@ layout(std140) uniform type_u_EveryFrame
 
 layout(location = 0) in vec3 in_var_POSITION;
 layout(location = 1) in vec2 in_var_TEXCOORD0;
-out vec2 out_var_TEXCOORD0;
-out vec2 out_var_TEXCOORD1;
-out vec2 out_var_TEXCOORD2;
-out vec2 out_var_TEXCOORD3;
-out vec2 out_var_TEXCOORD4;
-out vec4 out_var_COLOR0;
-out vec4 out_var_COLOR1;
+out vec2 varying_TEXCOORD0;
+out vec2 varying_TEXCOORD1;
+out vec2 varying_TEXCOORD2;
+out vec2 varying_TEXCOORD3;
+out vec2 varying_TEXCOORD4;
+out vec4 varying_COLOR0;
+out vec4 varying_COLOR1;
 
 void main()
 {
     gl_Position = vec4(in_var_POSITION.xy, 0.0, 1.0);
-    out_var_TEXCOORD0 = in_var_TEXCOORD0;
-    out_var_TEXCOORD1 = in_var_TEXCOORD0 + (u_EveryFrame.u_stepSizeThickness.xy * vec2(-1.0));
-    out_var_TEXCOORD2 = in_var_TEXCOORD0 + (u_EveryFrame.u_stepSizeThickness.xy * vec2(1.0, -1.0));
-    out_var_TEXCOORD3 = in_var_TEXCOORD0 + (u_EveryFrame.u_stepSizeThickness.xy * vec2(-1.0, 1.0));
-    out_var_TEXCOORD4 = in_var_TEXCOORD0 + u_EveryFrame.u_stepSizeThickness.xy;
-    out_var_COLOR0 = u_EveryFrame.u_colour;
-    out_var_COLOR1 = u_EveryFrame.u_stepSizeThickness;
+    varying_TEXCOORD0 = in_var_TEXCOORD0;
+    varying_TEXCOORD1 = in_var_TEXCOORD0 + (u_EveryFrame.u_stepSizeThickness.xy * vec2(-1.0));
+    varying_TEXCOORD2 = in_var_TEXCOORD0 + (u_EveryFrame.u_stepSizeThickness.xy * vec2(1.0, -1.0));
+    varying_TEXCOORD3 = in_var_TEXCOORD0 + (u_EveryFrame.u_stepSizeThickness.xy * vec2(-1.0, 1.0));
+    varying_TEXCOORD4 = in_var_TEXCOORD0 + u_EveryFrame.u_stepSizeThickness.xy;
+    varying_COLOR0 = u_EveryFrame.u_colour;
+    varying_COLOR1 = u_EveryFrame.u_stepSizeThickness;
 }
 

--- a/src/gl/opengl/shaders/mobile/imageColourSkyboxFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/imageColourSkyboxFragmentShader.frag
@@ -4,14 +4,14 @@ precision highp int;
 
 uniform highp sampler2D SPIRV_Cross_Combinedu_texturesampler0;
 
-in highp vec2 in_var_TEXCOORD0;
-in highp vec4 in_var_COLOR0;
+in highp vec2 varying_TEXCOORD0;
+in highp vec4 varying_COLOR0;
 layout(location = 0) out highp vec4 out_var_SV_Target;
 
 void main()
 {
-    highp vec4 _30 = texture(SPIRV_Cross_Combinedu_texturesampler0, in_var_TEXCOORD0);
-    highp float _33 = min(_30.w, in_var_COLOR0.w);
-    out_var_SV_Target = vec4((_30.xyz * _33) + (in_var_COLOR0.xyz * (1.0 - _33)), 1.0);
+    highp vec4 _30 = texture(SPIRV_Cross_Combinedu_texturesampler0, varying_TEXCOORD0);
+    highp float _33 = min(_30.w, varying_COLOR0.w);
+    out_var_SV_Target = vec4((_30.xyz * _33) + (varying_COLOR0.xyz * (1.0 - _33)), 1.0);
 }
 

--- a/src/gl/opengl/shaders/mobile/imageColourSkyboxVertexShader.vert
+++ b/src/gl/opengl/shaders/mobile/imageColourSkyboxVertexShader.vert
@@ -8,13 +8,13 @@ layout(std140) uniform type_u_EveryFrame
 
 layout(location = 0) in vec3 in_var_POSITION;
 layout(location = 1) in vec2 in_var_TEXCOORD0;
-out vec2 out_var_TEXCOORD0;
-out vec4 out_var_COLOR0;
+out vec2 varying_TEXCOORD0;
+out vec4 varying_COLOR0;
 
 void main()
 {
     gl_Position = vec4(in_var_POSITION.xy, 0.0, 1.0);
-    out_var_TEXCOORD0 = in_var_TEXCOORD0 / u_EveryFrame.u_imageSize.xy;
-    out_var_COLOR0 = u_EveryFrame.u_tintColour;
+    varying_TEXCOORD0 = in_var_TEXCOORD0 / u_EveryFrame.u_imageSize.xy;
+    varying_COLOR0 = u_EveryFrame.u_tintColour;
 }
 

--- a/src/gl/opengl/shaders/mobile/imageRendererBillboardVertexShader.vert
+++ b/src/gl/opengl/shaders/mobile/imageRendererBillboardVertexShader.vert
@@ -9,9 +9,9 @@ layout(std140) uniform type_u_EveryObject
 
 layout(location = 0) in vec3 in_var_POSITION;
 layout(location = 1) in vec2 in_var_TEXCOORD0;
-out vec2 out_var_TEXCOORD0;
-out vec4 out_var_COLOR0;
-out vec2 out_var_TEXCOORD1;
+out vec2 varying_TEXCOORD0;
+out vec4 varying_COLOR0;
+out vec2 varying_TEXCOORD1;
 
 vec2 _32;
 
@@ -23,8 +23,8 @@ void main()
     vec2 _55 = _32;
     _55.x = 1.0 + _44;
     gl_Position = vec4(_50.x, _50.y, _38.z, _38.w);
-    out_var_TEXCOORD0 = in_var_TEXCOORD0;
-    out_var_COLOR0 = u_EveryObject.u_colour;
-    out_var_TEXCOORD1 = _55;
+    varying_TEXCOORD0 = in_var_TEXCOORD0;
+    varying_COLOR0 = u_EveryObject.u_colour;
+    varying_TEXCOORD1 = _55;
 }
 

--- a/src/gl/opengl/shaders/mobile/imageRendererFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/imageRendererFragmentShader.frag
@@ -12,14 +12,14 @@ layout(std140) uniform type_u_cameraPlaneParams
 
 uniform highp sampler2D SPIRV_Cross_Combinedtexture0sampler0;
 
-in highp vec2 in_var_TEXCOORD0;
-in highp vec4 in_var_COLOR0;
-in highp vec2 in_var_TEXCOORD1;
+in highp vec2 varying_TEXCOORD0;
+in highp vec4 varying_COLOR0;
+in highp vec2 varying_TEXCOORD1;
 layout(location = 0) out highp vec4 out_var_SV_Target;
 
 void main()
 {
-    out_var_SV_Target = texture(SPIRV_Cross_Combinedtexture0sampler0, in_var_TEXCOORD0) * in_var_COLOR0;
-    gl_FragDepth = log2(in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    out_var_SV_Target = texture(SPIRV_Cross_Combinedtexture0sampler0, varying_TEXCOORD0) * varying_COLOR0;
+    gl_FragDepth = log2(varying_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
 }
 

--- a/src/gl/opengl/shaders/mobile/imageRendererMeshVertexShader.vert
+++ b/src/gl/opengl/shaders/mobile/imageRendererMeshVertexShader.vert
@@ -10,9 +10,9 @@ layout(std140) uniform type_u_EveryObject
 layout(location = 0) in vec3 in_var_POSITION;
 layout(location = 1) in vec3 in_var_NORMAL;
 layout(location = 2) in vec2 in_var_TEXCOORD0;
-out vec2 out_var_TEXCOORD0;
-out vec4 out_var_COLOR0;
-out vec2 out_var_TEXCOORD1;
+out vec2 varying_TEXCOORD0;
+out vec4 varying_COLOR0;
+out vec2 varying_TEXCOORD1;
 
 vec2 _29;
 
@@ -22,8 +22,8 @@ void main()
     vec2 _44 = _29;
     _44.x = 1.0 + _39.w;
     gl_Position = _39;
-    out_var_TEXCOORD0 = in_var_TEXCOORD0;
-    out_var_COLOR0 = u_EveryObject.u_colour;
-    out_var_TEXCOORD1 = _44;
+    varying_TEXCOORD0 = in_var_TEXCOORD0;
+    varying_COLOR0 = u_EveryObject.u_colour;
+    varying_TEXCOORD1 = _44;
 }
 

--- a/src/gl/opengl/shaders/mobile/imgui3DVertexShader.vert
+++ b/src/gl/opengl/shaders/mobile/imgui3DVertexShader.vert
@@ -9,15 +9,15 @@ layout(std140) uniform type_u_EveryObject
 layout(location = 0) in vec2 in_var_POSITION;
 layout(location = 1) in vec2 in_var_TEXCOORD0;
 layout(location = 2) in vec4 in_var_COLOR0;
-out vec4 out_var_COLOR0;
-out vec2 out_var_TEXCOORD0;
+out vec4 varying_COLOR0;
+out vec2 varying_TEXCOORD0;
 
 void main()
 {
     vec4 _35 = vec4(0.0, 0.0, 0.0, 1.0) * u_EveryObject.u_worldViewProjectionMatrix;
     vec2 _43 = _35.xy + ((u_EveryObject.u_screenSize.xy * in_var_POSITION) * _35.w);
     gl_Position = vec4(_43.x, _43.y, _35.z, _35.w);
-    out_var_COLOR0 = in_var_COLOR0;
-    out_var_TEXCOORD0 = in_var_TEXCOORD0;
+    varying_COLOR0 = in_var_COLOR0;
+    varying_TEXCOORD0 = in_var_TEXCOORD0;
 }
 

--- a/src/gl/opengl/shaders/mobile/imguiFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/imguiFragmentShader.frag
@@ -4,12 +4,12 @@ precision highp int;
 
 uniform highp sampler2D SPIRV_Cross_Combinedtexture0sampler0;
 
-in highp vec4 in_var_COLOR0;
-in highp vec2 in_var_TEXCOORD0;
+in highp vec4 varying_COLOR0;
+in highp vec2 varying_TEXCOORD0;
 layout(location = 0) out highp vec4 out_var_SV_Target;
 
 void main()
 {
-    out_var_SV_Target = in_var_COLOR0 * texture(SPIRV_Cross_Combinedtexture0sampler0, in_var_TEXCOORD0);
+    out_var_SV_Target = varying_COLOR0 * texture(SPIRV_Cross_Combinedtexture0sampler0, varying_TEXCOORD0);
 }
 

--- a/src/gl/opengl/shaders/mobile/imguiVertexShader.vert
+++ b/src/gl/opengl/shaders/mobile/imguiVertexShader.vert
@@ -8,13 +8,13 @@ layout(std140) uniform type_u_EveryFrame
 layout(location = 0) in vec2 in_var_POSITION;
 layout(location = 1) in vec2 in_var_TEXCOORD0;
 layout(location = 2) in vec4 in_var_COLOR0;
-out vec4 out_var_COLOR0;
-out vec2 out_var_TEXCOORD0;
+out vec4 varying_COLOR0;
+out vec2 varying_TEXCOORD0;
 
 void main()
 {
     gl_Position = vec4(in_var_POSITION, 0.0, 1.0) * u_EveryFrame.ProjectionMatrix;
-    out_var_COLOR0 = in_var_COLOR0;
-    out_var_TEXCOORD0 = in_var_TEXCOORD0;
+    varying_COLOR0 = in_var_COLOR0;
+    varying_TEXCOORD0 = in_var_TEXCOORD0;
 }
 

--- a/src/gl/opengl/shaders/mobile/panoramaSkyboxFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/panoramaSkyboxFragmentShader.frag
@@ -9,12 +9,12 @@ layout(std140) uniform type_u_EveryFrame
 
 uniform highp sampler2D SPIRV_Cross_Combinedu_texturesampler0;
 
-in highp vec4 in_var_TEXCOORD0;
+in highp vec4 varying_TEXCOORD0;
 layout(location = 0) out highp vec4 out_var_SV_Target;
 
 void main()
 {
-    highp vec4 _40 = vec4(in_var_TEXCOORD0.xy, 1.0, 1.0) * u_EveryFrame.u_inverseViewProjection;
+    highp vec4 _40 = vec4(varying_TEXCOORD0.xy, 1.0, 1.0) * u_EveryFrame.u_inverseViewProjection;
     highp vec3 _45 = normalize(_40.xyz / vec3(_40.w));
     out_var_SV_Target = texture(SPIRV_Cross_Combinedu_texturesampler0, vec2(atan(_45.x, _45.y) + 3.1415927410125732421875, acos(_45.z)) * vec2(0.15915493667125701904296875, 0.3183098733425140380859375));
 }

--- a/src/gl/opengl/shaders/mobile/panoramaSkyboxVertexShader.vert
+++ b/src/gl/opengl/shaders/mobile/panoramaSkyboxVertexShader.vert
@@ -2,12 +2,12 @@
 
 layout(location = 0) in vec3 in_var_POSITION;
 layout(location = 1) in vec2 in_var_TEXCOORD0;
-out vec4 out_var_TEXCOORD0;
+out vec4 varying_TEXCOORD0;
 
 void main()
 {
     vec4 _21 = vec4(in_var_POSITION.xy, 0.0, 1.0);
     gl_Position = _21;
-    out_var_TEXCOORD0 = _21;
+    varying_TEXCOORD0 = _21;
 }
 

--- a/src/gl/opengl/shaders/mobile/polygonP3N3UV2FragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/polygonP3N3UV2FragmentShader.frag
@@ -12,16 +12,16 @@ layout(std140) uniform type_u_cameraPlaneParams
 
 uniform highp sampler2D SPIRV_Cross_Combinedtexture0sampler0;
 
-in highp vec2 in_var_TEXCOORD0;
-in highp vec3 in_var_NORMAL;
-in highp vec4 in_var_COLOR0;
-in highp vec2 in_var_TEXCOORD1;
+in highp vec2 varying_TEXCOORD0;
+in highp vec3 varying_NORMAL;
+in highp vec4 varying_COLOR0;
+in highp vec2 varying_TEXCOORD1;
 layout(location = 0) out highp vec4 out_var_SV_Target;
 
 void main()
 {
-    highp vec4 _48 = texture(SPIRV_Cross_Combinedtexture0sampler0, in_var_TEXCOORD0) * in_var_COLOR0;
-    out_var_SV_Target = vec4(_48.xyz * ((dot(in_var_NORMAL, normalize(vec3(0.85000002384185791015625, 0.1500000059604644775390625, 0.5))) * 0.5) + 0.5), _48.w);
-    gl_FragDepth = log2(in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    highp vec4 _48 = texture(SPIRV_Cross_Combinedtexture0sampler0, varying_TEXCOORD0) * varying_COLOR0;
+    out_var_SV_Target = vec4(_48.xyz * ((dot(varying_NORMAL, normalize(vec3(0.85000002384185791015625, 0.1500000059604644775390625, 0.5))) * 0.5) + 0.5), _48.w);
+    gl_FragDepth = log2(varying_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
 }
 

--- a/src/gl/opengl/shaders/mobile/polygonP3N3UV2VertexShader.vert
+++ b/src/gl/opengl/shaders/mobile/polygonP3N3UV2VertexShader.vert
@@ -10,10 +10,10 @@ layout(std140) uniform type_u_EveryObject
 layout(location = 0) in vec3 in_var_POSITION;
 layout(location = 1) in vec3 in_var_NORMAL;
 layout(location = 2) in vec2 in_var_TEXCOORD0;
-out vec2 out_var_TEXCOORD0;
-out vec3 out_var_NORMAL;
-out vec4 out_var_COLOR0;
-out vec2 out_var_TEXCOORD1;
+out vec2 varying_TEXCOORD0;
+out vec3 varying_NORMAL;
+out vec4 varying_COLOR0;
+out vec2 varying_TEXCOORD1;
 
 vec2 _34;
 
@@ -23,9 +23,9 @@ void main()
     vec2 _59 = _34;
     _59.x = 1.0 + _54.w;
     gl_Position = _54;
-    out_var_TEXCOORD0 = in_var_TEXCOORD0;
-    out_var_NORMAL = normalize((vec4(in_var_NORMAL, 0.0) * u_EveryObject.u_worldMatrix).xyz);
-    out_var_COLOR0 = u_EveryObject.u_colour;
-    out_var_TEXCOORD1 = _59;
+    varying_TEXCOORD0 = in_var_TEXCOORD0;
+    varying_NORMAL = normalize((vec4(in_var_NORMAL, 0.0) * u_EveryObject.u_worldMatrix).xyz);
+    varying_COLOR0 = u_EveryObject.u_colour;
+    varying_TEXCOORD1 = _59;
 }
 

--- a/src/gl/opengl/shaders/mobile/postEffectsFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/postEffectsFragmentShader.frag
@@ -5,13 +5,13 @@ precision highp int;
 uniform highp sampler2D SPIRV_Cross_Combinedtexture1sampler1;
 uniform highp sampler2D SPIRV_Cross_Combinedtexture0sampler0;
 
-in highp vec2 in_var_TEXCOORD0;
-in highp vec2 in_var_TEXCOORD1;
-in highp vec2 in_var_TEXCOORD2;
-in highp vec2 in_var_TEXCOORD3;
-in highp vec2 in_var_TEXCOORD4;
-in highp vec2 in_var_TEXCOORD5;
-in highp float in_var_TEXCOORD6;
+in highp vec2 varying_TEXCOORD0;
+in highp vec2 varying_TEXCOORD1;
+in highp vec2 varying_TEXCOORD2;
+in highp vec2 varying_TEXCOORD3;
+in highp vec2 varying_TEXCOORD4;
+in highp vec2 varying_TEXCOORD5;
+in highp float varying_TEXCOORD6;
 layout(location = 0) out highp vec4 out_var_SV_Target;
 
 float _66;
@@ -20,12 +20,12 @@ vec2 _68;
 
 void main()
 {
-    highp vec4 _80 = texture(SPIRV_Cross_Combinedtexture1sampler1, in_var_TEXCOORD0);
+    highp vec4 _80 = texture(SPIRV_Cross_Combinedtexture1sampler1, varying_TEXCOORD0);
     highp float _81 = _80.x;
     highp vec4 _535;
-    if ((1.0 - (((step(abs(texture(SPIRV_Cross_Combinedtexture1sampler1, in_var_TEXCOORD1).x - _81), 0.0030000000260770320892333984375) * step(abs(texture(SPIRV_Cross_Combinedtexture1sampler1, in_var_TEXCOORD2).x - _81), 0.0030000000260770320892333984375)) * step(abs(texture(SPIRV_Cross_Combinedtexture1sampler1, in_var_TEXCOORD3).x - _81), 0.0030000000260770320892333984375)) * step(abs(texture(SPIRV_Cross_Combinedtexture1sampler1, in_var_TEXCOORD4).x - _81), 0.0030000000260770320892333984375))) == 0.0)
+    if ((1.0 - (((step(abs(texture(SPIRV_Cross_Combinedtexture1sampler1, varying_TEXCOORD1).x - _81), 0.0030000000260770320892333984375) * step(abs(texture(SPIRV_Cross_Combinedtexture1sampler1, varying_TEXCOORD2).x - _81), 0.0030000000260770320892333984375)) * step(abs(texture(SPIRV_Cross_Combinedtexture1sampler1, varying_TEXCOORD3).x - _81), 0.0030000000260770320892333984375)) * step(abs(texture(SPIRV_Cross_Combinedtexture1sampler1, varying_TEXCOORD4).x - _81), 0.0030000000260770320892333984375))) == 0.0)
     {
-        _535 = texture(SPIRV_Cross_Combinedtexture0sampler0, in_var_TEXCOORD0);
+        _535 = texture(SPIRV_Cross_Combinedtexture0sampler0, varying_TEXCOORD0);
     }
     else
     {
@@ -35,9 +35,9 @@ void main()
             default:
             {
                 highp vec2 _123 = _67;
-                _123.x = in_var_TEXCOORD0.x;
+                _123.x = varying_TEXCOORD0.x;
                 highp vec2 _125 = _123;
-                _125.y = in_var_TEXCOORD0.y;
+                _125.y = varying_TEXCOORD0.y;
                 highp vec4 _127 = textureLod(SPIRV_Cross_Combinedtexture0sampler0, _125, 0.0);
                 highp vec4 _129 = textureLodOffset(SPIRV_Cross_Combinedtexture0sampler0, _125, 0.0, ivec2(0, 1));
                 highp float _130 = _129.y;
@@ -75,11 +75,11 @@ void main()
                 highp float _209;
                 if (_200)
                 {
-                    _209 = in_var_TEXCOORD5.y;
+                    _209 = varying_TEXCOORD5.y;
                 }
                 else
                 {
-                    _209 = in_var_TEXCOORD5.x;
+                    _209 = varying_TEXCOORD5.x;
                 }
                 highp float _216 = abs(_204 - _140);
                 highp float _217 = abs(_205 - _140);
@@ -94,13 +94,13 @@ void main()
                     _223 = _209;
                 }
                 highp float _226 = clamp(abs(((((_167 + _168) * 2.0) + (_180 + _174)) * 0.083333335816860198974609375) - _140) * (1.0 / _150), 0.0, 1.0);
-                highp float _227 = _203 ? 0.0 : in_var_TEXCOORD5.x;
-                highp float _229 = _200 ? 0.0 : in_var_TEXCOORD5.y;
+                highp float _227 = _203 ? 0.0 : varying_TEXCOORD5.x;
+                highp float _229 = _200 ? 0.0 : varying_TEXCOORD5.y;
                 highp vec2 _235;
                 if (_203)
                 {
                     highp vec2 _234 = _125;
-                    _234.x = in_var_TEXCOORD0.x + (_223 * 0.5);
+                    _234.x = varying_TEXCOORD0.x + (_223 * 0.5);
                     _235 = _234;
                 }
                 else
@@ -483,27 +483,27 @@ void main()
                 highp float _494;
                 if (_203)
                 {
-                    _494 = in_var_TEXCOORD0.y - _483.y;
+                    _494 = varying_TEXCOORD0.y - _483.y;
                 }
                 else
                 {
-                    _494 = in_var_TEXCOORD0.x - _483.x;
+                    _494 = varying_TEXCOORD0.x - _483.x;
                 }
                 highp float _499;
                 if (_203)
                 {
-                    _499 = _482.y - in_var_TEXCOORD0.y;
+                    _499 = _482.y - varying_TEXCOORD0.y;
                 }
                 else
                 {
-                    _499 = _482.x - in_var_TEXCOORD0.x;
+                    _499 = _482.x - varying_TEXCOORD0.x;
                 }
                 highp float _514 = max(((_494 < _499) ? ((_485 < 0.0) != _268) : ((_484 < 0.0) != _268)) ? ((min(_494, _499) * ((-1.0) / (_499 + _494))) + 0.5) : 0.0, (_267 * _267) * 0.75);
                 highp vec2 _520;
                 if (_203)
                 {
                     highp vec2 _519 = _125;
-                    _519.x = in_var_TEXCOORD0.x + (_514 * _223);
+                    _519.x = varying_TEXCOORD0.x + (_514 * _223);
                     _520 = _519;
                 }
                 else
@@ -527,6 +527,6 @@ void main()
         }
         _535 = _534;
     }
-    out_var_SV_Target = vec4(mix(vec3(dot(_535.xyz, vec3(0.2125000059604644775390625, 0.7153999805450439453125, 0.07209999859333038330078125))), _535.xyz, vec3(in_var_TEXCOORD6)), 1.0);
+    out_var_SV_Target = vec4(mix(vec3(dot(_535.xyz, vec3(0.2125000059604644775390625, 0.7153999805450439453125, 0.07209999859333038330078125))), _535.xyz, vec3(varying_TEXCOORD6)), 1.0);
 }
 

--- a/src/gl/opengl/shaders/mobile/postEffectsVertexShader.vert
+++ b/src/gl/opengl/shaders/mobile/postEffectsVertexShader.vert
@@ -8,23 +8,23 @@ layout(std140) uniform type_u_params
 
 layout(location = 0) in vec3 in_var_POSITION;
 layout(location = 1) in vec2 in_var_TEXCOORD0;
-out vec2 out_var_TEXCOORD0;
-out vec2 out_var_TEXCOORD1;
-out vec2 out_var_TEXCOORD2;
-out vec2 out_var_TEXCOORD3;
-out vec2 out_var_TEXCOORD4;
-out vec2 out_var_TEXCOORD5;
-out float out_var_TEXCOORD6;
+out vec2 varying_TEXCOORD0;
+out vec2 varying_TEXCOORD1;
+out vec2 varying_TEXCOORD2;
+out vec2 varying_TEXCOORD3;
+out vec2 varying_TEXCOORD4;
+out vec2 varying_TEXCOORD5;
+out float varying_TEXCOORD6;
 
 void main()
 {
     gl_Position = vec4(in_var_POSITION.xy, 0.0, 1.0);
-    out_var_TEXCOORD0 = in_var_TEXCOORD0;
-    out_var_TEXCOORD1 = in_var_TEXCOORD0 + u_params.u_screenParams.xy;
-    out_var_TEXCOORD2 = in_var_TEXCOORD0 - u_params.u_screenParams.xy;
-    out_var_TEXCOORD3 = in_var_TEXCOORD0 + vec2(u_params.u_screenParams.x, -u_params.u_screenParams.y);
-    out_var_TEXCOORD4 = in_var_TEXCOORD0 + vec2(-u_params.u_screenParams.x, u_params.u_screenParams.y);
-    out_var_TEXCOORD5 = u_params.u_screenParams.xy;
-    out_var_TEXCOORD6 = u_params.u_saturation.x;
+    varying_TEXCOORD0 = in_var_TEXCOORD0;
+    varying_TEXCOORD1 = in_var_TEXCOORD0 + u_params.u_screenParams.xy;
+    varying_TEXCOORD2 = in_var_TEXCOORD0 - u_params.u_screenParams.xy;
+    varying_TEXCOORD3 = in_var_TEXCOORD0 + vec2(u_params.u_screenParams.x, -u_params.u_screenParams.y);
+    varying_TEXCOORD4 = in_var_TEXCOORD0 + vec2(-u_params.u_screenParams.x, u_params.u_screenParams.y);
+    varying_TEXCOORD5 = u_params.u_screenParams.xy;
+    varying_TEXCOORD6 = u_params.u_saturation.x;
 }
 

--- a/src/gl/opengl/shaders/mobile/tileFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/tileFragmentShader.frag
@@ -12,14 +12,14 @@ layout(std140) uniform type_u_cameraPlaneParams
 
 uniform highp sampler2D SPIRV_Cross_Combinedtexture0sampler0;
 
-in highp vec4 in_var_COLOR0;
-in highp vec2 in_var_TEXCOORD0;
-in highp vec2 in_var_TEXCOORD1;
+in highp vec4 varying_COLOR0;
+in highp vec2 varying_TEXCOORD0;
+in highp vec2 varying_TEXCOORD1;
 layout(location = 0) out highp vec4 out_var_SV_Target;
 
 void main()
 {
-    out_var_SV_Target = vec4(texture(SPIRV_Cross_Combinedtexture0sampler0, in_var_TEXCOORD0).xyz * in_var_COLOR0.xyz, in_var_COLOR0.w);
-    gl_FragDepth = log2(in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    out_var_SV_Target = vec4(texture(SPIRV_Cross_Combinedtexture0sampler0, varying_TEXCOORD0).xyz * varying_COLOR0.xyz, varying_COLOR0.w);
+    gl_FragDepth = log2(varying_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
 }
 

--- a/src/gl/opengl/shaders/mobile/tileVertexShader.vert
+++ b/src/gl/opengl/shaders/mobile/tileVertexShader.vert
@@ -14,9 +14,9 @@ layout(std140) uniform type_u_EveryObject
 uniform highp sampler2D SPIRV_Cross_Combinedtexture1sampler1;
 
 layout(location = 0) in vec3 in_var_POSITION;
-out vec4 out_var_COLOR0;
-out vec2 out_var_TEXCOORD0;
-out vec2 out_var_TEXCOORD1;
+out vec4 varying_COLOR0;
+out vec2 varying_TEXCOORD0;
+out vec2 varying_TEXCOORD1;
 
 vec2 _47;
 
@@ -38,8 +38,8 @@ void main()
     vec2 _128 = _47;
     _128.x = 1.0 + _117.w;
     gl_Position = _117;
-    out_var_COLOR0 = u_EveryObject.u_colour;
-    out_var_TEXCOORD0 = u_EveryObject.u_uvOffsetScale.xy + (u_EveryObject.u_uvOffsetScale.zw * in_var_POSITION.xy);
-    out_var_TEXCOORD1 = _128;
+    varying_COLOR0 = u_EveryObject.u_colour;
+    varying_TEXCOORD0 = u_EveryObject.u_uvOffsetScale.xy + (u_EveryObject.u_uvOffsetScale.zw * in_var_POSITION.xy);
+    varying_TEXCOORD1 = _128;
 }
 

--- a/src/gl/opengl/shaders/mobile/udFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/udFragmentShader.frag
@@ -5,12 +5,12 @@ precision highp int;
 uniform highp sampler2D SPIRV_Cross_Combinedtexture0sampler0;
 uniform highp sampler2D SPIRV_Cross_Combinedtexture1sampler1;
 
-in highp vec2 in_var_TEXCOORD0;
+in highp vec2 varying_TEXCOORD0;
 layout(location = 0) out highp vec4 out_var_SV_Target;
 
 void main()
 {
-    out_var_SV_Target = vec4(texture(SPIRV_Cross_Combinedtexture0sampler0, in_var_TEXCOORD0).xyz, 1.0);
-    gl_FragDepth = texture(SPIRV_Cross_Combinedtexture1sampler1, in_var_TEXCOORD0).x;
+    out_var_SV_Target = vec4(texture(SPIRV_Cross_Combinedtexture0sampler0, varying_TEXCOORD0).xyz, 1.0);
+    gl_FragDepth = texture(SPIRV_Cross_Combinedtexture1sampler1, varying_TEXCOORD0).x;
 }
 

--- a/src/gl/opengl/shaders/mobile/udSplatIdFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/udSplatIdFragmentShader.frag
@@ -10,13 +10,13 @@ layout(std140) uniform type_u_params
 uniform highp sampler2D SPIRV_Cross_Combinedtexture0sampler0;
 uniform highp sampler2D SPIRV_Cross_Combinedtexture1sampler1;
 
-in highp vec2 in_var_TEXCOORD0;
+in highp vec2 varying_TEXCOORD0;
 layout(location = 0) out highp vec4 out_var_SV_Target;
 
 void main()
 {
-    highp vec4 _42 = texture(SPIRV_Cross_Combinedtexture0sampler0, in_var_TEXCOORD0);
-    highp vec4 _46 = texture(SPIRV_Cross_Combinedtexture1sampler1, in_var_TEXCOORD0);
+    highp vec4 _42 = texture(SPIRV_Cross_Combinedtexture0sampler0, varying_TEXCOORD0);
+    highp vec4 _46 = texture(SPIRV_Cross_Combinedtexture1sampler1, varying_TEXCOORD0);
     highp float _51 = _42.w;
     highp vec4 _59;
     if ((u_params.u_idOverride.w == 0.0) || (abs(u_params.u_idOverride.w - _51) <= 0.00150000001303851604461669921875))

--- a/src/gl/opengl/shaders/mobile/udVertexShader.vert
+++ b/src/gl/opengl/shaders/mobile/udVertexShader.vert
@@ -2,11 +2,11 @@
 
 layout(location = 0) in vec3 in_var_POSITION;
 layout(location = 1) in vec2 in_var_TEXCOORD0;
-out vec2 out_var_TEXCOORD0;
+out vec2 varying_TEXCOORD0;
 
 void main()
 {
     gl_Position = vec4(in_var_POSITION.xy, 0.0, 1.0);
-    out_var_TEXCOORD0 = in_var_TEXCOORD0;
+    varying_TEXCOORD0 = in_var_TEXCOORD0;
 }
 

--- a/src/gl/opengl/shaders/mobile/viewShedFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/viewShedFragmentShader.frag
@@ -22,16 +22,16 @@ layout(std140) uniform type_u_params
 uniform highp sampler2D SPIRV_Cross_Combinedtexture0sampler0;
 uniform highp sampler2D SPIRV_Cross_Combinedtexture1sampler1;
 
-in highp vec4 in_var_TEXCOORD0;
-in highp vec2 in_var_TEXCOORD1;
+in highp vec4 varying_TEXCOORD0;
+in highp vec2 varying_TEXCOORD1;
 layout(location = 0) out highp vec4 out_var_SV_Target;
 
 void main()
 {
-    highp vec4 _61 = texture(SPIRV_Cross_Combinedtexture0sampler0, in_var_TEXCOORD1);
+    highp vec4 _61 = texture(SPIRV_Cross_Combinedtexture0sampler0, varying_TEXCOORD1);
     highp float _67 = u_cameraPlaneParams.s_CameraFarPlane - u_cameraPlaneParams.s_CameraNearPlane;
     highp float _73 = log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0);
-    highp vec4 _91 = vec4(in_var_TEXCOORD0.xy, (((u_cameraPlaneParams.s_CameraFarPlane / _67) + (((u_cameraPlaneParams.s_CameraFarPlane * u_cameraPlaneParams.s_CameraNearPlane) / (u_cameraPlaneParams.s_CameraNearPlane - u_cameraPlaneParams.s_CameraFarPlane)) / (pow(2.0, _61.x * _73) - 1.0))) * (u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear)) + u_cameraPlaneParams.u_clipZNear, 1.0) * u_params.u_inverseProjection;
+    highp vec4 _91 = vec4(varying_TEXCOORD0.xy, (((u_cameraPlaneParams.s_CameraFarPlane / _67) + (((u_cameraPlaneParams.s_CameraFarPlane * u_cameraPlaneParams.s_CameraNearPlane) / (u_cameraPlaneParams.s_CameraNearPlane - u_cameraPlaneParams.s_CameraFarPlane)) / (pow(2.0, _61.x * _73) - 1.0))) * (u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear)) + u_cameraPlaneParams.u_clipZNear, 1.0) * u_params.u_inverseProjection;
     highp vec4 _100 = vec4((_91 / vec4(_91.w)).xyz, 1.0);
     highp vec4 _101 = _100 * u_params.u_shadowMapVP[0];
     highp vec4 _104 = _100 * u_params.u_shadowMapVP[1];

--- a/src/gl/opengl/shaders/mobile/viewShedVertexShader.vert
+++ b/src/gl/opengl/shaders/mobile/viewShedVertexShader.vert
@@ -2,14 +2,14 @@
 
 layout(location = 0) in vec3 in_var_POSITION;
 layout(location = 1) in vec2 in_var_TEXCOORD0;
-out vec4 out_var_TEXCOORD0;
-out vec2 out_var_TEXCOORD1;
+out vec4 varying_TEXCOORD0;
+out vec2 varying_TEXCOORD1;
 
 void main()
 {
     vec4 _24 = vec4(in_var_POSITION.xy, 0.0, 1.0);
     gl_Position = _24;
-    out_var_TEXCOORD0 = _24;
-    out_var_TEXCOORD1 = in_var_TEXCOORD0;
+    varying_TEXCOORD0 = _24;
+    varying_TEXCOORD1 = in_var_TEXCOORD0;
 }
 

--- a/src/gl/opengl/shaders/mobile/visualizationFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/visualizationFragmentShader.frag
@@ -29,25 +29,25 @@ layout(std140) uniform type_u_fragParams
 uniform highp sampler2D SPIRV_Cross_Combinedtexture0sampler0;
 uniform highp sampler2D SPIRV_Cross_Combinedtexture1sampler1;
 
-in highp vec4 in_var_TEXCOORD0;
-in highp vec2 in_var_TEXCOORD1;
-in highp vec2 in_var_TEXCOORD2;
-in highp vec2 in_var_TEXCOORD3;
-in highp vec2 in_var_TEXCOORD4;
-in highp vec2 in_var_TEXCOORD5;
+in highp vec4 varying_TEXCOORD0;
+in highp vec2 varying_TEXCOORD1;
+in highp vec2 varying_TEXCOORD2;
+in highp vec2 varying_TEXCOORD3;
+in highp vec2 varying_TEXCOORD4;
+in highp vec2 varying_TEXCOORD5;
 layout(location = 0) out highp vec4 out_var_SV_Target;
 
 void main()
 {
-    highp vec4 _77 = texture(SPIRV_Cross_Combinedtexture0sampler0, in_var_TEXCOORD1);
-    highp vec4 _81 = texture(SPIRV_Cross_Combinedtexture1sampler1, in_var_TEXCOORD1);
+    highp vec4 _77 = texture(SPIRV_Cross_Combinedtexture0sampler0, varying_TEXCOORD1);
+    highp vec4 _81 = texture(SPIRV_Cross_Combinedtexture1sampler1, varying_TEXCOORD1);
     highp float _82 = _81.x;
     highp float _88 = u_cameraPlaneParams.s_CameraFarPlane / (u_cameraPlaneParams.s_CameraFarPlane - u_cameraPlaneParams.s_CameraNearPlane);
     highp float _91 = (u_cameraPlaneParams.s_CameraFarPlane * u_cameraPlaneParams.s_CameraNearPlane) / (u_cameraPlaneParams.s_CameraNearPlane - u_cameraPlaneParams.s_CameraFarPlane);
     highp float _93 = log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0);
     highp float _103 = u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear;
     highp float _105 = ((_88 + (_91 / (pow(2.0, _82 * _93) - 1.0))) * _103) + u_cameraPlaneParams.u_clipZNear;
-    highp vec4 _110 = vec4(in_var_TEXCOORD0.xy, _105, 1.0);
+    highp vec4 _110 = vec4(varying_TEXCOORD0.xy, _105, 1.0);
     highp vec4 _111 = _110 * u_fragParams.u_inverseViewProjection;
     highp vec4 _114 = _111 / vec4(_111.w);
     highp vec4 _117 = _110 * u_fragParams.u_inverseProjection;
@@ -58,19 +58,19 @@ void main()
     highp vec4 _351;
     if ((u_fragParams.u_outlineParams.x > 0.0) && (u_fragParams.u_outlineColour.w > 0.0))
     {
-        highp vec4 _222 = vec4((in_var_TEXCOORD1.x * 2.0) - 1.0, (in_var_TEXCOORD1.y * 2.0) - 1.0, _105, 1.0) * u_fragParams.u_inverseProjection;
-        highp vec4 _227 = texture(SPIRV_Cross_Combinedtexture1sampler1, in_var_TEXCOORD2);
+        highp vec4 _222 = vec4((varying_TEXCOORD1.x * 2.0) - 1.0, (varying_TEXCOORD1.y * 2.0) - 1.0, _105, 1.0) * u_fragParams.u_inverseProjection;
+        highp vec4 _227 = texture(SPIRV_Cross_Combinedtexture1sampler1, varying_TEXCOORD2);
         highp float _228 = _227.x;
-        highp vec4 _230 = texture(SPIRV_Cross_Combinedtexture1sampler1, in_var_TEXCOORD3);
+        highp vec4 _230 = texture(SPIRV_Cross_Combinedtexture1sampler1, varying_TEXCOORD3);
         highp float _231 = _230.x;
-        highp vec4 _233 = texture(SPIRV_Cross_Combinedtexture1sampler1, in_var_TEXCOORD4);
+        highp vec4 _233 = texture(SPIRV_Cross_Combinedtexture1sampler1, varying_TEXCOORD4);
         highp float _234 = _233.x;
-        highp vec4 _236 = texture(SPIRV_Cross_Combinedtexture1sampler1, in_var_TEXCOORD5);
+        highp vec4 _236 = texture(SPIRV_Cross_Combinedtexture1sampler1, varying_TEXCOORD5);
         highp float _237 = _236.x;
-        highp vec4 _252 = vec4((in_var_TEXCOORD2.x * 2.0) - 1.0, (in_var_TEXCOORD2.y * 2.0) - 1.0, ((_88 + (_91 / (pow(2.0, _228 * _93) - 1.0))) * _103) + u_cameraPlaneParams.u_clipZNear, 1.0) * u_fragParams.u_inverseProjection;
-        highp vec4 _267 = vec4((in_var_TEXCOORD3.x * 2.0) - 1.0, (in_var_TEXCOORD3.y * 2.0) - 1.0, ((_88 + (_91 / (pow(2.0, _231 * _93) - 1.0))) * _103) + u_cameraPlaneParams.u_clipZNear, 1.0) * u_fragParams.u_inverseProjection;
-        highp vec4 _282 = vec4((in_var_TEXCOORD4.x * 2.0) - 1.0, (in_var_TEXCOORD4.y * 2.0) - 1.0, ((_88 + (_91 / (pow(2.0, _234 * _93) - 1.0))) * _103) + u_cameraPlaneParams.u_clipZNear, 1.0) * u_fragParams.u_inverseProjection;
-        highp vec4 _297 = vec4((in_var_TEXCOORD5.x * 2.0) - 1.0, (in_var_TEXCOORD5.y * 2.0) - 1.0, ((_88 + (_91 / (pow(2.0, _237 * _93) - 1.0))) * _103) + u_cameraPlaneParams.u_clipZNear, 1.0) * u_fragParams.u_inverseProjection;
+        highp vec4 _252 = vec4((varying_TEXCOORD2.x * 2.0) - 1.0, (varying_TEXCOORD2.y * 2.0) - 1.0, ((_88 + (_91 / (pow(2.0, _228 * _93) - 1.0))) * _103) + u_cameraPlaneParams.u_clipZNear, 1.0) * u_fragParams.u_inverseProjection;
+        highp vec4 _267 = vec4((varying_TEXCOORD3.x * 2.0) - 1.0, (varying_TEXCOORD3.y * 2.0) - 1.0, ((_88 + (_91 / (pow(2.0, _231 * _93) - 1.0))) * _103) + u_cameraPlaneParams.u_clipZNear, 1.0) * u_fragParams.u_inverseProjection;
+        highp vec4 _282 = vec4((varying_TEXCOORD4.x * 2.0) - 1.0, (varying_TEXCOORD4.y * 2.0) - 1.0, ((_88 + (_91 / (pow(2.0, _234 * _93) - 1.0))) * _103) + u_cameraPlaneParams.u_clipZNear, 1.0) * u_fragParams.u_inverseProjection;
+        highp vec4 _297 = vec4((varying_TEXCOORD5.x * 2.0) - 1.0, (varying_TEXCOORD5.y * 2.0) - 1.0, ((_88 + (_91 / (pow(2.0, _237 * _93) - 1.0))) * _103) + u_cameraPlaneParams.u_clipZNear, 1.0) * u_fragParams.u_inverseProjection;
         highp vec3 _310 = (_222 / vec4(_222.w)).xyz;
         highp vec4 _347 = mix(vec4(_200, _82), vec4(mix(_200.xyz, u_fragParams.u_outlineColour.xyz, vec3(u_fragParams.u_outlineColour.w)), min(min(min(_228, _231), _234), _237)), vec4(1.0 - (((step(length(_310 - (_252 / vec4(_252.w)).xyz), u_fragParams.u_outlineParams.y) * step(length(_310 - (_267 / vec4(_267.w)).xyz), u_fragParams.u_outlineParams.y)) * step(length(_310 - (_282 / vec4(_282.w)).xyz), u_fragParams.u_outlineParams.y)) * step(length(_310 - (_297 / vec4(_297.w)).xyz), u_fragParams.u_outlineParams.y))));
         _350 = _347.w;

--- a/src/gl/opengl/shaders/mobile/visualizationVertexShader.vert
+++ b/src/gl/opengl/shaders/mobile/visualizationVertexShader.vert
@@ -7,12 +7,12 @@ layout(std140) uniform type_u_vertParams
 
 layout(location = 0) in vec3 in_var_POSITION;
 layout(location = 1) in vec2 in_var_TEXCOORD0;
-out vec4 out_var_TEXCOORD0;
-out vec2 out_var_TEXCOORD1;
-out vec2 out_var_TEXCOORD2;
-out vec2 out_var_TEXCOORD3;
-out vec2 out_var_TEXCOORD4;
-out vec2 out_var_TEXCOORD5;
+out vec4 varying_TEXCOORD0;
+out vec2 varying_TEXCOORD1;
+out vec2 varying_TEXCOORD2;
+out vec2 varying_TEXCOORD3;
+out vec2 varying_TEXCOORD4;
+out vec2 varying_TEXCOORD5;
 
 void main()
 {
@@ -21,11 +21,11 @@ void main()
     vec2 _40 = _39.xz;
     vec2 _43 = _39.zy;
     gl_Position = _34;
-    out_var_TEXCOORD0 = _34;
-    out_var_TEXCOORD1 = in_var_TEXCOORD0;
-    out_var_TEXCOORD2 = in_var_TEXCOORD0 + _40;
-    out_var_TEXCOORD3 = in_var_TEXCOORD0 - _40;
-    out_var_TEXCOORD4 = in_var_TEXCOORD0 + _43;
-    out_var_TEXCOORD5 = in_var_TEXCOORD0 - _43;
+    varying_TEXCOORD0 = _34;
+    varying_TEXCOORD1 = in_var_TEXCOORD0;
+    varying_TEXCOORD2 = in_var_TEXCOORD0 + _40;
+    varying_TEXCOORD3 = in_var_TEXCOORD0 - _40;
+    varying_TEXCOORD4 = in_var_TEXCOORD0 + _43;
+    varying_TEXCOORD5 = in_var_TEXCOORD0 - _43;
 }
 

--- a/src/gl/opengl/shaders/mobile/waterFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/waterFragmentShader.frag
@@ -12,19 +12,19 @@ layout(std140) uniform type_u_EveryFrameFrag
 uniform highp sampler2D SPIRV_Cross_Combinedu_normalMapsampler0;
 uniform highp sampler2D SPIRV_Cross_Combinedu_skyboxsampler1;
 
-in highp vec2 in_var_TEXCOORD0;
-in highp vec2 in_var_TEXCOORD1;
-in highp vec4 in_var_COLOR0;
-in highp vec4 in_var_COLOR1;
+in highp vec2 varying_TEXCOORD0;
+in highp vec2 varying_TEXCOORD1;
+in highp vec4 varying_COLOR0;
+in highp vec4 varying_COLOR1;
 layout(location = 0) out highp vec4 out_var_SV_Target;
 
 void main()
 {
-    highp vec3 _77 = normalize(((texture(SPIRV_Cross_Combinedu_normalMapsampler0, in_var_TEXCOORD0).xyz * vec3(2.0)) - vec3(1.0)) + ((texture(SPIRV_Cross_Combinedu_normalMapsampler0, in_var_TEXCOORD1).xyz * vec3(2.0)) - vec3(1.0)));
-    highp vec3 _79 = normalize(in_var_COLOR0.xyz);
+    highp vec3 _77 = normalize(((texture(SPIRV_Cross_Combinedu_normalMapsampler0, varying_TEXCOORD0).xyz * vec3(2.0)) - vec3(1.0)) + ((texture(SPIRV_Cross_Combinedu_normalMapsampler0, varying_TEXCOORD1).xyz * vec3(2.0)) - vec3(1.0)));
+    highp vec3 _79 = normalize(varying_COLOR0.xyz);
     highp vec3 _95 = normalize((vec4(_77, 0.0) * u_EveryFrameFrag.u_eyeNormalMatrix).xyz);
     highp vec3 _97 = normalize(reflect(_79, _95));
     highp vec3 _121 = normalize((vec4(_97, 0.0) * u_EveryFrameFrag.u_inverseViewMatrix).xyz);
-    out_var_SV_Target = vec4(mix(texture(SPIRV_Cross_Combinedu_skyboxsampler1, vec2(atan(_121.x, _121.y) + 3.1415927410125732421875, acos(_121.z)) * vec2(0.15915493667125701904296875, 0.3183098733425140380859375)).xyz, in_var_COLOR1.xyz * mix(vec3(1.0, 1.0, 0.60000002384185791015625), vec3(0.3499999940395355224609375), vec3(pow(max(0.0, _77.z), 5.0))), vec3(((dot(_95, _79) * (-0.5)) + 0.5) * 0.75)) + vec3(pow(abs(dot(_97, normalize((vec4(normalize(u_EveryFrameFrag.u_specularDir.xyz), 0.0) * u_EveryFrameFrag.u_eyeNormalMatrix).xyz))), 50.0) * 0.5), 1.0);
+    out_var_SV_Target = vec4(mix(texture(SPIRV_Cross_Combinedu_skyboxsampler1, vec2(atan(_121.x, _121.y) + 3.1415927410125732421875, acos(_121.z)) * vec2(0.15915493667125701904296875, 0.3183098733425140380859375)).xyz, varying_COLOR1.xyz * mix(vec3(1.0, 1.0, 0.60000002384185791015625), vec3(0.3499999940395355224609375), vec3(pow(max(0.0, _77.z), 5.0))), vec3(((dot(_95, _79) * (-0.5)) + 0.5) * 0.75)) + vec3(pow(abs(dot(_97, normalize((vec4(normalize(u_EveryFrameFrag.u_specularDir.xyz), 0.0) * u_EveryFrameFrag.u_eyeNormalMatrix).xyz))), 50.0) * 0.5), 1.0);
 }
 

--- a/src/gl/opengl/shaders/mobile/waterVertexShader.vert
+++ b/src/gl/opengl/shaders/mobile/waterVertexShader.vert
@@ -13,19 +13,19 @@ layout(std140) uniform type_u_EveryObject
 } u_EveryObject;
 
 layout(location = 0) in vec2 in_var_POSITION;
-out vec2 out_var_TEXCOORD0;
-out vec2 out_var_TEXCOORD1;
-out vec4 out_var_COLOR0;
-out vec3 out_var_COLOR1;
+out vec2 varying_TEXCOORD0;
+out vec2 varying_TEXCOORD1;
+out vec4 varying_COLOR0;
+out vec3 varying_COLOR1;
 
 void main()
 {
     float _48 = u_EveryFrameVert.u_time.x * 0.0625;
     vec4 _63 = vec4(in_var_POSITION, 0.0, 1.0);
     gl_Position = _63 * u_EveryObject.u_worldViewProjectionMatrix;
-    out_var_TEXCOORD0 = ((in_var_POSITION * u_EveryObject.u_colourAndSize.w) * vec2(0.25)) - vec2(_48);
-    out_var_TEXCOORD1 = ((in_var_POSITION.yx * u_EveryObject.u_colourAndSize.w) * vec2(0.5)) - vec2(_48, u_EveryFrameVert.u_time.x * 0.046875);
-    out_var_COLOR0 = _63 * u_EveryObject.u_worldViewMatrix;
-    out_var_COLOR1 = u_EveryObject.u_colourAndSize.xyz;
+    varying_TEXCOORD0 = ((in_var_POSITION * u_EveryObject.u_colourAndSize.w) * vec2(0.25)) - vec2(_48);
+    varying_TEXCOORD1 = ((in_var_POSITION.yx * u_EveryObject.u_colourAndSize.w) * vec2(0.5)) - vec2(_48, u_EveryFrameVert.u_time.x * 0.046875);
+    varying_COLOR0 = _63 * u_EveryObject.u_worldViewMatrix;
+    varying_COLOR1 = u_EveryObject.u_colourAndSize.xyz;
 }
 

--- a/src/vcModals.cpp
+++ b/src/vcModals.cpp
@@ -221,6 +221,11 @@ bool vcModals_OverwriteExistingFile(const char *pFilename)
 // Presents user with a message if the specified file exists, then returns false if user declines to overwrite the file
 bool vcModals_AllowDestructiveAction(const char *pTitle, const char *pMessage)
 {
+#if UDPLATFORM_EMSCRIPTEN
+  udUnused(pTitle);
+  udUnused(pMessage);
+  return true;
+#else
   bool result = false;
 
   const SDL_MessageBoxButtonData buttons[] = {
@@ -255,6 +260,7 @@ bool vcModals_AllowDestructiveAction(const char *pTitle, const char *pMessage)
     result = true;
 
   return result;
+#endif
 }
 
 // Returns true if user accepts ending the session

--- a/src/vcWebFile.cpp
+++ b/src/vcWebFile.cpp
@@ -20,8 +20,9 @@ static udResult vcWebFile_Load(udFile *pFile, void **ppBuffer, int64_t *pBufferL
 
   UD_ERROR_IF(vdkWeb_RequestAdv(pFile->pFilenameCopy, options, &pData, &dataLength, &responseCode) != vE_Success, udR_ReadFailure);
 
-  *ppBuffer = udMemDup(pData, dataLength, 0, udAF_None);
+  *ppBuffer = udMemDup(pData, dataLength, 1, udAF_None);
   UD_ERROR_NULL(*ppBuffer, udR_MemoryAllocationFailure);
+  ((char *)*ppBuffer)[dataLength] = 0;
 
   if (pBufferLength != nullptr)
     *pBufferLength = (int64_t)dataLength;


### PR DESCRIPTION
- OpenGL ES shaders use varying between stages instead of in_var and out_var
- Emscripten temporarily ignores destructive action prompt due to lack of message box system
- Fixed bug in vcWebFile that would result in text files not being null terminated when using udFile_Load