### PR TITLE
awu/ClearConvertOutputName.

### DIFF
--- a/src/vcConvert.cpp
+++ b/src/vcConvert.cpp
@@ -716,6 +716,8 @@ void vcConvert_ShowUI(vcState *pProgramState)
             while (pSelectedJob->pConvertInfo->totalItems > 0)
               vdkConvert_RemoveItem(pSelectedJob->pConvertContext, 0);
 
+            vdkConvert_SetOutputFilename(pSelectedJob->pConvertContext, "");
+
             udLockMutex(pSelectedJob->pMutex);
             while (pSelectedJob->itemsToProcess.length > 0)
             {


### PR DESCRIPTION
[AB#858](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/858).

The ".uds" was left, it can only be fixed in vdk. Or it is better to clear the whole file name in vdk.