### PR TITLE
Fixed POI bug and organised code

### DIFF
--- a/builds/assets/lang/enAU.json
+++ b/builds/assets/lang/enAU.json
@@ -211,6 +211,8 @@
   "settingsVisClassRename": "Rename",
   "settingsVisClassSet": "Set",
 
+  "settingsToolsDefaultValues": "Default values for new tool items",
+
   "settingsConvert": "Convert Defaults",
 
   "convertTitle": "Convert",
@@ -522,6 +524,7 @@
   "scenePOILineShowAllLengths": "Show All Lengths",
   "scenePOILineShowArea": "Show Area",
   "scenePOILineClosed": "Close Polygon",
+  "scenePOICloseAndExit": "Close Polygon (this will exit measure mode)",
   "scenePOILineColour1": "Line Colour 1",
   "scenePOILineColour2": "Line Colour 2",
   "scenePOILineWidth": "Line Width",

--- a/src/imgui_ex/vcImGuiSimpleWidgets.cpp
+++ b/src/imgui_ex/vcImGuiSimpleWidgets.cpp
@@ -162,6 +162,20 @@ udFloat4 vcIGSW_BGRAToImGui(uint32_t lineColour)
   return colours;
 }
 
+ uint32_t vcIGSW_ImGuiToBGRA(udFloat4 const & vec)
+{
+  uint32_t val = 0;
+
+  udFloat4 clamped = udClamp(vec, udFloat4::create(0.f, 0.f, 0.f, 0.f), udFloat4::create(1.f, 1.f, 1.f, 1.f));
+
+  val |= ((uint32_t)(clamped[0] * 255) << 16); // Blue
+  val |= ((uint32_t)(clamped[1] * 255) << 8); // Green
+  val |= ((uint32_t)(clamped[2] * 255) << 0); // Red
+  val |= ((uint32_t)(clamped[3] * 255) << 24); // Alpha
+
+  return val;
+}
+
 uint32_t vcIGSW_BGRAToRGBAUInt32(uint32_t lineColour)
 {
   // BGRA to RGBA

--- a/src/imgui_ex/vcImGuiSimpleWidgets.h
+++ b/src/imgui_ex/vcImGuiSimpleWidgets.h
@@ -19,6 +19,7 @@ bool vcIGSW_ColorPickerU32(const char *pLabel, uint32_t *pColor, ImGuiColorEditF
 bool vcIGSW_StickyIntSlider(const char* label, int* v, int v_min, int v_max, int sticky);
 
 udFloat4 vcIGSW_BGRAToImGui(uint32_t lineColour);
+uint32_t vcIGSW_ImGuiToBGRA(const udFloat4 &vec);
 uint32_t vcIGSW_BGRAToRGBAUInt32(uint32_t lineColour);
 
 bool vcIGSW_IsItemHovered(ImGuiHoveredFlags flags = 0, float timer = 0.5f); // Timer not currently working

--- a/src/scene/vcPOI.h
+++ b/src/scene/vcPOI.h
@@ -11,6 +11,8 @@
 #include "vcLineRenderer.h"
 #include "gl/vcGLState.h"
 
+class vcPOIState_General;
+struct vcRenderPolyInstance;
 struct udWorkerPool;
 struct vdkPointCloud;
 struct vcTexture;
@@ -34,6 +36,9 @@ struct vcLineInfo
 
 class vcPOI : public vcSceneItem
 {
+  friend class vcPOIState_General;
+  friend class vcPOIState_MeasureLine;
+  friend class vcPOIState_MeasureArea;
 private:
   vcLineInfo m_line; // TODO: 1452
   uint32_t m_nameColour;
@@ -82,11 +87,13 @@ private:
     double segmentProgress;
   } m_flyThrough;
 
+  vcPOIState_General *m_pState;
+
   void HandleBasicUI(vcState *pProgramState, size_t itemID);
 
 public:
   vcPOI(vdkProject *pProject, vdkProjectNode *pNode, vcState *pProgramState);
-  ~vcPOI() {};
+  ~vcPOI();
 
   void OnNodeUpdate(vcState *pProgramState);
 
@@ -112,6 +119,14 @@ public:
   bool IsSubitemSelected(uint64_t internalId);
 
 private:
+  void InsertPoint(const udDouble3 &position);
+  void UpdateState(vcState *pProgramState);
+  vcRenderPolyInstance *AddNodeToRenderData(vcState *pProgramState, vcRenderData *pRenderData, size_t i);
+  bool IsVisible(vcState *pProgramState);
+  void AddFenceToScene(vcRenderData *pRenderData);
+  void AddLabelsToScene(vcRenderData *pRenderData);
+  void AddAttachedModelsToScene(vcState *pProgramState, vcRenderData *pRenderData);
+  void DoFlythrough(vcState *pProgramState);
   bool LoadAttachedModel(const char *pNewPath);
   bool GetPointAtDistanceAlongLine(double distance, udDouble3 *pPoint, int *pSegmentIndex, double *pSegmentProgress);
 };

--- a/src/vcSettings.cpp
+++ b/src/vcSettings.cpp
@@ -304,6 +304,29 @@ bool vcSettings_Load(vcSettings *pSettings, bool forceReset /*= false*/, vcSetti
     pSettings->postVisualization.contours.rainbowIntensity = data.Get("postVisualization.contours.rainbowIntensity").AsFloat(0.f);
   }
 
+  if (group == vcSC_Tools || group == vcSC_All)
+  {
+    const float defaultLineColour[4] = {1.0f, 1.0f, 1.0f, 1.0f};
+    const float defaultTextColour[4] = {1.0f, 1.0f, 1.0f, 1.0f};
+    const float defaultBackgroundColour[4] = {0.0f, 0.0f, 0.0f, 0.5f};
+
+    //Lines
+    pSettings->tools.line.minWidth = data.Get("tools.line.minWidth").AsFloat(0.1f);
+    pSettings->tools.line.maxWidth = data.Get("tools.line.maxWidth").AsFloat(1000.f);
+    pSettings->tools.line.width = data.Get("tools.line.width").AsFloat(7.f);
+    pSettings->tools.line.fenceMode = data.Get("tools.line.fenceMode").AsInt(1);
+    pSettings->tools.line.style = data.Get("tools.line.style").AsInt(1);
+    for (int i = 0; i < 4; i++)
+      pSettings->tools.line.colour[i] = data.Get("tools.line.colour[%d]", i).AsFloat(defaultLineColour[i]);
+
+    //Labels
+    for (int i = 0; i < 4; i++)
+      pSettings->tools.label.textColour[i] = data.Get("tools.label.textColour[%d]", i).AsFloat(defaultTextColour[i]);
+    for (int i = 0; i < 4; i++)
+      pSettings->tools.label.backgroundColour[i] = data.Get("tools.label.backgroundColour[%d]", i).AsFloat(defaultBackgroundColour[i]);
+    pSettings->tools.label.textSize = data.Get("tools.label.textSize").AsInt(1);
+  }
+
   if (group == vcSC_Convert || group == vcSC_All)
   {
     udStrcpy(pSettings->convertdefaults.tempDirectory, data.Get("convert.tempDirectory").AsString(""));
@@ -613,6 +636,19 @@ bool vcSettings_Save(vcSettings *pSettings)
   data.Set("postVisualization.contours.bandHeight = %f", pSettings->postVisualization.contours.bandHeight);
   data.Set("postVisualization.contours.rainbowRepeat = %f", pSettings->postVisualization.contours.rainbowRepeat);
   data.Set("postVisualization.contours.rainbowIntensity = %f", pSettings->postVisualization.contours.rainbowIntensity);
+
+  //Tool Settings
+  data.Set("tools.line.width = %f", pSettings->tools.line.width);
+  data.Set("tools.line.fenceMode = %i", pSettings->tools.line.fenceMode);
+  data.Set("tools.line.style = %i", pSettings->tools.line.style);
+  for (int i = 0; i < 4; i++)
+    data.Set("tools.line.colour[] = %f", pSettings->tools.line.colour[i]);
+
+  for (int i = 0; i < 4; i++)
+    data.Set("tools.label.textColour[] = %f", pSettings->tools.label.textColour[i]);
+  for (int i = 0; i < 4; i++)
+    data.Set("tools.label.backgroundColour[] = %f", pSettings->tools.label.backgroundColour[i]);
+  data.Set("tools.label.textSize = %i", pSettings->tools.label.textSize);
 
   // Convert Settings
   tempNode.SetString(pSettings->convertdefaults.tempDirectory);

--- a/src/vcSettings.h
+++ b/src/vcSettings.h
@@ -69,6 +69,7 @@ enum vcSettingsUIRegions
   vcSR_Inputs,
   vcSR_Maps,
   vcSR_Visualisations,
+  vcSR_Tools,
   vcSR_KeyBindings,
   vcSR_ConvertDefaults,
   vcSR_Screenshot,
@@ -86,6 +87,7 @@ enum vcSettingCategory
   vcSC_InputControls,
   vcSC_MapsElevation,
   vcSC_Visualization,
+  vcSC_Tools,
   vcSC_Convert,
   vcSC_Languages,
   vcSC_Bindings,
@@ -146,6 +148,26 @@ struct vcVisualizationSettings
   bool customClassificationToggles[256];
   uint32_t customClassificationColors[256];
   const char *customClassificationColorLabels[256];
+};
+
+struct vcToolSettings
+{
+  struct
+  {
+    float minWidth;
+    float maxWidth;
+    float width;
+    int fenceMode;
+    int style;
+    udFloat4 colour;
+  } line;
+
+  struct
+  {
+    udFloat4 textColour;
+    udFloat4 backgroundColour;
+    int textSize;
+  } label;
 };
 
 struct vcSettings
@@ -232,6 +254,7 @@ struct vcSettings
   } loginInfo;
 
   vcVisualizationSettings visualization;
