### PR TITLE
Fhart/line move node fix

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1531,13 +1531,6 @@ void vcRenderScene_HandlePicking(vcState *pProgramState, vcRenderData &renderDat
           // ...and indeed we have a valid polygon as a pick result
           // ...and the polygon we have picked is a POI
           // ...and the internal ID of the picked polygon is valid (at least, 0 ==  not the entire model)
-
-          pickResult.pPolygon->pSceneItem->SelectSubitem(pickResult.pPolygon->sceneItemInternalId);
-          pProgramState->activeTool = vcActiveTool_Select;
-          pProgramState->gizmo.operation = vcGO_Translate;
-        }
-        else
-        {
           pPOI->AddPoint(pProgramState, pProgramState->worldMousePosCartesian);
         }
       }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1516,12 +1516,22 @@ void vcRenderScene_HandlePicking(vcState *pProgramState, vcRenderData &renderDat
 
     case vcActiveTool_MeasureLine:
     case vcActiveTool_MeasureArea:
+
+      //Are these checks necessary? If a tool is being used would that not suggest we indeed have a valid clickedItem?
       if (pProgramState->sceneExplorer.clickedItem.pItem != nullptr && pProgramState->sceneExplorer.clickedItem.pItem->itemtype == vdkPNT_PointOfInterest)
       {
         vcPOI *pPOI = (vcPOI*)pProgramState->sceneExplorer.clickedItem.pItem->pUserData;
 
         if (selectPolygons && pickResult.pPolygon != nullptr && pickResult.pPolygon->pSceneItem == pPOI && pickResult.pPolygon->sceneItemInternalId != 0)
         {
+          // This is a fair chunk of state we need to query before we get here. I've had to write this out just to understand what state we are in...
+          // In the scene explorer, we have a valid item in focus
+          // ...and this item is a POI
+          // Now, out of the two 'types' of entites we can pick (ud and mesh) we are trying to select a polygon (mesh?)
+          // ...and indeed we have a valid polygon as a pick result
+          // ...and the polygon we have picked is a POI
+          // ...and the internal ID of the picked polygon is valid (at least, 0 ==  not the entire model)
+
           pickResult.pPolygon->pSceneItem->SelectSubitem(pickResult.pPolygon->sceneItemInternalId);
           pProgramState->activeTool = vcActiveTool_Select;
           pProgramState->gizmo.operation = vcGO_Translate;

--- a/src/scene/vcPOI.cpp
+++ b/src/scene/vcPOI.cpp
@@ -197,8 +197,19 @@ void vcPOI::AddToScene(vcState *pProgramState, vcRenderData *pRenderData)
     return;
 
   bool isMeasuring = (pProgramState->activeTool == vcActiveTool_MeasureLine || pProgramState->activeTool == vcActiveTool_MeasureArea);
+  bool wasPreviouslyPreviewing = m_hasPreviewPoint;
   if (m_hasPreviewPoint && (!m_selected || !isMeasuring))
     ChangeProjection(pProgramState->gis.zone);
+
+  //Preview has ended
+  if (wasPreviouslyPreviewing && !m_hasPreviewPoint)
+  {
+    if (m_pFence != nullptr)
+    {
+      vcFenceRenderer_ClearPoints(m_pFence);
+      vcFenceRenderer_AddPoints(m_pFence, m_line.pPoints, m_line.numPoints, m_line.closed);
+    }
+  }
 
   if (m_selected)
   {


### PR DESCRIPTION
[AB#1356](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1356) 
EDIT: also [AB#1355](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1355)
New changes while in line measurement mode:
 - clicking will add new nodes in the line
 - escape will cancel line measure mode