### PR TITLE
Depth now stored in alpha of colour attachments.

### DIFF
--- a/src/gl/directx11/shaders/compassFragmentShader.hlsl
+++ b/src/gl/directx11/shaders/compassFragmentShader.hlsl
@@ -37,5 +37,6 @@ PS_OUTPUT main(PS_INPUT input)
   float halfFcoef = 1.0 / log2(s_CameraFarPlane + 1.0);
   output.Depth0 = log2(input.fLogDepth.x) * halfFcoef;
 
+  output.Color0.a = output.Depth0; // depth packed here
   return output;
 }

--- a/src/gl/directx11/shaders/depthOnlyFragmentShader.hlsl
+++ b/src/gl/directx11/shaders/depthOnlyFragmentShader.hlsl
@@ -30,5 +30,6 @@ PS_OUTPUT main(PS_INPUT input)
   float halfFcoef = 1.0 / log2(s_CameraFarPlane + 1.0);
   output.Depth0 = log2(input.fLogDepth.x) * halfFcoef;
 
+  output.Color0.a = output.Depth0; // depth packed here
   return output;
 }

--- a/src/gl/directx11/shaders/fenceFragmentShader.hlsl
+++ b/src/gl/directx11/shaders/fenceFragmentShader.hlsl
@@ -36,5 +36,6 @@ PS_OUTPUT main(PS_INPUT input)
   float halfFcoef = 1.0 / log2(s_CameraFarPlane + 1.0);
   output.Depth0 = log2(input.fLogDepth.x) * halfFcoef;
 
+  output.Color0.a = output.Depth0; // depth packed here
   return output;
 }

--- a/src/gl/directx11/shaders/flatColourFragmentShader.hlsl
+++ b/src/gl/directx11/shaders/flatColourFragmentShader.hlsl
@@ -18,6 +18,7 @@ struct PS_INPUT
 struct PS_OUTPUT
 {
   float4 Color0 : SV_Target;
+  float Depth0 : SV_Depth;
 };
 
 PS_OUTPUT main(PS_INPUT input)
@@ -25,6 +26,10 @@ PS_OUTPUT main(PS_INPUT input)
   PS_OUTPUT output;
 
   output.Color0 = input.colour;
+  
+  float halfFcoef = 1.0 / log2(s_CameraFarPlane + 1.0);
+  output.Depth0 = log2(input.fLogDepth.x) * halfFcoef;
 
+  output.Color0.a = output.Depth0; // depth packed here
   return output;
 }

--- a/src/gl/directx11/shaders/imageColourSkyboxFragmentShader.hlsl
+++ b/src/gl/directx11/shaders/imageColourSkyboxFragmentShader.hlsl
@@ -20,5 +20,5 @@ float4 main(PS_INPUT input) : SV_Target
 {
   float4 colour = albedoTexture.Sample(albedoSampler, input.uv).rgba;
   float effectiveAlpha = min(colour.a, input.tintColour.a);
-  return float4((colour.rgb * effectiveAlpha) + (input.tintColour.rgb * (1 - effectiveAlpha)), 1);
+  return float4((colour.rgb * effectiveAlpha) + (input.tintColour.rgb * (1 - effectiveAlpha)), 1.0);
 }

--- a/src/gl/directx11/shaders/imageRendererFragmentShader.hlsl
+++ b/src/gl/directx11/shaders/imageRendererFragmentShader.hlsl
@@ -32,5 +32,6 @@ PS_OUTPUT main(PS_INPUT input)
   float halfFcoef = 1.0 / log2(s_CameraFarPlane + 1.0);
   output.Depth0 = log2(input.fLogDepth.x) * halfFcoef;
 
+  output.Color0.a = output.Depth0; // depth packed here
   return output;
 }

--- a/src/gl/directx11/shaders/lineFragmentShader.hlsl
+++ b/src/gl/directx11/shaders/lineFragmentShader.hlsl
@@ -30,5 +30,6 @@ PS_OUTPUT main(PS_INPUT input)
   float halfFcoef = 1.0 / log2(s_CameraFarPlane + 1.0);
   output.Depth0 = log2(input.fLogDepth.x) * halfFcoef;
 
+  output.Color0.a = output.Depth0; // depth packed here
   return output;
 }

--- a/src/gl/directx11/shaders/polygonImageFragmentShader.hlsl
+++ b/src/gl/directx11/shaders/polygonImageFragmentShader.hlsl
@@ -33,5 +33,6 @@ PS_OUTPUT main(PS_INPUT input)
   float halfFcoef = 1.0 / log2(s_CameraFarPlane + 1.0);
   output.Depth0 = log2(input.fLogDepth.x) * halfFcoef;
 
+  output.Color0.a = output.Depth0; // depth packed here
   return output;
 }

--- a/src/gl/directx11/shaders/polygonP3N3UV2FragmentShader.hlsl
+++ b/src/gl/directx11/shaders/polygonP3N3UV2FragmentShader.hlsl
@@ -40,5 +40,6 @@ PS_OUTPUT main(PS_INPUT input)
   float halfFcoef = 1.0 / log2(s_CameraFarPlane + 1.0);
   output.Depth0 = log2(input.fLogDepth.x) * halfFcoef;
 
+  output.Color0.a = output.Depth0; // depth packed here
   return output;
 }

--- a/src/gl/directx11/shaders/tileFragmentShader.hlsl
+++ b/src/gl/directx11/shaders/tileFragmentShader.hlsl
@@ -32,5 +32,7 @@ PS_OUTPUT main(PS_INPUT input)
   output.Depth0 = log2(input.fLogDepth.x) * halfFcoef;
 
   output.Color0 = float4(col.xyz * input.colour.xyz, input.colour.w);
+  
+  output.Color0.a = output.Depth0; // depth packed here
   return output;
 }

--- a/src/gl/directx11/shaders/udFragmentShader.hlsl
+++ b/src/gl/directx11/shaders/udFragmentShader.hlsl
@@ -34,5 +34,6 @@ PS_OUTPUT main(PS_INPUT input)
   output.Color0 = float4(col.zyx, 1.0);// UD always opaque, UD is BGRA but uploaded as RGBA
   output.Depth0 = depth;
 
+  output.Color0.a = output.Depth0; // depth packed here
   return output;
 }

--- a/src/gl/directx11/shaders/visualizationFragmentShader.hlsl
+++ b/src/gl/directx11/shaders/visualizationFragmentShader.hlsl
@@ -178,5 +178,7 @@ PS_OUTPUT main(PS_INPUT input)
 
   output.Color0 = float4(col.xyz, 1.0);// UD always opaque
   output.Depth0 = logDepth;
+  
+  output.Color0.a = output.Depth0; // depth packed here
   return output;
 }

--- a/src/gl/directx11/shaders/waterFragmentShader.hlsl
+++ b/src/gl/directx11/shaders/waterFragmentShader.hlsl
@@ -82,5 +82,7 @@ PS_OUTPUT main(PS_INPUT input)
   
   // dull colour until sort out ECEF water
   output.Color0 = output.Color0 * 0.3 + float4(0.2, 0.4, 0.7, 1.0);
+  
+  output.Color0.a = output.Depth0; // depth packed here
   return output;
 }

