### PR TITLE
The maximum attached camera speed was separated from moving speed now.

### DIFF
--- a/src/scene/vcPOI.cpp
+++ b/src/scene/vcPOI.cpp
@@ -548,7 +548,7 @@ void vcPOI::HandleImGui(vcState *pProgramState, size_t *pItemID)
   if (m_attachment.pModel != nullptr)
   {
     const double minSpeed = 0.0;
-    const double maxSpeed = vcSL_CameraMaxMoveSpeed;
+    const double maxSpeed = vcSL_CameraMaxAttachSpeed;
 
     if (ImGui::SliderScalar(vcString::Get("scenePOIAttachmentSpeed"), ImGuiDataType_Double, &m_attachment.moveSpeed, &minSpeed, &maxSpeed))
     {
@@ -625,7 +625,7 @@ void vcPOI::HandleAttachmentUI(vcState * /*pProgramState*/)
   if (m_cameraFollowingAttachment)
   {
     const double minSpeed = 0.0;
-    const double maxSpeed = vcSL_CameraMaxMoveSpeed;
+    const double maxSpeed = vcSL_CameraMaxAttachSpeed;
 
     if (ImGui::SliderScalar(vcString::Get("scenePOIAttachmentSpeed"), ImGuiDataType_Double, &m_attachment.moveSpeed, &minSpeed, &maxSpeed))
     {

--- a/src/vcSettings.h
+++ b/src/vcSettings.h
@@ -333,7 +333,8 @@ const float vcSL_GlobalLimitf = (float)vcSL_GlobalLimit;
 const float vcSL_GlobalLimitSmallf = (float)vcSL_GlobalLimitSmall;
 
 const float vcSL_CameraMinMoveSpeed = 0.5f;
-const float vcSL_CameraMaxMoveSpeed = 500.f;
+const float vcSL_CameraMaxMoveSpeed = 1000000.f;
+const float vcSL_CameraMaxAttachSpeed = 500.f;
 const float vcSL_CameraFieldOfViewMin = 5;
 const float vcSL_CameraFieldOfViewMax = 100;
 


### PR DESCRIPTION
[AB#1445](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1445).