### PR TITLE
Fixed issue with ReadPixelEnd in WebGL builds

### DIFF
--- a/src/vcRender.cpp
+++ b/src/vcRender.cpp
@@ -1332,7 +1332,9 @@ void vcRender_RenderScene(vcState *pProgramState, vcRenderContext *pRenderContex
   if (selectionBufferActive)
     vcRender_ApplySelectionBuffer(pProgramState, pRenderContext);
 
+#if !UDPLATFORM_EMSCRIPTEN
   vcRender_PostProcessPass(pProgramState, pRenderContext);
+#endif
   vcRender_RenderUI(pProgramState, pProgramState->pRenderContext, renderData);
 
   vcGLState_ResetState();


### PR DESCRIPTION
- OpenGL: All texture reads are done using the asynchronous method
- Emscripten: No longer performs FXAA due to issues