--- a/src/gl/directx11/vcTexture.cpp
+++ b/src/gl/directx11/vcTexture.cpp
@@ -458,7 +458,7 @@ bool vcTexture_EndReadPixels(vcTexture *pTexture, uint32_t x, uint32_t y, uint32
 
   udResult result = udR_Success;
   int pixelBytes = 0;
-  uint32_t *pPixelData = nullptr;
+  uint8_t *pPixelData = nullptr;
   D3D11_MAPPED_SUBRESOURCE msr;
   vcTexture_GetFormatAndPixelSize(pTexture->format, pTexture->isRenderTarget, &pixelBytes);
 
@@ -469,16 +469,16 @@ bool vcTexture_EndReadPixels(vcTexture *pTexture, uint32_t x, uint32_t y, uint32
 
   if (x == 0 && y == 0 && width == (uint32_t)pTexture->width && height == (uint32_t)pTexture->height)
   {
-    pPixelData = (uint32_t*)msr.pData;
+    pPixelData = (uint8_t*)msr.pData;
     memcpy((uint8_t*)pPixels, pPixelData, height * width * pixelBytes);
   }
   else
   {
-    pPixelData = ((uint32_t *)msr.pData) + (x + y * pTexture->width);
+    pPixelData = ((uint8_t *)msr.pData) + (x + y * pTexture->width) * pixelBytes;
     for (int i = 0; i < (int)height; ++i)
     {
-      memcpy((uint8_t*)pPixels + (i * pTexture->width * pixelBytes), pPixelData, width * pixelBytes);
-      pPixelData += pTexture->width;
+      memcpy((uint8_t*)pPixels + (i * width * pixelBytes), pPixelData, width * pixelBytes);
+      pPixelData += pTexture->width * pixelBytes;
     }
   }
 

--- a/src/gl/metal/shaders/desktop/compassFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/compassFragmentShader.metal
@@ -30,8 +30,11 @@ fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlanePa
 {
     main0_out out = {};
     float3 _50 = (in.in_var_COLOR0 * float3(2.0)) - float3(1.0);
-    out.out_var_SV_Target = float4(((in.in_var_COLOR1.xyz * (0.5 + (dot(in.in_var_COLOR2, _50) * (-0.5)))) + (float3(1.0, 1.0, 0.89999997615814208984375) * pow(fast::max(0.0, -dot(-normalize(in.in_var_COLOR3.xyz / float3(in.in_var_COLOR3.w)), _50)), 60.0))) * in.in_var_COLOR1.w, 1.0);
-    out.gl_FragDepth = log2(in.in_var_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _76 = log2(in.in_var_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float4 _77 = float4(((in.in_var_COLOR1.xyz * (0.5 + (dot(in.in_var_COLOR2, _50) * (-0.5)))) + (float3(1.0, 1.0, 0.89999997615814208984375) * pow(fast::max(0.0, -dot(-normalize(in.in_var_COLOR3.xyz / float3(in.in_var_COLOR3.w)), _50)), 60.0))) * in.in_var_COLOR1.w, 1.0);
+    _77.w = _76;
+    out.out_var_SV_Target = _77;
+    out.gl_FragDepth = _76;
     return out;
 }
 

--- a/src/gl/metal/shaders/desktop/depthOnlyFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/depthOnlyFragmentShader.metal
@@ -25,8 +25,11 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]])
 {
     main0_out out = {};
-    out.out_var_SV_Target = float4(0.0);
-    out.gl_FragDepth = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _39 = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float4 _40 = float4(0.0);
+    _40.w = _39;
+    out.out_var_SV_Target = _40;
+    out.gl_FragDepth = _39;
     return out;
 }
 

--- a/src/gl/metal/shaders/desktop/fenceFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/fenceFragmentShader.metal
@@ -11,6 +11,8 @@ struct type_u_cameraPlaneParams
     float u_clipZFar;
 };
 
+constant float _33 = {};
+
 struct main0_out
 {
     float4 out_var_SV_Target [[color(0)]];
@@ -27,9 +29,11 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], texture2d<float> colourTexture [[texture(0)]], sampler colourSampler [[sampler(0)]])
 {
     main0_out out = {};
-    float4 _40 = colourTexture.sample(colourSampler, in.in_var_TEXCOORD0);
-    out.out_var_SV_Target = float4(_40.xyz * in.in_var_COLOR0.xyz, _40.w * in.in_var_COLOR0.w);
-    out.gl_FragDepth = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _56 = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float4 _57 = float4(colourTexture.sample(colourSampler, in.in_var_TEXCOORD0).xyz * in.in_var_COLOR0.xyz, _33);
+    _57.w = _56;
+    out.out_var_SV_Target = _57;
+    out.gl_FragDepth = _56;
     return out;
 }
 

--- a/src/gl/metal/shaders/desktop/flatColourFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/flatColourFragmentShader.metal
@@ -3,20 +3,34 @@
 
 using namespace metal;
 
+struct type_u_cameraPlaneParams
+{
+    float s_CameraNearPlane;
+    float s_CameraFarPlane;
+    float u_clipZNear;
+    float u_clipZFar;
+};
+
 struct main0_out
 {
     float4 out_var_SV_Target [[color(0)]];
+    float gl_FragDepth [[depth(any)]];
 };
 
 struct main0_in
 {
     float4 in_var_COLOR0 [[user(locn2)]];
+    float2 in_var_TEXCOORD1 [[user(locn3)]];
 };
 
-fragment main0_out main0(main0_in in [[stage_in]])
+fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]])
 {
     main0_out out = {};
-    out.out_var_SV_Target = in.in_var_COLOR0;
+    float _38 = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float4 _39 = in.in_var_COLOR0;
+    _39.w = _38;
+    out.out_var_SV_Target = _39;
+    out.gl_FragDepth = _38;
     return out;
 }
 

--- a/src/gl/metal/shaders/desktop/imageRendererFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/imageRendererFragmentShader.metal
@@ -27,8 +27,11 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], texture2d<float> albedoTexture [[texture(0)]], sampler albedoSampler [[sampler(0)]])
 {
     main0_out out = {};
-    out.out_var_SV_Target = albedoTexture.sample(albedoSampler, in.in_var_TEXCOORD0) * in.in_var_COLOR0;
-    out.gl_FragDepth = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _48 = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float4 _49 = albedoTexture.sample(albedoSampler, in.in_var_TEXCOORD0) * in.in_var_COLOR0;
+    _49.w = _48;
+    out.out_var_SV_Target = _49;
+    out.gl_FragDepth = _48;
     return out;
 }
 

--- a/src/gl/metal/shaders/desktop/lineFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/lineFragmentShader.metal
@@ -26,8 +26,11 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]])
 {
     main0_out out = {};
-    out.out_var_SV_Target = in.in_var_COLOR0;
-    out.gl_FragDepth = log2(in.in_var_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _34 = log2(in.in_var_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float4 _35 = in.in_var_COLOR0;
+    _35.w = _34;
+    out.out_var_SV_Target = _35;
+    out.gl_FragDepth = _34;
     return out;
 }
 

--- a/src/gl/metal/shaders/desktop/polygonImageFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/polygonImageFragmentShader.metal
@@ -27,8 +27,11 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], texture2d<float> albedoTexture [[texture(0)]], sampler albedoSampler [[sampler(0)]])
 {
     main0_out out = {};
-    out.out_var_SV_Target = albedoTexture.sample(albedoSampler, in.in_var_TEXCOORD0) * in.in_var_COLOR0;
-    out.gl_FragDepth = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _51 = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float4 _52 = albedoTexture.sample(albedoSampler, in.in_var_TEXCOORD0) * in.in_var_COLOR0;
+    _52.w = _51;
+    out.out_var_SV_Target = _52;
+    out.gl_FragDepth = _51;
     return out;
 }
 

--- a/src/gl/metal/shaders/desktop/polygonP3N3UV2FragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/polygonP3N3UV2FragmentShader.metal
@@ -11,6 +11,8 @@ struct type_u_cameraPlaneParams
     float u_clipZFar;
 };
 
