### PR TITLE
Turned off any tile face culling

### DIFF
--- a/src/rendering/vcTileRenderer.cpp
+++ b/src/rendering/vcTileRenderer.cpp
@@ -1064,9 +1064,10 @@ void vcTileRenderer_Render(vcTileRenderer *pTileRenderer, const udDouble4x4 &vie
 
   udDouble4x4 viewWithMapTranslation = view * udDouble4x4::translation(0, 0, pTileRenderer->pSettings->maptiles.mapHeight);
 
-  vcGLStateCullMode cullMode = vcGLSCM_Back;
-  if (cameraInsideGround)
-    cullMode = vcGLSCM_Front;
+  udUnused(cameraInsideGround);
+  vcGLStateCullMode cullMode = vcGLSCM_None;
+  //if (cameraInsideGround)
+  //  cullMode = vcGLSCM_Front;
 
   vcGLState_SetFaceMode(vcGLSFM_Solid, cullMode);
   vcGLState_SetDepthStencilMode(vcGLSDM_LessOrEqual, true);

--- a/src/vcRender.cpp
+++ b/src/vcRender.cpp
@@ -721,6 +721,7 @@ void vcRenderTerrain(vcState *pProgramState, vcRenderContext *pRenderContext)
     udDouble3 cameraToZeroAltitude = localCamPos - cameraZeroAltitude;
     double cameraDistanceToAltitudeZero = udMag3(cameraToZeroAltitude);
 
+    //This might be difficult to do now that tiles are height-mapped.
     // TODO: Fix this
     // determine if camera is 'inside' the ground
     //udDouble3 zoneRoot = udGeoZone_LatLongToCartesian(pProgramState->gis.zone, udDouble3::zero());


### PR DESCRIPTION
[AB#1216](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1216)

I turned off tile face culling.  Being able to see tiles from underneath just seems cleaner, and easier to know where you are if you go below ground. I didn't see any noticeable performance hit in doing so.