### PR TITLE
Fixed issues with Metal crashing

### DIFF
--- a/src/gl/directx11/shaders/flatColourFragmentShader.hlsl
+++ b/src/gl/directx11/shaders/flatColourFragmentShader.hlsl
@@ -18,7 +18,6 @@ struct PS_INPUT
 struct PS_OUTPUT
 {
   float4 Color0 : SV_Target;
-  float Depth0 : SV_Depth;
 };
 
 PS_OUTPUT main(PS_INPUT input)
@@ -26,9 +25,6 @@ PS_OUTPUT main(PS_INPUT input)
   PS_OUTPUT output;
 
   output.Color0 = input.colour;
-
-  float halfFcoef = 1.0 / log2(s_CameraFarPlane + 1.0);
-  output.Depth0 = log2(input.fLogDepth.x) * halfFcoef;
 
   return output;
 }

--- a/src/gl/directx11/shaders/udSplatIdFragmentShader.hlsl
+++ b/src/gl/directx11/shaders/udSplatIdFragmentShader.hlsl
@@ -15,7 +15,6 @@ struct PS_INPUT
 struct PS_OUTPUT
 {
   float4 Color0 : SV_Target;
-  float Depth0 : SV_Depth;
 };
 
 cbuffer u_params : register(b0)
@@ -26,9 +25,6 @@ cbuffer u_params : register(b0)
 sampler sampler0;
 Texture2D texture0;
 
-sampler sampler1;
-Texture2D texture1;
-
 bool floatEquals(float a, float b)
 {
   return abs(a - b) <= 0.0015f;
@@ -38,7 +34,6 @@ PS_OUTPUT main(PS_INPUT input)
 {
   PS_OUTPUT output;
   float4 col = texture0.Sample(sampler0, input.uv);
-  float depth = texture1.Sample(sampler1, input.uv).x;
 
   output.Color0 = float4(0.0, 0.0, 0.0, 0.0);
   if ((u_idOverride.w == 0.0 || floatEquals(u_idOverride.w, col.w)))
@@ -46,6 +41,5 @@ PS_OUTPUT main(PS_INPUT input)
     output.Color0 = float4(col.w, 0, 0, 1.0);
   }
 
-  output.Depth0 = depth;
   return output;
 }

--- a/src/gl/metal/shaders/desktop/flatColourFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/flatColourFragmentShader.metal
@@ -3,31 +3,20 @@
 
 using namespace metal;
 
-struct type_u_cameraPlaneParams
-{
-    float s_CameraNearPlane;
-    float s_CameraFarPlane;
-    float u_clipZNear;
-    float u_clipZFar;
-};
-
 struct main0_out
 {
     float4 out_var_SV_Target [[color(0)]];
-    float gl_FragDepth [[depth(any)]];
 };
 
 struct main0_in
 {
     float4 in_var_COLOR0 [[user(locn2)]];
-    float2 in_var_TEXCOORD1 [[user(locn3)]];
 };
 
-fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]])
+fragment main0_out main0(main0_in in [[stage_in]])
 {
     main0_out out = {};
     out.out_var_SV_Target = in.in_var_COLOR0;
-    out.gl_FragDepth = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
     return out;
 }
 

--- a/src/gl/metal/shaders/desktop/udSplatIdFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/udSplatIdFragmentShader.metal
@@ -11,7 +11,6 @@ struct type_u_params
 struct main0_out
 {
     float4 out_var_SV_Target [[color(0)]];
-    float gl_FragDepth [[depth(any)]];
 };
 
 struct main0_in
@@ -19,23 +18,21 @@ struct main0_in
     float2 in_var_TEXCOORD0 [[user(locn0)]];
 };
 
-fragment main0_out main0(main0_in in [[stage_in]], constant type_u_params& u_params [[buffer(0)]], texture2d<float> texture0 [[texture(0)]], texture2d<float> texture1 [[texture(1)]], sampler sampler0 [[sampler(0)]], sampler sampler1 [[sampler(1)]])
+fragment main0_out main0(main0_in in [[stage_in]], constant type_u_params& u_params [[buffer(0)]], texture2d<float> texture0 [[texture(0)]], sampler sampler0 [[sampler(0)]])
 {
     main0_out out = {};
-    float4 _42 = texture0.sample(sampler0, in.in_var_TEXCOORD0);
-    float4 _46 = texture1.sample(sampler1, in.in_var_TEXCOORD0);
-    float _51 = _42.w;
-    float4 _59;
-    if ((u_params.u_idOverride.w == 0.0) || (abs(u_params.u_idOverride.w - _51) <= 0.00150000001303851604461669921875))
+    float4 _38 = texture0.sample(sampler0, in.in_var_TEXCOORD0);
+    float _42 = _38.w;
+    float4 _50;
+    if ((u_params.u_idOverride.w == 0.0) || (abs(u_params.u_idOverride.w - _42) <= 0.00150000001303851604461669921875))
     {
-        _59 = float4(_51, 0.0, 0.0, 1.0);
+        _50 = float4(_42, 0.0, 0.0, 1.0);
     }
     else
     {
-        _59 = float4(0.0);
+        _50 = float4(0.0);
     }
-    out.out_var_SV_Target = _59;
-    out.gl_FragDepth = _46.x;
+    out.out_var_SV_Target = _50;
     return out;
 }
 