+constant float _39 = {};
+
 struct main0_out
 {
     float4 out_var_SV_Target [[color(0)]];
@@ -28,9 +30,11 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], texture2d<float> albedoTexture [[texture(0)]], sampler albedoSampler [[sampler(0)]])
 {
     main0_out out = {};
-    float4 _48 = albedoTexture.sample(albedoSampler, in.in_var_TEXCOORD0) * in.in_var_COLOR0;
-    out.out_var_SV_Target = float4(_48.xyz * ((dot(in.in_var_NORMAL, normalize(float3(0.85000002384185791015625, 0.1500000059604644775390625, 0.5))) * 0.5) + 0.5), _48.w);
-    out.gl_FragDepth = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _67 = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float4 _68 = float4((albedoTexture.sample(albedoSampler, in.in_var_TEXCOORD0) * in.in_var_COLOR0).xyz * ((dot(in.in_var_NORMAL, normalize(float3(0.85000002384185791015625, 0.1500000059604644775390625, 0.5))) * 0.5) + 0.5), _39);
+    _68.w = _67;
+    out.out_var_SV_Target = _68;
+    out.gl_FragDepth = _67;
     return out;
 }
 

--- a/src/gl/metal/shaders/desktop/tileFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/tileFragmentShader.metal
@@ -11,6 +11,8 @@ struct type_u_cameraPlaneParams
     float u_clipZFar;
 };
 
+constant float _33 = {};
+
 struct main0_out
 {
     float4 out_var_SV_Target [[color(0)]];
@@ -27,8 +29,11 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], texture2d<float> colourTexture [[texture(0)]], sampler colourSampler [[sampler(0)]])
 {
     main0_out out = {};
-    out.out_var_SV_Target = float4(colourTexture.sample(colourSampler, in.in_var_TEXCOORD0).xyz * in.in_var_COLOR0.xyz, in.in_var_COLOR0.w);
-    out.gl_FragDepth = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _49 = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float4 _57 = float4(colourTexture.sample(colourSampler, in.in_var_TEXCOORD0).xyz * in.in_var_COLOR0.xyz, _33);
+    _57.w = _49;
+    out.out_var_SV_Target = _57;
+    out.gl_FragDepth = _49;
     return out;
 }
 

--- a/src/gl/metal/shaders/desktop/udFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/udFragmentShader.metal
@@ -17,8 +17,12 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> sceneColourTexture [[texture(0)]], texture2d<float> sceneDepthTexture [[texture(1)]], sampler sceneColourSampler [[sampler(0)]], sampler sceneDepthSampler [[sampler(1)]])
 {
     main0_out out = {};
-    out.out_var_SV_Target = float4(sceneColourTexture.sample(sceneColourSampler, in.in_var_TEXCOORD0).zyx, 1.0);
-    out.gl_FragDepth = sceneDepthTexture.sample(sceneDepthSampler, in.in_var_TEXCOORD0).x;
+    float4 _34 = sceneDepthTexture.sample(sceneDepthSampler, in.in_var_TEXCOORD0);
+    float _35 = _34.x;
+    float4 _40 = float4(sceneColourTexture.sample(sceneColourSampler, in.in_var_TEXCOORD0).zyx, 1.0);
+    _40.w = _35;
+    out.out_var_SV_Target = _40;
+    out.gl_FragDepth = _35;
     return out;
 }
 

--- a/src/gl/metal/shaders/desktop/visualizationFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/visualizationFragmentShader.metal
@@ -97,7 +97,9 @@ fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlanePa
         _350 = _82;
         _351 = float4(_200.x, _200.y, _200.z, _77.w);
     }
-    out.out_var_SV_Target = float4(_351.xyz, 1.0);
+    float4 _356 = float4(_351.xyz, 1.0);
+    _356.w = _350;
+    out.out_var_SV_Target = _356;
     out.gl_FragDepth = _350;
     return out;
 }

--- a/src/gl/metal/shaders/desktop/waterFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/waterFragmentShader.metal
@@ -41,8 +41,11 @@ fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlanePa
     float3 _108 = normalize((u_EveryFrameFrag.u_eyeNormalMatrix * float4(_90, 0.0)).xyz);
     float3 _110 = normalize(reflect(_92, _108));
     float3 _134 = normalize((u_EveryFrameFrag.u_inverseViewMatrix * float4(_110, 0.0)).xyz);
-    out.out_var_SV_Target = (float4(mix(skyboxTexture.sample(skyboxSampler, (float2(atan2(_134.x, _134.y) + 3.1415927410125732421875, acos(_134.z)) * float2(0.15915493667125701904296875, 0.3183098733425140380859375))).xyz, in.in_var_COLOR1.xyz * mix(float3(1.0, 1.0, 0.60000002384185791015625), float3(0.3499999940395355224609375), float3(pow(fast::max(0.0, _90.z), 5.0))), float3(((dot(_108, _92) * (-0.5)) + 0.5) * 0.75)) + float3(pow(abs(dot(_110, normalize((u_EveryFrameFrag.u_eyeNormalMatrix * float4(normalize(u_EveryFrameFrag.u_specularDir.xyz), 0.0)).xyz))), 50.0) * 0.5), 1.0) * 0.300000011920928955078125) + float4(0.20000000298023223876953125, 0.4000000059604644775390625, 0.699999988079071044921875, 1.0);
-    out.gl_FragDepth = log2(in.in_var_TEXCOORD2.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _162 = log2(in.in_var_TEXCOORD2.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float4 _165 = (float4(mix(skyboxTexture.sample(skyboxSampler, (float2(atan2(_134.x, _134.y) + 3.1415927410125732421875, acos(_134.z)) * float2(0.15915493667125701904296875, 0.3183098733425140380859375))).xyz, in.in_var_COLOR1.xyz * mix(float3(1.0, 1.0, 0.60000002384185791015625), float3(0.3499999940395355224609375), float3(pow(fast::max(0.0, _90.z), 5.0))), float3(((dot(_108, _92) * (-0.5)) + 0.5) * 0.75)) + float3(pow(abs(dot(_110, normalize((u_EveryFrameFrag.u_eyeNormalMatrix * float4(normalize(u_EveryFrameFrag.u_specularDir.xyz), 0.0)).xyz))), 50.0) * 0.5), 1.0) * 0.300000011920928955078125) + float4(0.20000000298023223876953125, 0.4000000059604644775390625, 0.699999988079071044921875, 1.0);
+    _165.w = _162;
+    out.out_var_SV_Target = _165;
+    out.gl_FragDepth = _162;
     return out;
 }
 

--- a/src/gl/metal/shaders/mobile/compassFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/compassFragmentShader.metal
@@ -30,8 +30,11 @@ fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlanePa
 {
     main0_out out = {};
     float3 _50 = (in.in_var_COLOR0 * float3(2.0)) - float3(1.0);
-    out.out_var_SV_Target = float4(((in.in_var_COLOR1.xyz * (0.5 + (dot(in.in_var_COLOR2, _50) * (-0.5)))) + (float3(1.0, 1.0, 0.89999997615814208984375) * pow(fast::max(0.0, -dot(-normalize(in.in_var_COLOR3.xyz / float3(in.in_var_COLOR3.w)), _50)), 60.0))) * in.in_var_COLOR1.w, 1.0);
-    out.gl_FragDepth = log2(in.in_var_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _76 = log2(in.in_var_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float4 _77 = float4(((in.in_var_COLOR1.xyz * (0.5 + (dot(in.in_var_COLOR2, _50) * (-0.5)))) + (float3(1.0, 1.0, 0.89999997615814208984375) * pow(fast::max(0.0, -dot(-normalize(in.in_var_COLOR3.xyz / float3(in.in_var_COLOR3.w)), _50)), 60.0))) * in.in_var_COLOR1.w, 1.0);
+    _77.w = _76;
+    out.out_var_SV_Target = _77;
+    out.gl_FragDepth = _76;
     return out;
 }
 

--- a/src/gl/metal/shaders/mobile/depthOnlyFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/depthOnlyFragmentShader.metal
@@ -25,8 +25,11 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]])
 {
     main0_out out = {};
-    out.out_var_SV_Target = float4(0.0);
-    out.gl_FragDepth = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _39 = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float4 _40 = float4(0.0);
+    _40.w = _39;
+    out.out_var_SV_Target = _40;
+    out.gl_FragDepth = _39;
     return out;
 }
 

