### PR TITLE
Improving Client Map System

### DIFF
--- a/builds/assets/lang/enAU.json
+++ b/builds/assets/lang/enAU.json
@@ -125,6 +125,7 @@
 
   "settingsMaps": "Maps & Elevation",
   "settingsMapsMapTiles": "Map Tiles",
+  "settingsMapsDEM": "Digital Elevation Model",
   "settingsMapsMouseLock": "Mouse can lock to maps",
   "settingsMapsTileServerTitle": "Tile Server",
   "settingsMapsTileServerButton": "Tile Server",

--- a/docs/TranslationGuide.md
+++ b/docs/TranslationGuide.md
@@ -293,8 +293,10 @@ Modules are currently:
 - `settingsViewportCameraLens100mm`: Label for the 100mm lens option,
 - `settingsViewportFOV`: Label next to slider for setting a custom field of view
 - `settingsMaps`: Title of the Maps & Elevation subheading in Settings
+- `settingsMapsDEM`: Title of the Digital Elevation Model heading in map settings
 - `settingsMapsRestoreDefaults`: Used to restore default values for all maps settings
 - `settingsMapsMapTiles`: Label next to checkbox for toggling the visibility of map tiles in the scene
+- `settingsMapsMapTilesdem`: Label next to checkbox for toggling the visibility of map tiles in the scene
 - `settingsMapsMouseLock`: Label next to checkbox for toggling whether or not the user can click on map tiles within the scene
 - `settingsMapsTileServerTitle`: Title used on tile server window
 - `settingsMapsTileServerButton`: Label used on button for opening the tile server window

--- a/src/rendering/vcTileRenderer.cpp
+++ b/src/rendering/vcTileRenderer.cpp
@@ -854,7 +854,7 @@ void vcTileRenderer_UpdateTextureQueuesRecursive(vcTileRenderer *pTileRenderer, 
   }
 
   // hacky - looking for specific DEM levels