--- a/src/gl/metal/shaders/mobile/flatColourFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/flatColourFragmentShader.metal
@@ -3,31 +3,20 @@
 
 using namespace metal;
 
-struct type_u_cameraPlaneParams
-{
-    float s_CameraNearPlane;
-    float s_CameraFarPlane;
-    float u_clipZNear;
-    float u_clipZFar;
-};
-
 struct main0_out
 {
     float4 out_var_SV_Target [[color(0)]];
-    float gl_FragDepth [[depth(any)]];
 };
 
 struct main0_in
 {
     float4 in_var_COLOR0 [[user(locn2)]];
-    float2 in_var_TEXCOORD1 [[user(locn3)]];
 };
 
-fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]])
+fragment main0_out main0(main0_in in [[stage_in]])
 {
     main0_out out = {};
     out.out_var_SV_Target = in.in_var_COLOR0;
-    out.gl_FragDepth = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
     return out;
 }
 

--- a/src/gl/metal/shaders/mobile/udSplatIdFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/udSplatIdFragmentShader.metal
@@ -11,7 +11,6 @@ struct type_u_params
 struct main0_out
 {
     float4 out_var_SV_Target [[color(0)]];
-    float gl_FragDepth [[depth(any)]];
 };
 
 struct main0_in
@@ -19,23 +18,21 @@ struct main0_in
     float2 in_var_TEXCOORD0 [[user(locn0)]];
 };
 
-fragment main0_out main0(main0_in in [[stage_in]], constant type_u_params& u_params [[buffer(0)]], texture2d<float> texture0 [[texture(0)]], texture2d<float> texture1 [[texture(1)]], sampler sampler0 [[sampler(0)]], sampler sampler1 [[sampler(1)]])
+fragment main0_out main0(main0_in in [[stage_in]], constant type_u_params& u_params [[buffer(0)]], texture2d<float> texture0 [[texture(0)]], sampler sampler0 [[sampler(0)]])
 {
     main0_out out = {};
-    float4 _42 = texture0.sample(sampler0, in.in_var_TEXCOORD0);
-    float4 _46 = texture1.sample(sampler1, in.in_var_TEXCOORD0);
-    float _51 = _42.w;
-    float4 _59;
-    if ((u_params.u_idOverride.w == 0.0) || (abs(u_params.u_idOverride.w - _51) <= 0.00150000001303851604461669921875))
+    float4 _38 = texture0.sample(sampler0, in.in_var_TEXCOORD0);
+    float _42 = _38.w;
+    float4 _50;
+    if ((u_params.u_idOverride.w == 0.0) || (abs(u_params.u_idOverride.w - _42) <= 0.00150000001303851604461669921875))
     {
-        _59 = float4(_51, 0.0, 0.0, 1.0);
+        _50 = float4(_42, 0.0, 0.0, 1.0);
     }
     else
     {
-        _59 = float4(0.0);
+        _50 = float4(0.0);
     }
-    out.out_var_SV_Target = _59;
-    out.gl_FragDepth = _46.x;
+    out.out_var_SV_Target = _50;
     return out;
 }
 

--- a/src/gl/opengl/shaders/desktop/flatColourFragmentShader.frag
+++ b/src/gl/opengl/shaders/desktop/flatColourFragmentShader.frag
@@ -1,14 +1,6 @@
 #version 330
 #extension GL_ARB_separate_shader_objects : require
 
-layout(std140) uniform type_u_cameraPlaneParams
-{
-    float s_CameraNearPlane;
-    float s_CameraFarPlane;
-    float u_clipZNear;
-    float u_clipZFar;
-} u_cameraPlaneParams;
-
 layout(location = 0) in vec2 in_var_TEXCOORD0;
 layout(location = 1) in vec3 in_var_NORMAL;
 layout(location = 2) in vec4 in_var_COLOR0;
@@ -18,6 +10,5 @@ layout(location = 0) out vec4 out_var_SV_Target;
 void main()
 {
     out_var_SV_Target = in_var_COLOR0;
-    gl_FragDepth = log2(in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
 }
 

--- a/src/gl/opengl/shaders/desktop/udSplatIdFragmentShader.frag
+++ b/src/gl/opengl/shaders/desktop/udSplatIdFragmentShader.frag
@@ -7,26 +7,23 @@ layout(std140) uniform type_u_params
 } u_params;
 
 uniform sampler2D SPIRV_Cross_Combinedtexture0sampler0;
