### PR TITLE
Fixed bug when closing polygon, also refactored code

### DIFF
--- a/builds/assets/lang/enAU.json
+++ b/builds/assets/lang/enAU.json
@@ -205,6 +205,8 @@
   "settingsVisClassRename": "Rename",
   "settingsVisClassSet": "Set",
 
+  "settingsToolsDefaultValues": "Default values for new tool items" 
+
   "settingsConvert": "Convert Defaults",
 
   "convertTitle": "Convert",

--- a/builds/defaultsettings.json
+++ b/builds/defaultsettings.json
@@ -53,6 +53,21 @@
     "minIntensity": 0,
     "maxIntensity": 65535
   },
+  "tools": {
+    "line": {
+      "minWidth": 0.01,
+      "maxWidth": 1000.0,
+      "width": 7.0,
+      "fenceMode": 0,
+      "style": 0,
+      "colour": [ 1.000000, 1.000000, 1.000000, 1.000000 ]
+    },
+    "label": {
+      "textColour": [ 1.000000, 1.000000, 1.000000, 1.000000 ],
+      "backgroundColour": [ 0, 0, 0, 0.5 ],
+      "textSize": 1
+    }
+  },
   "postVisualization": {
     "edgeOutlines": {
       "enabled": false,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1055,10 +1055,6 @@ void vcRenderSceneUI(vcState *pProgramState, const ImVec2 &windowPos, const ImVe
           char bufferB[128];
           vcHotkey::GetKeyName(vcB_Cancel, bufferB);
           ImGui::TextUnformatted(vcStringFormat(bufferA, udLengthOf(bufferA), vcString::Get("toolMeasureNext"), bufferB));
-
-          ImGui::Separator();
-
-          pSceneItem->HandleToolUI(pProgramState);
         }
         else
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1049,8 +1049,6 @@ void vcRenderSceneUI(vcState *pProgramState, const ImVec2 &windowPos, const ImVe
       {
         if (pProgramState->sceneExplorer.clickedItem.pItem != nullptr && pProgramState->sceneExplorer.clickedItem.pItem->itemtype == vdkPNT_PointOfInterest && pProgramState->sceneExplorer.clickedItem.pItem->pUserData != nullptr)
         {
-          vcSceneItem *pSceneItem = (vcSceneItem*)pProgramState->sceneExplorer.clickedItem.pItem->pUserData;
-
           char bufferA[128];
           char bufferB[128];
           vcHotkey::GetKeyName(vcB_Cancel, bufferB);

--- a/src/scene/vcPOI.cpp
+++ b/src/scene/vcPOI.cpp
@@ -151,7 +151,7 @@ vcPOIState *vcPOIState_Append::ChangeState(vcState *pProgramState)
     if (m_pParent->m_pFence != nullptr)
     {
       vcFenceRenderer_ClearPoints(m_pParent->m_pFence);
-      vcFenceRenderer_AddPoints(m_pParent->m_pFence, m_pParent->m_line.pPoints, m_pParent->m_line.numPoints, m_pParent->m_line.closed);
+      vcFenceRenderer_AddPoints(m_pParent->m_pFence, m_pParent->m_line.pPoints, m_pParent->m_line.numPoints - 1, m_pParent->m_line.closed);
     }
 
     m_pParent->ChangeProjection(pProgramState->gis.zone);

--- a/src/scene/vcPOI.h
+++ b/src/scene/vcPOI.h
@@ -11,6 +11,8 @@
 #include "vcLineRenderer.h"
 #include "gl/vcGLState.h"
 
+class  vcPOIState;
+struct vcRenderPolyInstance;
 struct udWorkerPool;
 struct vdkPointCloud;
 struct vcTexture;
@@ -34,6 +36,9 @@ struct vcLineInfo
 
 class vcPOI : public vcSceneItem
 {
+  friend class vcPOIState;
+  friend class vcPOIState_General;
+  friend class vcPOIState_Append;
 private:
   vcLineInfo m_line; // TODO: 1452
   uint32_t m_nameColour;
@@ -82,11 +87,13 @@ private:
     double segmentProgress;
   } m_flyThrough;
 
+  vcPOIState *m_pState;
+
   void HandleBasicUI(vcState *pProgramState, size_t itemID);
 
 public:
   vcPOI(vdkProject *pProject, vdkProjectNode *pNode, vcState *pProgramState);
-  ~vcPOI() {};
+  ~vcPOI();
 
   void OnNodeUpdate(vcState *pProgramState);
 
@@ -112,6 +119,13 @@ public:
   bool IsSubitemSelected(uint64_t internalId);
 
 private:
+  void UpdateState(vcState *pProgramState);
+  vcRenderPolyInstance *AddNodeToRenderData(vcState *pProgramState, vcRenderData *pRenderData, size_t i);
+  bool IsVisible(vcState *pProgramState);
+  void AddFenceToScene(vcRenderData *pRenderData);
+  void AddLabelsToScene(vcRenderData *pRenderData);
+  void AddAttachedModelsToScene(vcState *pProgramState, vcRenderData *pRenderData);
+  void DoFlythrough(vcState *pProgramState);
   bool LoadAttachedModel(const char *pNewPath);
   bool GetPointAtDistanceAlongLine(double distance, udDouble3 *pPoint, int *pSegmentIndex, double *pSegmentProgress);
 };

--- a/src/vcSettings.cpp
+++ b/src/vcSettings.cpp
@@ -297,6 +297,29 @@ bool vcSettings_Load(vcSettings *pSettings, bool forceReset /*= false*/, vcSetti
     pSettings->postVisualization.contours.rainbowIntensity = data.Get("postVisualization.contours.rainbowIntensity").AsFloat(0.f);
   }
 
+  if (group == vcSC_Tools || group == vcSC_All)
+  {
+    const float defaultLineColour[4] = {0.5f, 0.5f, 0.5f, 0.5f};
+    const float defaultTextColour[4] = {0.5f, 0.5f, 0.5f, 0.5f};
+    const float defaultBackgroundColour[4] = {0.5f, 0.5f, 0.5f, 0.5f};
+
+    //Lines
+    pSettings->tools.line.minWidth = data.Get("tools.line.minWidth").AsFloat(0.1f);
+    pSettings->tools.line.maxWidth = data.Get("tools.line.maxWidth").AsFloat(1000.f);
+    pSettings->tools.line.width = data.Get("tools.line.width").AsFloat(7.f);
+    pSettings->tools.line.fenceMode = data.Get("tools.line.fenceMode").AsInt(1);
+    pSettings->tools.line.style = data.Get("tools.line.style").AsInt(1);
+    for (int i = 0; i < 4; i++)
+      pSettings->tools.line.colour[i] = data.Get("tools.line.colour[%d]", i).AsFloat(defaultLineColour[i]);
+
+    //Labels
+    for (int i = 0; i < 4; i++)
+      pSettings->tools.label.textColour[i] = data.Get("tools.label.textColour[%d]", i).AsFloat(defaultTextColour[i]);
+    for (int i = 0; i < 4; i++)
+      pSettings->tools.label.backgroundColour[i] = data.Get("tools.label.backgroundColour[%d]", i).AsFloat(defaultBackgroundColour[i]);
+    pSettings->tools.label.textSize = data.Get("tools.label.textSize").AsInt(1);
+  }
+
   if (group == vcSC_Convert || group == vcSC_All)
   {
     udStrcpy(pSettings->convertdefaults.tempDirectory, data.Get("convert.tempDirectory").AsString(""));
@@ -598,6 +621,19 @@ bool vcSettings_Save(vcSettings *pSettings)
   data.Set("postVisualization.contours.bandHeight = %f", pSettings->postVisualization.contours.bandHeight);
   data.Set("postVisualization.contours.rainbowRepeat = %f", pSettings->postVisualization.contours.rainbowRepeat);
   data.Set("postVisualization.contours.rainbowIntensity = %f", pSettings->postVisualization.contours.rainbowIntensity);
+
+  //Tool Settings
+  data.Set("tools.line.width = %f", pSettings->tools.line.width);
+  data.Set("tools.line.fenceMode = %i", pSettings->tools.line.fenceMode);
+  data.Set("tools.line.style = %i", pSettings->tools.line.style);
+  for (int i = 0; i < 4; i++)
+    data.Set("tools.line.colour[] = %f", pSettings->tools.line.colour[i]);
+
+  for (int i = 0; i < 4; i++)
+    data.Set("tools.label.textColour[] = %f", pSettings->tools.label.textColour[i]);
+  for (int i = 0; i < 4; i++)
+    data.Set("tools.label.backgroundColour[] = %f", pSettings->tools.label.backgroundColour[i]);
+  data.Set("tools.label.textSize = %i", pSettings->tools.label.textSize);
 
   // Convert Settings
   tempNode.SetString(pSettings->convertdefaults.tempDirectory);

--- a/src/vcSettings.h
+++ b/src/vcSettings.h
@@ -60,6 +60,7 @@ enum vcSettingsUIRegions
   vcSR_Inputs,
   vcSR_Maps,
   vcSR_Visualisations,
+  vcSR_Tools,
   vcSR_KeyBindings,
   vcSR_ConvertDefaults,
   vcSR_Screenshot,
@@ -77,6 +78,7 @@ enum vcSettingCategory
   vcSC_InputControls,
   vcSC_MapsElevation,
   vcSC_Visualization,
+  vcSC_Tools,
   vcSC_Convert,
   vcSC_Languages,
   vcSC_Bindings,
@@ -129,6 +131,26 @@ struct vcVisualizationSettings
   bool customClassificationToggles[256];
   uint32_t customClassificationColors[256];
   const char *customClassificationColorLabels[256];
+};
+
+struct vcToolSettings
+{
+  struct
+  {
+    float minWidth;
+    float maxWidth;
+    float width;
+    int fenceMode;
+    int style;
+    udFloat4 colour;
+  } line;
+
+  struct
+  {
+    udFloat4 textColour;
+    udFloat4 backgroundColour;
+    int textSize;
+  } label;
 };
 
 struct vcSettings
@@ -215,6 +237,7 @@ struct vcSettings
   } loginInfo;
 
   vcVisualizationSettings visualization;
+  vcToolSettings tools;  
 
   struct
   {

--- a/src/vcSettingsUI.cpp
+++ b/src/vcSettingsUI.cpp
@@ -451,7 +451,7 @@ void vcSettingsUI_Show(vcState *pProgramState)
         if (pProgramState->activeSetting == vcSR_Tools)
         {
           vcSettingsUI_ShowHeader(pProgramState, "Tools", vcSC_Tools);
-          ImGui::Text(vcString::Get("settingsToolsDefaultValues"));
+          ImGui::Text("%s", vcString::Get("settingsToolsDefaultValues"));
           ImGui::SliderFloat(vcString::Get("scenePOILineWidth"), &pProgramState->settings.tools.line.width, pProgramState->settings.tools.line.minWidth, pProgramState->settings.tools.line.maxWidth, "%.2f", 3.f);
            
           const char *fenceOptions[] = { vcString::Get("scenePOILineOrientationVert"), vcString::Get("scenePOILineOrientationHorz") };

--- a/src/vcSettingsUI.cpp
+++ b/src/vcSettingsUI.cpp
@@ -160,6 +160,7 @@ void vcSettingsUI_Show(vcState *pProgramState)
         ImGui::Unindent();
         change |= ImGui::RadioButton(udTempStr("%s##MapSettings", vcString::Get("settingsMaps")), &pProgramState->activeSetting, vcSR_Maps);
         change |= ImGui::RadioButton(udTempStr("%s##VisualisationSettings", vcString::Get("settingsVis")), &pProgramState->activeSetting, vcSR_Visualisations);
+        change |= ImGui::RadioButton(udTempStr("%s", "Tools"), &pProgramState->activeSetting, vcSR_Tools);
         change |= ImGui::RadioButton(udTempStr("%s##ConvertSettings", vcString::Get("settingsConvert")), &pProgramState->activeSetting, vcSR_ConvertDefaults);
         change |= ImGui::RadioButton(udTempStr("%s##ScreenshotSettings", vcString::Get("settingsScreenshot")), &pProgramState->activeSetting, vcSR_Screenshot);
         change |= ImGui::RadioButton(udTempStr("%s##ConnectionSettings", vcString::Get("settingsConnection")), &pProgramState->activeSetting, vcSR_Connection);
@@ -445,6 +446,26 @@ void vcSettingsUI_Show(vcState *pProgramState)
             if (ImGui::SliderFloat(vcString::Get("settingsVisContoursRainbowIntensity"), &pProgramState->settings.postVisualization.contours.rainbowIntensity, 0.f, 1.f, "%.3f", 2))
               pProgramState->settings.postVisualization.contours.rainbowIntensity = udClamp(pProgramState->settings.postVisualization.contours.rainbowIntensity, 0.f, 1.f);
           }
+        }
+
+        if (pProgramState->activeSetting == vcSR_Tools)
+        {
+          vcSettingsUI_ShowHeader(pProgramState, "Tools", vcSC_Tools);
+          ImGui::Text(vcString::Get("settingsToolsDefaultValues"));
+          ImGui::SliderFloat(vcString::Get("scenePOILineWidth"), &pProgramState->settings.tools.line.width, pProgramState->settings.tools.line.minWidth, pProgramState->settings.tools.line.maxWidth, "%.2f", 3.f);
+           
+          const char *fenceOptions[] = { vcString::Get("scenePOILineOrientationVert"), vcString::Get("scenePOILineOrientationHorz") };
+          ImGui::Combo(vcString::Get("scenePOILineOrientation"), &pProgramState->settings.tools.line.fenceMode, fenceOptions, (int)udLengthOf(fenceOptions));
+         
+          const char *lineOptions[] = { vcString::Get("scenePOILineStyleArrow"), vcString::Get("scenePOILineStyleGlow"), vcString::Get("scenePOILineStyleSolid"), vcString::Get("scenePOILineStyleDiagonal") };
+          ImGui::Combo(vcString::Get("scenePOILineStyle"), &pProgramState->settings.tools.line.style, lineOptions, (int)udLengthOf(lineOptions));
+
+          ImGui::ColorEdit4(vcString::Get("scenePOILineColour1"), &pProgramState->settings.tools.line.colour[0], ImGuiColorEditFlags_None);
+          ImGui::ColorEdit4(vcString::Get("scenePOILabelColour"), &pProgramState->settings.tools.label.textColour[0], ImGuiColorEditFlags_None);
+          ImGui::ColorEdit4(vcString::Get("scenePOILabelBackgroundColour"), &pProgramState->settings.tools.label.backgroundColour[0], ImGuiColorEditFlags_None);
+
+          const char *labelSizeOptions[] = { "Small", "Medium", "Large" };
+          ImGui::Combo(vcString::Get("scenePOILabelSize"), &pProgramState->settings.tools.label.textSize, labelSizeOptions, (int)udLengthOf(labelSizeOptions));
         }
 
         if (pProgramState->activeSetting == vcSR_KeyBindings)

--- a/src/vcSettingsUI.cpp
+++ b/src/vcSettingsUI.cpp
@@ -454,7 +454,7 @@ void vcSettingsUI_Show(vcState *pProgramState)
           ImGui::Text("%s", vcString::Get("settingsToolsDefaultValues"));
           ImGui::SliderFloat(vcString::Get("scenePOILineWidth"), &pProgramState->settings.tools.line.width, pProgramState->settings.tools.line.minWidth, pProgramState->settings.tools.line.maxWidth, "%.2f", 3.f);
            
-          const char *fenceOptions[] = { vcString::Get("scenePOILineOrientationVert"), vcString::Get("scenePOILineOrientationHorz") };
+          const char *fenceOptions[] = { vcString::Get("scenePOILineOrientationScreenLine"), vcString::Get("scenePOILineOrientationVert"), vcString::Get("scenePOILineOrientationHorz") };
           ImGui::Combo(vcString::Get("scenePOILineOrientation"), &pProgramState->settings.tools.line.fenceMode, fenceOptions, (int)udLengthOf(fenceOptions));
          
           const char *lineOptions[] = { vcString::Get("scenePOILineStyleArrow"), vcString::Get("scenePOILineStyleGlow"), vcString::Get("scenePOILineStyleSolid"), vcString::Get("scenePOILineStyleDiagonal") };


### PR DESCRIPTION
[AB#1374](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1374)
Changes:
  - I have removed the pop-up window when starting a new measurement.
  - I have added a Tools section in settings, where the user can set line and node defaults

Also, In an effort to simplify the vcPOI class, I have introduced an internal state machine. With the addition of the measurement tools, a POI can now be in either a measure mode (`Append`ing points) or passive mode (`General`). The POI functions a little differently depending on what state it is in. At this stage I have restricted this change to `vcPOI::AddToScene()` but with the plan to update other methods so as to reduce the amount of state querying (`if (isMeasuring)...` for example). I found it a little convoluted to have to query parts of the program state to determine what state the POI should be in.

As I add different tools, the POI will be the base 3D point object I'll use, so there may be a variety of different states the POI may be in, hence the motivation for the change.