-  if (pNode->slippyPosition.z <= HACK_DEM_LEVEL)
+  if (pTileRenderer->pSettings->maptiles.demEnabled && pNode->slippyPosition.z <= HACK_DEM_LEVEL)
   {
     bool demLeaf = vcQuadTree_IsVisibleLeafNode(&pTileRenderer->quadTree, pNode) || (pNode->slippyPosition.z == HACK_DEM_LEVEL);
     if (demLeaf && pNode->demInfo.loadStatus.Get() != vcNodeRenderInfo::vcTLS_Loaded)
@@ -937,7 +937,7 @@ void vcTileRenderer_DrawNode(vcTileRenderer *pTileRenderer, vcQuadTreeNode *pNod
   }
 
   vcTexture *pDemTexture = pNode->demInfo.drawInfo.pTexture;
-  if (pDemTexture == nullptr)
+  if (pDemTexture == nullptr || !pTileRenderer->pSettings->maptiles.demEnabled)
   {
     // TODO: completeRender = false?
     pDemTexture = pTileRenderer->pEmptyDemTileTexture;

--- a/src/vcRender.cpp
+++ b/src/vcRender.cpp
@@ -748,18 +748,14 @@ void vcRenderTerrain(vcState *pProgramState, vcRenderContext *pRenderContext, co
 #endif
     udDouble3 localCamPos = cameraMatrix.axis.t.toVector3();
 
-    // Corners [nw, ne, sw, se]
-    udDouble3 localCorners[4];
-    udInt2 slippyCorners[4];
-
     int currentZoom = 21;
 
     // project camera position to base altitude
     udDouble3 cameraPositionInLongLat = udGeoZone_CartesianToLatLong(pProgramState->gis.zone, pProgramState->camera.position);
     cameraPositionInLongLat.z = 0.0;
     udDouble3 cameraZeroAltitude = udGeoZone_LatLongToCartesian(pProgramState->gis.zone, cameraPositionInLongLat);
-    udDouble3 cameraToZeroAltitude = localCamPos - cameraZeroAltitude;
-    double cameraDistanceToAltitudeZero = udMag3(cameraToZeroAltitude);
+    udDouble3 earthNormal = localCamPos - cameraZeroAltitude;
+    double cameraDistanceToAltitudeZero = udMag3(earthNormal);
 
     // TODO: Fix this
     // determine if camera is 'inside' the ground
@@ -770,9 +766,13 @@ void vcRenderTerrain(vcState *pProgramState, vcRenderContext *pRenderContext, co
     bool cameraInsideGround = false;//udDot3(cameraToZeroAltitude, surfaceNormal) < 0;
 
     // These values were trial and errored.
-    const double BaseViewDistance = 20000.0;
-    const double HeightViewDistanceScale = 40.0;
+    const double BaseViewDistance = 10000.0;
+    const double HeightViewDistanceScale = 35.0;
     double visibleFarPlane = udMin((double)s_CameraFarPlane, BaseViewDistance + cameraDistanceToAltitudeZero * HeightViewDistanceScale);
+
+    // Corners [nw, ne, sw, se]
+    udDouble3 localCorners[4];
+    udInt2 slippyCorners[4];
 
     // Cardinal Limits
     localCorners[0] = localCamPos + udDouble3::create(-visibleFarPlane, +visibleFarPlane, 0);

--- a/src/vcSettings.cpp
+++ b/src/vcSettings.cpp
@@ -191,6 +191,7 @@ bool vcSettings_Load(vcSettings *pSettings, bool forceReset /*= false*/, vcSetti
   {
     // Map Tiles
     pSettings->maptiles.mapEnabled = data.Get("maptiles.enabled").AsBool(true);
+    pSettings->maptiles.demEnabled = data.Get("maptiles.demEnabled").AsBool(true);
     udStrcpy(pSettings->maptiles.tileServerAddress, data.Get("maptiles.serverURL").AsString("http://slippy.vault.euclideon.com/"));
     if (udStrEquali(pSettings->maptiles.tileServerAddress, "http://20.188.211.58"))
       udStrcpy(pSettings->maptiles.tileServerAddress, "http://slippy.vault.euclideon.com");
@@ -667,6 +668,7 @@ bool vcSettings_Save(vcSettings *pSettings)
 
   // Map Tiles
   data.Set("maptiles.enabled = %s", pSettings->maptiles.mapEnabled ? "true" : "false");
+  data.Set("maptiles.demEnabled = %s", pSettings->maptiles.demEnabled ? "true" : "false");
   data.Set("maptiles.blendMode = %d", pSettings->maptiles.blendMode);
   data.Set("maptiles.transparency = %f", pSettings->maptiles.transparency);
   data.Set("maptiles.mapHeight = %f", pSettings->maptiles.mapHeight);

--- a/src/vcSettings.h
+++ b/src/vcSettings.h
@@ -298,6 +298,7 @@ struct vcSettings
   struct
   {
     bool mapEnabled;
+    bool demEnabled;
 
     vcTileRendererMapQuality mapQuality;
     vcTileRendererFlags mapOptions;

--- a/src/vcSettingsUI.cpp
+++ b/src/vcSettingsUI.cpp
@@ -290,6 +290,8 @@ void vcSettingsUI_Show(vcState *pProgramState)
             if (ImGui::Button(vcString::Get("settingsMapsTileServerButton"), ImVec2(-1, 0)))
               vcModals_OpenModal(pProgramState, vcMT_TileServer);
 
+            ImGui::Checkbox(vcString::Get("settingsMapsDEM"), &pProgramState->settings.maptiles.demEnabled);
+
             if (ImGui::SliderFloat(vcString::Get("settingsMapsMapHeight"), &pProgramState->settings.maptiles.mapHeight, vcSL_MapHeightMin, vcSL_MapHeightMax, "%.3fm", 2.f))
               pProgramState->settings.maptiles.mapHeight = udClamp(pProgramState->settings.maptiles.mapHeight, -vcSL_GlobalLimitf, vcSL_GlobalLimitf);
 


### PR DESCRIPTION
Refactoring quad tree data layout (for future 'layers').
Re-prioritized tile loading to always load incomplete (colour) data first.
Improved design of tile loading handling, now a load request can process colour and DEM in the same request.
Quad tree generation is now every X seconds.
Fixed memory leak.
Fixed a bug where tiles were being incorrectly ejected from the load queue.
Fixed the AABB calculation for tiles.
Changed how tiles 'retry' to load, after a failed load.
DEM heights now factored into node descend.

[AB#1220](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1220)
[AB#149](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/149)
[AB#918](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/918)
[AB#1392](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1392)
[AB#1393](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1393)
[AB#586](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/586)