-uniform sampler2D SPIRV_Cross_Combinedtexture1sampler1;
 
 layout(location = 0) in vec2 in_var_TEXCOORD0;
 layout(location = 0) out vec4 out_var_SV_Target;
 
 void main()
 {
-    vec4 _42 = texture(SPIRV_Cross_Combinedtexture0sampler0, in_var_TEXCOORD0);
-    vec4 _46 = texture(SPIRV_Cross_Combinedtexture1sampler1, in_var_TEXCOORD0);
-    float _51 = _42.w;
-    vec4 _59;
-    if ((u_params.u_idOverride.w == 0.0) || (abs(u_params.u_idOverride.w - _51) <= 0.00150000001303851604461669921875))
+    vec4 _38 = texture(SPIRV_Cross_Combinedtexture0sampler0, in_var_TEXCOORD0);
+    float _42 = _38.w;
+    vec4 _50;
+    if ((u_params.u_idOverride.w == 0.0) || (abs(u_params.u_idOverride.w - _42) <= 0.00150000001303851604461669921875))
     {
-        _59 = vec4(_51, 0.0, 0.0, 1.0);
+        _50 = vec4(_42, 0.0, 0.0, 1.0);
     }
     else
     {
-        _59 = vec4(0.0);
+        _50 = vec4(0.0);
     }
-    out_var_SV_Target = _59;
-    gl_FragDepth = _46.x;
+    out_var_SV_Target = _50;
 }
 

--- a/src/gl/opengl/shaders/mobile/flatColourFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/flatColourFragmentShader.frag
@@ -2,14 +2,6 @@
 precision mediump float;
 precision highp int;
 
-layout(std140) uniform type_u_cameraPlaneParams
-{
-    highp float s_CameraNearPlane;
-    highp float s_CameraFarPlane;
-    highp float u_clipZNear;
-    highp float u_clipZFar;
-} u_cameraPlaneParams;
-
 in highp vec2 varying_TEXCOORD0;
 in highp vec3 varying_NORMAL;
 in highp vec4 varying_COLOR0;
@@ -19,6 +11,5 @@ layout(location = 0) out highp vec4 out_var_SV_Target;
 void main()
 {
     out_var_SV_Target = varying_COLOR0;
-    gl_FragDepth = log2(varying_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
 }
 

--- a/src/gl/opengl/shaders/mobile/udSplatIdFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/udSplatIdFragmentShader.frag
@@ -8,26 +8,23 @@ layout(std140) uniform type_u_params
 } u_params;
 
 uniform highp sampler2D SPIRV_Cross_Combinedtexture0sampler0;
-uniform highp sampler2D SPIRV_Cross_Combinedtexture1sampler1;
 
 in highp vec2 varying_TEXCOORD0;
 layout(location = 0) out highp vec4 out_var_SV_Target;
 
 void main()
 {
-    highp vec4 _42 = texture(SPIRV_Cross_Combinedtexture0sampler0, varying_TEXCOORD0);
-    highp vec4 _46 = texture(SPIRV_Cross_Combinedtexture1sampler1, varying_TEXCOORD0);
-    highp float _51 = _42.w;
-    highp vec4 _59;
-    if ((u_params.u_idOverride.w == 0.0) || (abs(u_params.u_idOverride.w - _51) <= 0.00150000001303851604461669921875))
+    highp vec4 _38 = texture(SPIRV_Cross_Combinedtexture0sampler0, varying_TEXCOORD0);
+    highp float _42 = _38.w;
+    highp vec4 _50;
+    if ((u_params.u_idOverride.w == 0.0) || (abs(u_params.u_idOverride.w - _42) <= 0.00150000001303851604461669921875))
     {
-        _59 = vec4(_51, 0.0, 0.0, 1.0);
+        _50 = vec4(_42, 0.0, 0.0, 1.0);
     }
     else
     {
-        _59 = vec4(0.0);
+        _50 = vec4(0.0);
     }
-    out_var_SV_Target = _59;
-    gl_FragDepth = _46.x;
+    out_var_SV_Target = _50;
 }
 

--- a/src/vcRender.cpp
+++ b/src/vcRender.cpp
@@ -665,7 +665,6 @@ void vcRender_SplatUDWithId(vcState *pProgramState, vcRenderContext *pRenderCont
   vcShader_Bind(pRenderContext->udRenderContext.splatIdShader.pProgram);
 
   vcShader_BindTexture(pRenderContext->udRenderContext.splatIdShader.pProgram, pRenderContext->udRenderContext.pColourTex, 0, pRenderContext->udRenderContext.splatIdShader.uniform_texture);
-  vcShader_BindTexture(pRenderContext->udRenderContext.splatIdShader.pProgram, pRenderContext->udRenderContext.pDepthTex, 1, pRenderContext->udRenderContext.splatIdShader.uniform_depth);
 
   pRenderContext->udRenderContext.splatIdShader.params.id = udFloat4::create(0.0f, 0.0f, 0.0f, id);
   vcShader_BindConstantBuffer(pRenderContext->udRenderContext.splatIdShader.pProgram, pRenderContext->udRenderContext.splatIdShader.uniform_params, &pRenderContext->udRenderContext.splatIdShader.params, sizeof(pRenderContext->udRenderContext.splatIdShader.params));


### PR DESCRIPTION
- udSplatIdFragmentShader no longer writes to a non-existent depth buffer
- flatColourFragmentShader no longer writes to a non-existent depth buffer
- No longer bind now unused depth texture for udSplatIdFragmentShader

Resolves [AB#481](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/481)
Resolves [AB#563](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/563)