+  vcToolSettings tools;  
 
   struct
   {

--- a/src/vcSettingsUI.cpp
+++ b/src/vcSettingsUI.cpp
@@ -160,6 +160,7 @@ void vcSettingsUI_Show(vcState *pProgramState)
         ImGui::Unindent();
         change |= ImGui::RadioButton(udTempStr("%s##MapSettings", vcString::Get("settingsMaps")), &pProgramState->activeSetting, vcSR_Maps);
         change |= ImGui::RadioButton(udTempStr("%s##VisualisationSettings", vcString::Get("settingsVis")), &pProgramState->activeSetting, vcSR_Visualisations);
+        change |= ImGui::RadioButton(udTempStr("%s", "Tools"), &pProgramState->activeSetting, vcSR_Tools);
         change |= ImGui::RadioButton(udTempStr("%s##ConvertSettings", vcString::Get("settingsConvert")), &pProgramState->activeSetting, vcSR_ConvertDefaults);
         change |= ImGui::RadioButton(udTempStr("%s##ScreenshotSettings", vcString::Get("settingsScreenshot")), &pProgramState->activeSetting, vcSR_Screenshot);
         change |= ImGui::RadioButton(udTempStr("%s##ConnectionSettings", vcString::Get("settingsConnection")), &pProgramState->activeSetting, vcSR_Connection);
@@ -447,6 +448,26 @@ void vcSettingsUI_Show(vcState *pProgramState)
             if (ImGui::SliderFloat(vcString::Get("settingsVisContoursRainbowIntensity"), &pProgramState->settings.postVisualization.contours.rainbowIntensity, 0.f, 1.f, "%.3f", 2))
               pProgramState->settings.postVisualization.contours.rainbowIntensity = udClamp(pProgramState->settings.postVisualization.contours.rainbowIntensity, 0.f, 1.f);
           }