--- a/src/gl/metal/shaders/mobile/fenceFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/fenceFragmentShader.metal
@@ -11,6 +11,8 @@ struct type_u_cameraPlaneParams
     float u_clipZFar;
 };
 
+constant float _33 = {};
+
 struct main0_out
 {
     float4 out_var_SV_Target [[color(0)]];
@@ -27,9 +29,11 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], texture2d<float> colourTexture [[texture(0)]], sampler colourSampler [[sampler(0)]])
 {
     main0_out out = {};
-    float4 _40 = colourTexture.sample(colourSampler, in.in_var_TEXCOORD0);
-    out.out_var_SV_Target = float4(_40.xyz * in.in_var_COLOR0.xyz, _40.w * in.in_var_COLOR0.w);
-    out.gl_FragDepth = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _56 = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float4 _57 = float4(colourTexture.sample(colourSampler, in.in_var_TEXCOORD0).xyz * in.in_var_COLOR0.xyz, _33);
+    _57.w = _56;
+    out.out_var_SV_Target = _57;
+    out.gl_FragDepth = _56;
     return out;
 }
 

--- a/src/gl/metal/shaders/mobile/flatColourFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/flatColourFragmentShader.metal
@@ -3,20 +3,34 @@
 
 using namespace metal;
 
+struct type_u_cameraPlaneParams
+{
+    float s_CameraNearPlane;
+    float s_CameraFarPlane;
+    float u_clipZNear;
+    float u_clipZFar;
+};
+
 struct main0_out
 {
     float4 out_var_SV_Target [[color(0)]];
+    float gl_FragDepth [[depth(any)]];
 };
 
 struct main0_in
 {
     float4 in_var_COLOR0 [[user(locn2)]];
+    float2 in_var_TEXCOORD1 [[user(locn3)]];
 };
 
-fragment main0_out main0(main0_in in [[stage_in]])
+fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]])
 {
     main0_out out = {};
-    out.out_var_SV_Target = in.in_var_COLOR0;
+    float _38 = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float4 _39 = in.in_var_COLOR0;
+    _39.w = _38;
+    out.out_var_SV_Target = _39;
+    out.gl_FragDepth = _38;
     return out;
 }
 

--- a/src/gl/metal/shaders/mobile/imageRendererFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/imageRendererFragmentShader.metal
@@ -27,8 +27,11 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], texture2d<float> albedoTexture [[texture(0)]], sampler albedoSampler [[sampler(0)]])
 {
     main0_out out = {};
-    out.out_var_SV_Target = albedoTexture.sample(albedoSampler, in.in_var_TEXCOORD0) * in.in_var_COLOR0;
-    out.gl_FragDepth = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _48 = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float4 _49 = albedoTexture.sample(albedoSampler, in.in_var_TEXCOORD0) * in.in_var_COLOR0;
+    _49.w = _48;
+    out.out_var_SV_Target = _49;
+    out.gl_FragDepth = _48;
     return out;
 }
 

--- a/src/gl/metal/shaders/mobile/lineFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/lineFragmentShader.metal
@@ -26,8 +26,11 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]])
 {
     main0_out out = {};
-    out.out_var_SV_Target = in.in_var_COLOR0;
-    out.gl_FragDepth = log2(in.in_var_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _34 = log2(in.in_var_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float4 _35 = in.in_var_COLOR0;
+    _35.w = _34;
+    out.out_var_SV_Target = _35;
+    out.gl_FragDepth = _34;
     return out;
 }
 

--- a/src/gl/metal/shaders/mobile/polygonImageFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/polygonImageFragmentShader.metal
@@ -27,8 +27,11 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], texture2d<float> albedoTexture [[texture(0)]], sampler albedoSampler [[sampler(0)]])
 {
     main0_out out = {};
-    out.out_var_SV_Target = albedoTexture.sample(albedoSampler, in.in_var_TEXCOORD0) * in.in_var_COLOR0;
-    out.gl_FragDepth = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _51 = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float4 _52 = albedoTexture.sample(albedoSampler, in.in_var_TEXCOORD0) * in.in_var_COLOR0;
+    _52.w = _51;
+    out.out_var_SV_Target = _52;
+    out.gl_FragDepth = _51;
     return out;
 }
 

--- a/src/gl/metal/shaders/mobile/polygonP3N3UV2FragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/polygonP3N3UV2FragmentShader.metal
@@ -11,6 +11,8 @@ struct type_u_cameraPlaneParams
     float u_clipZFar;
 };
 
+constant float _39 = {};
+
 struct main0_out
 {
     float4 out_var_SV_Target [[color(0)]];
@@ -28,9 +30,11 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], texture2d<float> albedoTexture [[texture(0)]], sampler albedoSampler [[sampler(0)]])
 {
     main0_out out = {};
-    float4 _48 = albedoTexture.sample(albedoSampler, in.in_var_TEXCOORD0) * in.in_var_COLOR0;
-    out.out_var_SV_Target = float4(_48.xyz * ((dot(in.in_var_NORMAL, normalize(float3(0.85000002384185791015625, 0.1500000059604644775390625, 0.5))) * 0.5) + 0.5), _48.w);
-    out.gl_FragDepth = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _67 = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float4 _68 = float4((albedoTexture.sample(albedoSampler, in.in_var_TEXCOORD0) * in.in_var_COLOR0).xyz * ((dot(in.in_var_NORMAL, normalize(float3(0.85000002384185791015625, 0.1500000059604644775390625, 0.5))) * 0.5) + 0.5), _39);
+    _68.w = _67;
+    out.out_var_SV_Target = _68;
+    out.gl_FragDepth = _67;
     return out;
 }
 

--- a/src/gl/metal/shaders/mobile/tileFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/tileFragmentShader.metal
@@ -11,6 +11,8 @@ struct type_u_cameraPlaneParams
     float u_clipZFar;
 };
 
+constant float _33 = {};
+
 struct main0_out
 {
     float4 out_var_SV_Target [[color(0)]];
@@ -27,8 +29,11 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], texture2d<float> colourTexture [[texture(0)]], sampler colourSampler [[sampler(0)]])
 {
     main0_out out = {};
-    out.out_var_SV_Target = float4(colourTexture.sample(colourSampler, in.in_var_TEXCOORD0).xyz * in.in_var_COLOR0.xyz, in.in_var_COLOR0.w);
-    out.gl_FragDepth = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _49 = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float4 _57 = float4(colourTexture.sample(colourSampler, in.in_var_TEXCOORD0).xyz * in.in_var_COLOR0.xyz, _33);
+    _57.w = _49;
+    out.out_var_SV_Target = _57;
+    out.gl_FragDepth = _49;
     return out;
 }
 

