### PR TITLE
Fixed crashes in Metal build

### DIFF
--- a/src/gl/metal/vcShader.mm
+++ b/src/gl/metal/vcShader.mm
@@ -18,15 +18,8 @@ void vcShader_CreatePipeline(vcShader *pShader, int pipelineIndex, id<MTLFunctio
     pDesc.colorAttachments[0].pixelFormat = MTLPixelFormatBGRA8Unorm;
     if (useDepth)
     {
-#if UDPLATFORM_IOS || UDPLATFORM_IOS_SIMULATOR
       pDesc.depthAttachmentPixelFormat = MTLPixelFormatDepth32Float;
-      pDesc.stencilAttachmentPixelFormat = MTLPixelFormatDepth32Float;
-#elif UDPLATFORM_OSX
-      pDesc.depthAttachmentPixelFormat = MTLPixelFormatDepth32Float_Stencil8;
-      pDesc.stencilAttachmentPixelFormat = MTLPixelFormatDepth32Float_Stencil8;
-#else
-# error "Unknown platform!"
-#endif
+      pDesc.stencilAttachmentPixelFormat = MTLPixelFormatInvalid;
     }
     else
     {


### PR DESCRIPTION
- Metal: Fixed crash on boot due to texture type mismatch in pipeline and framebuffer
- Metal: Fixed crash when selecting models in the scene
- Metal: Copied pixel copy code from DirectX to avoid excessive, and wrong, pointer arithmetic

Resolves [AB#1460](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1460)