+        }
+
+        if (pProgramState->activeSetting == vcSR_Tools)
+        {
+          vcSettingsUI_ShowHeader(pProgramState, "Tools", vcSC_Tools);
+          ImGui::Text("%s", vcString::Get("settingsToolsDefaultValues"));
+          ImGui::SliderFloat(vcString::Get("scenePOILineWidth"), &pProgramState->settings.tools.line.width, pProgramState->settings.tools.line.minWidth, pProgramState->settings.tools.line.maxWidth, "%.2f", 3.f);
+           
+          const char *fenceOptions[] = { vcString::Get("scenePOILineOrientationScreenLine"), vcString::Get("scenePOILineOrientationVert"), vcString::Get("scenePOILineOrientationHorz") };
+          ImGui::Combo(vcString::Get("scenePOILineOrientation"), &pProgramState->settings.tools.line.fenceMode, fenceOptions, (int)udLengthOf(fenceOptions));
+         
+          const char *lineOptions[] = { vcString::Get("scenePOILineStyleArrow"), vcString::Get("scenePOILineStyleGlow"), vcString::Get("scenePOILineStyleSolid"), vcString::Get("scenePOILineStyleDiagonal") };
+          ImGui::Combo(vcString::Get("scenePOILineStyle"), &pProgramState->settings.tools.line.style, lineOptions, (int)udLengthOf(lineOptions));
+
+          ImGui::ColorEdit4(vcString::Get("scenePOILineColour1"), &pProgramState->settings.tools.line.colour[0], ImGuiColorEditFlags_None);
+          ImGui::ColorEdit4(vcString::Get("scenePOILabelColour"), &pProgramState->settings.tools.label.textColour[0], ImGuiColorEditFlags_None);
+          ImGui::ColorEdit4(vcString::Get("scenePOILabelBackgroundColour"), &pProgramState->settings.tools.label.backgroundColour[0], ImGuiColorEditFlags_None);
+
+          const char *labelSizeOptions[] = { "Small", "Medium", "Large" };
+          ImGui::Combo(vcString::Get("scenePOILabelSize"), &pProgramState->settings.tools.label.textSize, labelSizeOptions, (int)udLengthOf(labelSizeOptions));
         }
 
         if (pProgramState->activeSetting == vcSR_KeyBindings)


### PR DESCRIPTION
[AB#1374](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1374)

Changes:

I have added a Tools section in settings, where the user can set line and node defaults
Also, In an effort to simplify the vcPOI class, I have pulled out the three different states: MeasureLine, MeasureArea and General, and added them to an internal state machine `m_pState`. I found the POI functions a little differently depending on what it was being used for. This seemed to be a source of bugs, as each POI method was trying to handle each mode, leading to excessive state checking and redundant code.