--- a/src/gl/metal/shaders/mobile/udFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/udFragmentShader.metal
@@ -17,8 +17,12 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> sceneColourTexture [[texture(0)]], texture2d<float> sceneDepthTexture [[texture(1)]], sampler sceneColourSampler [[sampler(0)]], sampler sceneDepthSampler [[sampler(1)]])
 {
     main0_out out = {};
-    out.out_var_SV_Target = float4(sceneColourTexture.sample(sceneColourSampler, in.in_var_TEXCOORD0).zyx, 1.0);
-    out.gl_FragDepth = sceneDepthTexture.sample(sceneDepthSampler, in.in_var_TEXCOORD0).x;
+    float4 _34 = sceneDepthTexture.sample(sceneDepthSampler, in.in_var_TEXCOORD0);
+    float _35 = _34.x;
+    float4 _40 = float4(sceneColourTexture.sample(sceneColourSampler, in.in_var_TEXCOORD0).zyx, 1.0);
+    _40.w = _35;
+    out.out_var_SV_Target = _40;
+    out.gl_FragDepth = _35;
     return out;
 }
 

--- a/src/gl/metal/shaders/mobile/visualizationFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/visualizationFragmentShader.metal
@@ -97,7 +97,9 @@ fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlanePa
         _350 = _82;
         _351 = float4(_200.x, _200.y, _200.z, _77.w);
     }
-    out.out_var_SV_Target = float4(_351.xyz, 1.0);
+    float4 _356 = float4(_351.xyz, 1.0);
+    _356.w = _350;
+    out.out_var_SV_Target = _356;
     out.gl_FragDepth = _350;
     return out;
 }

--- a/src/gl/metal/shaders/mobile/waterFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/waterFragmentShader.metal
@@ -41,8 +41,11 @@ fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlanePa
     float3 _108 = normalize((u_EveryFrameFrag.u_eyeNormalMatrix * float4(_90, 0.0)).xyz);
     float3 _110 = normalize(reflect(_92, _108));
     float3 _134 = normalize((u_EveryFrameFrag.u_inverseViewMatrix * float4(_110, 0.0)).xyz);
-    out.out_var_SV_Target = (float4(mix(skyboxTexture.sample(skyboxSampler, (float2(atan2(_134.x, _134.y) + 3.1415927410125732421875, acos(_134.z)) * float2(0.15915493667125701904296875, 0.3183098733425140380859375))).xyz, in.in_var_COLOR1.xyz * mix(float3(1.0, 1.0, 0.60000002384185791015625), float3(0.3499999940395355224609375), float3(pow(fast::max(0.0, _90.z), 5.0))), float3(((dot(_108, _92) * (-0.5)) + 0.5) * 0.75)) + float3(pow(abs(dot(_110, normalize((u_EveryFrameFrag.u_eyeNormalMatrix * float4(normalize(u_EveryFrameFrag.u_specularDir.xyz), 0.0)).xyz))), 50.0) * 0.5), 1.0) * 0.300000011920928955078125) + float4(0.20000000298023223876953125, 0.4000000059604644775390625, 0.699999988079071044921875, 1.0);
-    out.gl_FragDepth = log2(in.in_var_TEXCOORD2.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _162 = log2(in.in_var_TEXCOORD2.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float4 _165 = (float4(mix(skyboxTexture.sample(skyboxSampler, (float2(atan2(_134.x, _134.y) + 3.1415927410125732421875, acos(_134.z)) * float2(0.15915493667125701904296875, 0.3183098733425140380859375))).xyz, in.in_var_COLOR1.xyz * mix(float3(1.0, 1.0, 0.60000002384185791015625), float3(0.3499999940395355224609375), float3(pow(fast::max(0.0, _90.z), 5.0))), float3(((dot(_108, _92) * (-0.5)) + 0.5) * 0.75)) + float3(pow(abs(dot(_110, normalize((u_EveryFrameFrag.u_eyeNormalMatrix * float4(normalize(u_EveryFrameFrag.u_specularDir.xyz), 0.0)).xyz))), 50.0) * 0.5), 1.0) * 0.300000011920928955078125) + float4(0.20000000298023223876953125, 0.4000000059604644775390625, 0.699999988079071044921875, 1.0);
+    _165.w = _162;
+    out.out_var_SV_Target = _165;
+    out.gl_FragDepth = _162;
     return out;
 }
 

--- a/src/gl/opengl/shaders/desktop/compassFragmentShader.frag
+++ b/src/gl/opengl/shaders/desktop/compassFragmentShader.frag
@@ -19,7 +19,10 @@ layout(location = 0) out vec4 out_var_SV_Target;
 void main()
 {
     vec3 _50 = (in_var_COLOR0 * vec3(2.0)) - vec3(1.0);
-    out_var_SV_Target = vec4(((in_var_COLOR1.xyz * (0.5 + (dot(in_var_COLOR2, _50) * (-0.5)))) + (vec3(1.0, 1.0, 0.89999997615814208984375) * pow(max(0.0, -dot(-normalize(in_var_COLOR3.xyz / vec3(in_var_COLOR3.w)), _50)), 60.0))) * in_var_COLOR1.w, 1.0);
-    gl_FragDepth = log2(in_var_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _76 = log2(in_var_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    vec4 _77 = vec4(((in_var_COLOR1.xyz * (0.5 + (dot(in_var_COLOR2, _50) * (-0.5)))) + (vec3(1.0, 1.0, 0.89999997615814208984375) * pow(max(0.0, -dot(-normalize(in_var_COLOR3.xyz / vec3(in_var_COLOR3.w)), _50)), 60.0))) * in_var_COLOR1.w, 1.0);
+    _77.w = _76;
+    out_var_SV_Target = _77;
+    gl_FragDepth = _76;
 }
 

--- a/src/gl/opengl/shaders/desktop/depthOnlyFragmentShader.frag
+++ b/src/gl/opengl/shaders/desktop/depthOnlyFragmentShader.frag
@@ -17,7 +17,10 @@ layout(location = 0) out vec4 out_var_SV_Target;
 
 void main()
 {
-    out_var_SV_Target = vec4(0.0);
-    gl_FragDepth = log2(in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _39 = log2(in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    vec4 _40 = vec4(0.0);
+    _40.w = _39;
+    out_var_SV_Target = _40;
+    gl_FragDepth = _39;
 }
 

--- a/src/gl/opengl/shaders/desktop/fenceFragmentShader.frag
+++ b/src/gl/opengl/shaders/desktop/fenceFragmentShader.frag
@@ -16,10 +16,14 @@ layout(location = 1) in vec2 in_var_TEXCOORD0;
 layout(location = 2) in vec2 in_var_TEXCOORD1;
 layout(location = 0) out vec4 out_var_SV_Target;
 
+float _33;
+
 void main()
 {
-    vec4 _40 = texture(SPIRV_Cross_CombinedcolourTexturecolourSampler, in_var_TEXCOORD0);
-    out_var_SV_Target = vec4(_40.xyz * in_var_COLOR0.xyz, _40.w * in_var_COLOR0.w);
-    gl_FragDepth = log2(in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _56 = log2(in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    vec4 _57 = vec4(texture(SPIRV_Cross_CombinedcolourTexturecolourSampler, in_var_TEXCOORD0).xyz * in_var_COLOR0.xyz, _33);
+    _57.w = _56;
+    out_var_SV_Target = _57;
+    gl_FragDepth = _56;
 }
 

--- a/src/gl/opengl/shaders/desktop/flatColourFragmentShader.frag
+++ b/src/gl/opengl/shaders/desktop/flatColourFragmentShader.frag
@@ -1,6 +1,14 @@
 #version 330
 #extension GL_ARB_separate_shader_objects : require
 
+layout(std140) uniform type_u_cameraPlaneParams
+{
+    float s_CameraNearPlane;
+    float s_CameraFarPlane;
+    float u_clipZNear;
+    float u_clipZFar;
+} u_cameraPlaneParams;
+
 layout(location = 0) in vec2 in_var_TEXCOORD0;
 layout(location = 1) in vec3 in_var_NORMAL;
 layout(location = 2) in vec4 in_var_COLOR0;
@@ -9,6 +17,10 @@ layout(location = 0) out vec4 out_var_SV_Target;
 
 void main()
 {
-    out_var_SV_Target = in_var_COLOR0;
+    float _38 = log2(in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    vec4 _39 = in_var_COLOR0;
+    _39.w = _38;
+    out_var_SV_Target = _39;
+    gl_FragDepth = _38;
 }
 

--- a/src/gl/opengl/shaders/desktop/imageRendererFragmentShader.frag
+++ b/src/gl/opengl/shaders/desktop/imageRendererFragmentShader.frag
@@ -18,7 +18,10 @@ layout(location = 0) out vec4 out_var_SV_Target;
 
 void main()
 {
-    out_var_SV_Target = texture(SPIRV_Cross_CombinedalbedoTexturealbedoSampler, in_var_TEXCOORD0) * in_var_COLOR0;
-    gl_FragDepth = log2(in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _48 = log2(in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    vec4 _49 = texture(SPIRV_Cross_CombinedalbedoTexturealbedoSampler, in_var_TEXCOORD0) * in_var_COLOR0;
+    _49.w = _48;
+    out_var_SV_Target = _49;
+    gl_FragDepth = _48;
 }
 

--- a/src/gl/opengl/shaders/desktop/lineFragmentShader.frag
+++ b/src/gl/opengl/shaders/desktop/lineFragmentShader.frag
@@ -15,7 +15,10 @@ layout(location = 0) out vec4 out_var_SV_Target;
 
 void main()
 {
-    out_var_SV_Target = in_var_COLOR0;
-    gl_FragDepth = log2(in_var_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _34 = log2(in_var_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    vec4 _35 = in_var_COLOR0;
+    _35.w = _34;
+    out_var_SV_Target = _35;
+    gl_FragDepth = _34;
 }
 

--- a/src/gl/opengl/shaders/desktop/polygonImageFragmentShader.frag
+++ b/src/gl/opengl/shaders/desktop/polygonImageFragmentShader.frag
@@ -19,7 +19,10 @@ layout(location = 0) out vec4 out_var_SV_Target;
 
 void main()
 {
-    out_var_SV_Target = texture(SPIRV_Cross_CombinedalbedoTexturealbedoSampler, in_var_TEXCOORD0) * in_var_COLOR0;
-    gl_FragDepth = log2(in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _51 = log2(in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    vec4 _52 = texture(SPIRV_Cross_CombinedalbedoTexturealbedoSampler, in_var_TEXCOORD0) * in_var_COLOR0;
+    _52.w = _51;
+    out_var_SV_Target = _52;
+    gl_FragDepth = _51;
 }
 

--- a/src/gl/opengl/shaders/desktop/polygonP3N3UV2FragmentShader.frag
+++ b/src/gl/opengl/shaders/desktop/polygonP3N3UV2FragmentShader.frag
@@ -17,10 +17,14 @@ layout(location = 2) in vec4 in_var_COLOR0;
 layout(location = 3) in vec2 in_var_TEXCOORD1;
 layout(location = 0) out vec4 out_var_SV_Target;
 
+float _39;
+
 void main()
 {
-    vec4 _48 = texture(SPIRV_Cross_CombinedalbedoTexturealbedoSampler, in_var_TEXCOORD0) * in_var_COLOR0;
-    out_var_SV_Target = vec4(_48.xyz * ((dot(in_var_NORMAL, normalize(vec3(0.85000002384185791015625, 0.1500000059604644775390625, 0.5))) * 0.5) + 0.5), _48.w);
-    gl_FragDepth = log2(in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _67 = log2(in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    vec4 _68 = vec4((texture(SPIRV_Cross_CombinedalbedoTexturealbedoSampler, in_var_TEXCOORD0) * in_var_COLOR0).xyz * ((dot(in_var_NORMAL, normalize(vec3(0.85000002384185791015625, 0.1500000059604644775390625, 0.5))) * 0.5) + 0.5), _39);
+    _68.w = _67;
+    out_var_SV_Target = _68;
+    gl_FragDepth = _67;
 }
 

--- a/src/gl/opengl/shaders/desktop/tileFragmentShader.frag
+++ b/src/gl/opengl/shaders/desktop/tileFragmentShader.frag
@@ -16,9 +16,14 @@ layout(location = 1) in vec2 in_var_TEXCOORD0;
 layout(location = 2) in vec2 in_var_TEXCOORD1;
 layout(location = 0) out vec4 out_var_SV_Target;
 
+float _33;
+
 void main()
 {
-    out_var_SV_Target = vec4(texture(SPIRV_Cross_CombinedcolourTexturecolourSampler, in_var_TEXCOORD0).xyz * in_var_COLOR0.xyz, in_var_COLOR0.w);
-    gl_FragDepth = log2(in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _49 = log2(in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    vec4 _57 = vec4(texture(SPIRV_Cross_CombinedcolourTexturecolourSampler, in_var_TEXCOORD0).xyz * in_var_COLOR0.xyz, _33);
+    _57.w = _49;
+    out_var_SV_Target = _57;
+    gl_FragDepth = _49;
 }
 

--- a/src/gl/opengl/shaders/desktop/udFragmentShader.frag
+++ b/src/gl/opengl/shaders/desktop/udFragmentShader.frag
@@ -9,7 +9,11 @@ layout(location = 0) out vec4 out_var_SV_Target;
 
 void main()
 {
-    out_var_SV_Target = vec4(texture(SPIRV_Cross_CombinedsceneColourTexturesceneColourSampler, in_var_TEXCOORD0).zyx, 1.0);
-    gl_FragDepth = texture(SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler, in_var_TEXCOORD0).x;
+    vec4 _34 = texture(SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler, in_var_TEXCOORD0);
+    float _35 = _34.x;
+    vec4 _40 = vec4(texture(SPIRV_Cross_CombinedsceneColourTexturesceneColourSampler, in_var_TEXCOORD0).zyx, 1.0);
+    _40.w = _35;
+    out_var_SV_Target = _40;
+    gl_FragDepth = _35;
 }
 

--- a/src/gl/opengl/shaders/desktop/visualizationFragmentShader.frag
+++ b/src/gl/opengl/shaders/desktop/visualizationFragmentShader.frag
@@ -80,7 +80,9 @@ void main()
         _350 = _82;
         _351 = vec4(_200.x, _200.y, _200.z, _77.w);
     }
-    out_var_SV_Target = vec4(_351.xyz, 1.0);
+    vec4 _356 = vec4(_351.xyz, 1.0);
+    _356.w = _350;
+    out_var_SV_Target = _356;
     gl_FragDepth = _350;
 }
 

--- a/src/gl/opengl/shaders/desktop/waterFragmentShader.frag
+++ b/src/gl/opengl/shaders/desktop/waterFragmentShader.frag
@@ -33,7 +33,10 @@ void main()
     vec3 _108 = normalize((vec4(_90, 0.0) * u_EveryFrameFrag.u_eyeNormalMatrix).xyz);
     vec3 _110 = normalize(reflect(_92, _108));
     vec3 _134 = normalize((vec4(_110, 0.0) * u_EveryFrameFrag.u_inverseViewMatrix).xyz);
-    out_var_SV_Target = (vec4(mix(texture(SPIRV_Cross_CombinedskyboxTextureskyboxSampler, vec2(atan(_134.x, _134.y) + 3.1415927410125732421875, acos(_134.z)) * vec2(0.15915493667125701904296875, 0.3183098733425140380859375)).xyz, in_var_COLOR1.xyz * mix(vec3(1.0, 1.0, 0.60000002384185791015625), vec3(0.3499999940395355224609375), vec3(pow(max(0.0, _90.z), 5.0))), vec3(((dot(_108, _92) * (-0.5)) + 0.5) * 0.75)) + vec3(pow(abs(dot(_110, normalize((vec4(normalize(u_EveryFrameFrag.u_specularDir.xyz), 0.0) * u_EveryFrameFrag.u_eyeNormalMatrix).xyz))), 50.0) * 0.5), 1.0) * 0.300000011920928955078125) + vec4(0.20000000298023223876953125, 0.4000000059604644775390625, 0.699999988079071044921875, 1.0);
-    gl_FragDepth = log2(in_var_TEXCOORD2.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _162 = log2(in_var_TEXCOORD2.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    vec4 _165 = (vec4(mix(texture(SPIRV_Cross_CombinedskyboxTextureskyboxSampler, vec2(atan(_134.x, _134.y) + 3.1415927410125732421875, acos(_134.z)) * vec2(0.15915493667125701904296875, 0.3183098733425140380859375)).xyz, in_var_COLOR1.xyz * mix(vec3(1.0, 1.0, 0.60000002384185791015625), vec3(0.3499999940395355224609375), vec3(pow(max(0.0, _90.z), 5.0))), vec3(((dot(_108, _92) * (-0.5)) + 0.5) * 0.75)) + vec3(pow(abs(dot(_110, normalize((vec4(normalize(u_EveryFrameFrag.u_specularDir.xyz), 0.0) * u_EveryFrameFrag.u_eyeNormalMatrix).xyz))), 50.0) * 0.5), 1.0) * 0.300000011920928955078125) + vec4(0.20000000298023223876953125, 0.4000000059604644775390625, 0.699999988079071044921875, 1.0);
+    _165.w = _162;
+    out_var_SV_Target = _165;
+    gl_FragDepth = _162;
 }
 

--- a/src/gl/opengl/shaders/mobile/compassFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/compassFragmentShader.frag
@@ -20,7 +20,10 @@ layout(location = 0) out highp vec4 out_var_SV_Target;
 void main()
 {
     highp vec3 _50 = (varying_COLOR0 * vec3(2.0)) - vec3(1.0);
-    out_var_SV_Target = vec4(((varying_COLOR1.xyz * (0.5 + (dot(varying_COLOR2, _50) * (-0.5)))) + (vec3(1.0, 1.0, 0.89999997615814208984375) * pow(max(0.0, -dot(-normalize(varying_COLOR3.xyz / vec3(varying_COLOR3.w)), _50)), 60.0))) * varying_COLOR1.w, 1.0);
-    gl_FragDepth = log2(varying_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    highp float _76 = log2(varying_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    highp vec4 _77 = vec4(((varying_COLOR1.xyz * (0.5 + (dot(varying_COLOR2, _50) * (-0.5)))) + (vec3(1.0, 1.0, 0.89999997615814208984375) * pow(max(0.0, -dot(-normalize(varying_COLOR3.xyz / vec3(varying_COLOR3.w)), _50)), 60.0))) * varying_COLOR1.w, 1.0);
+    _77.w = _76;
+    out_var_SV_Target = _77;
+    gl_FragDepth = _76;
 }
 

--- a/src/gl/opengl/shaders/mobile/depthOnlyFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/depthOnlyFragmentShader.frag
@@ -18,7 +18,10 @@ layout(location = 0) out highp vec4 out_var_SV_Target;
 
 void main()
 {
-    out_var_SV_Target = vec4(0.0);
-    gl_FragDepth = log2(varying_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    highp float _39 = log2(varying_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    highp vec4 _40 = vec4(0.0);
+    _40.w = _39;
+    out_var_SV_Target = _40;
+    gl_FragDepth = _39;
 }
 

--- a/src/gl/opengl/shaders/mobile/fenceFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/fenceFragmentShader.frag
@@ -17,10 +17,14 @@ in highp vec2 varying_TEXCOORD0;
 in highp vec2 varying_TEXCOORD1;
 layout(location = 0) out highp vec4 out_var_SV_Target;
 
+float _33;
+
 void main()
 {
-    highp vec4 _40 = texture(SPIRV_Cross_CombinedcolourTexturecolourSampler, varying_TEXCOORD0);
-    out_var_SV_Target = vec4(_40.xyz * varying_COLOR0.xyz, _40.w * varying_COLOR0.w);
-    gl_FragDepth = log2(varying_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    highp float _56 = log2(varying_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    highp vec4 _57 = vec4(texture(SPIRV_Cross_CombinedcolourTexturecolourSampler, varying_TEXCOORD0).xyz * varying_COLOR0.xyz, _33);
+    _57.w = _56;
+    out_var_SV_Target = _57;
+    gl_FragDepth = _56;
 }
 

--- a/src/gl/opengl/shaders/mobile/flatColourFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/flatColourFragmentShader.frag
@@ -2,6 +2,14 @@
 precision mediump float;
 precision highp int;
 
+layout(std140) uniform type_u_cameraPlaneParams
+{
+    highp float s_CameraNearPlane;
+    highp float s_CameraFarPlane;
+    highp float u_clipZNear;
+    highp float u_clipZFar;
+} u_cameraPlaneParams;
+
 in highp vec2 varying_TEXCOORD0;
 in highp vec3 varying_NORMAL;
 in highp vec4 varying_COLOR0;
@@ -10,6 +18,10 @@ layout(location = 0) out highp vec4 out_var_SV_Target;
 
 void main()
 {
-    out_var_SV_Target = varying_COLOR0;
+    highp float _38 = log2(varying_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    highp vec4 _39 = varying_COLOR0;
+    _39.w = _38;
+    out_var_SV_Target = _39;
+    gl_FragDepth = _38;
 }
 

--- a/src/gl/opengl/shaders/mobile/imageRendererFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/imageRendererFragmentShader.frag
@@ -19,7 +19,10 @@ layout(location = 0) out highp vec4 out_var_SV_Target;
 
 void main()
 {
-    out_var_SV_Target = texture(SPIRV_Cross_CombinedalbedoTexturealbedoSampler, varying_TEXCOORD0) * varying_COLOR0;
-    gl_FragDepth = log2(varying_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    highp float _48 = log2(varying_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    highp vec4 _49 = texture(SPIRV_Cross_CombinedalbedoTexturealbedoSampler, varying_TEXCOORD0) * varying_COLOR0;
+    _49.w = _48;
+    out_var_SV_Target = _49;
+    gl_FragDepth = _48;
 }
 

--- a/src/gl/opengl/shaders/mobile/lineFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/lineFragmentShader.frag
@@ -16,7 +16,10 @@ layout(location = 0) out highp vec4 out_var_SV_Target;
 
 void main()
 {
-    out_var_SV_Target = varying_COLOR0;
-    gl_FragDepth = log2(varying_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    highp float _34 = log2(varying_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    highp vec4 _35 = varying_COLOR0;
+    _35.w = _34;
+    out_var_SV_Target = _35;
+    gl_FragDepth = _34;
 }
 

--- a/src/gl/opengl/shaders/mobile/polygonImageFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/polygonImageFragmentShader.frag
@@ -20,7 +20,10 @@ layout(location = 0) out highp vec4 out_var_SV_Target;
 
 void main()
 {
-    out_var_SV_Target = texture(SPIRV_Cross_CombinedalbedoTexturealbedoSampler, varying_TEXCOORD0) * varying_COLOR0;
-    gl_FragDepth = log2(varying_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    highp float _51 = log2(varying_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    highp vec4 _52 = texture(SPIRV_Cross_CombinedalbedoTexturealbedoSampler, varying_TEXCOORD0) * varying_COLOR0;
+    _52.w = _51;
+    out_var_SV_Target = _52;
+    gl_FragDepth = _51;
 }
 

--- a/src/gl/opengl/shaders/mobile/polygonP3N3UV2FragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/polygonP3N3UV2FragmentShader.frag
@@ -18,10 +18,14 @@ in highp vec4 varying_COLOR0;
 in highp vec2 varying_TEXCOORD1;
 layout(location = 0) out highp vec4 out_var_SV_Target;
 
+float _39;
+
 void main()
 {
-    highp vec4 _48 = texture(SPIRV_Cross_CombinedalbedoTexturealbedoSampler, varying_TEXCOORD0) * varying_COLOR0;
-    out_var_SV_Target = vec4(_48.xyz * ((dot(varying_NORMAL, normalize(vec3(0.85000002384185791015625, 0.1500000059604644775390625, 0.5))) * 0.5) + 0.5), _48.w);
-    gl_FragDepth = log2(varying_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    highp float _67 = log2(varying_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    highp vec4 _68 = vec4((texture(SPIRV_Cross_CombinedalbedoTexturealbedoSampler, varying_TEXCOORD0) * varying_COLOR0).xyz * ((dot(varying_NORMAL, normalize(vec3(0.85000002384185791015625, 0.1500000059604644775390625, 0.5))) * 0.5) + 0.5), _39);
+    _68.w = _67;
+    out_var_SV_Target = _68;
+    gl_FragDepth = _67;
 }
 

--- a/src/gl/opengl/shaders/mobile/tileFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/tileFragmentShader.frag
@@ -17,9 +17,14 @@ in highp vec2 varying_TEXCOORD0;
 in highp vec2 varying_TEXCOORD1;
 layout(location = 0) out highp vec4 out_var_SV_Target;
 
+float _33;
+
 void main()
 {
-    out_var_SV_Target = vec4(texture(SPIRV_Cross_CombinedcolourTexturecolourSampler, varying_TEXCOORD0).xyz * varying_COLOR0.xyz, varying_COLOR0.w);
-    gl_FragDepth = log2(varying_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    highp float _49 = log2(varying_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    highp vec4 _57 = vec4(texture(SPIRV_Cross_CombinedcolourTexturecolourSampler, varying_TEXCOORD0).xyz * varying_COLOR0.xyz, _33);
+    _57.w = _49;
+    out_var_SV_Target = _57;
+    gl_FragDepth = _49;
 }
 

--- a/src/gl/opengl/shaders/mobile/udFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/udFragmentShader.frag
@@ -10,7 +10,11 @@ layout(location = 0) out highp vec4 out_var_SV_Target;
 
 void main()
 {
-    out_var_SV_Target = vec4(texture(SPIRV_Cross_CombinedsceneColourTexturesceneColourSampler, varying_TEXCOORD0).zyx, 1.0);
-    gl_FragDepth = texture(SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler, varying_TEXCOORD0).x;
+    highp vec4 _34 = texture(SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler, varying_TEXCOORD0);
+    highp float _35 = _34.x;
+    highp vec4 _40 = vec4(texture(SPIRV_Cross_CombinedsceneColourTexturesceneColourSampler, varying_TEXCOORD0).zyx, 1.0);
+    _40.w = _35;
+    out_var_SV_Target = _40;
+    gl_FragDepth = _35;
 }
 

--- a/src/gl/opengl/shaders/mobile/visualizationFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/visualizationFragmentShader.frag
@@ -81,7 +81,9 @@ void main()
         _350 = _82;
         _351 = vec4(_200.x, _200.y, _200.z, _77.w);
     }
-    out_var_SV_Target = vec4(_351.xyz, 1.0);
+    highp vec4 _356 = vec4(_351.xyz, 1.0);
+    _356.w = _350;
+    out_var_SV_Target = _356;
     gl_FragDepth = _350;
 }
 

--- a/src/gl/opengl/shaders/mobile/waterFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/waterFragmentShader.frag
@@ -34,7 +34,10 @@ void main()
     highp vec3 _108 = normalize((vec4(_90, 0.0) * u_EveryFrameFrag.u_eyeNormalMatrix).xyz);
     highp vec3 _110 = normalize(reflect(_92, _108));
     highp vec3 _134 = normalize((vec4(_110, 0.0) * u_EveryFrameFrag.u_inverseViewMatrix).xyz);
-    out_var_SV_Target = (vec4(mix(texture(SPIRV_Cross_CombinedskyboxTextureskyboxSampler, vec2(atan(_134.x, _134.y) + 3.1415927410125732421875, acos(_134.z)) * vec2(0.15915493667125701904296875, 0.3183098733425140380859375)).xyz, varying_COLOR1.xyz * mix(vec3(1.0, 1.0, 0.60000002384185791015625), vec3(0.3499999940395355224609375), vec3(pow(max(0.0, _90.z), 5.0))), vec3(((dot(_108, _92) * (-0.5)) + 0.5) * 0.75)) + vec3(pow(abs(dot(_110, normalize((vec4(normalize(u_EveryFrameFrag.u_specularDir.xyz), 0.0) * u_EveryFrameFrag.u_eyeNormalMatrix).xyz))), 50.0) * 0.5), 1.0) * 0.300000011920928955078125) + vec4(0.20000000298023223876953125, 0.4000000059604644775390625, 0.699999988079071044921875, 1.0);
-    gl_FragDepth = log2(varying_TEXCOORD2.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    highp float _162 = log2(varying_TEXCOORD2.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    highp vec4 _165 = (vec4(mix(texture(SPIRV_Cross_CombinedskyboxTextureskyboxSampler, vec2(atan(_134.x, _134.y) + 3.1415927410125732421875, acos(_134.z)) * vec2(0.15915493667125701904296875, 0.3183098733425140380859375)).xyz, varying_COLOR1.xyz * mix(vec3(1.0, 1.0, 0.60000002384185791015625), vec3(0.3499999940395355224609375), vec3(pow(max(0.0, _90.z), 5.0))), vec3(((dot(_108, _92) * (-0.5)) + 0.5) * 0.75)) + vec3(pow(abs(dot(_110, normalize((vec4(normalize(u_EveryFrameFrag.u_specularDir.xyz), 0.0) * u_EveryFrameFrag.u_eyeNormalMatrix).xyz))), 50.0) * 0.5), 1.0) * 0.300000011920928955078125) + vec4(0.20000000298023223876953125, 0.4000000059604644775390625, 0.699999988079071044921875, 1.0);
+    _165.w = _162;
+    out_var_SV_Target = _165;
+    gl_FragDepth = _162;
 }
 

--- a/src/rendering/vcPolygonModel.cpp
+++ b/src/rendering/vcPolygonModel.cpp
@@ -508,8 +508,7 @@ udResult vcPolygonModel_Render(vcPolygonModel *pModel, const udDouble4x4 &modelM
       pPolygonShader = &gShaders[vcPMST_P3N3UV2_FlatColour];
     else if (passType == vcPMP_Shadows)
       pPolygonShader = &gShaders[vcPMST_P3N3UV2_DepthOnly];
-
-    if (pDiffuseOverride)
+    else if (pDiffuseOverride)
     {
       pDiffuseTexture = pDiffuseOverride;
       pPolygonShader = &gShaders[vcPMST_P3N3UV2_Opaque_Image]; // Assuming that models with textures could skip lighting.


### PR DESCRIPTION
Changed colour to rgba16f, and storing depth in alpha.
Fixed a bug where polygon models were not splatting their IDs correctly.
Fixed an issue with DirectX pixel readback assumed a pixel size of 4 bytes.
D3D: On passive picking (async readback), we're now only doing a 1x1 readback, instead of a full texture width*height readback (~1ms saved on desktop).