### PR TITLE
DEM and Colour tiles now load into a proxy

### DIFF
--- a/src/rendering/vcTileRenderer.cpp
+++ b/src/rendering/vcTileRenderer.cpp
@@ -353,8 +353,8 @@ uint32_t vcTileRenderer_LoadThread(void *pThreadData)
         vcStringFormat(serverURLColour, udLengthOf(serverURLColour), pRenderer->pSettings->maptiles.activeServer.tileServerAddress, pSlippyStrs, udLengthOf(pSlippyStrs));
       }
 
-      pBestNode->tag++;
-      uint32_t currentTag = pBestNode->tag;
+      ++pBestNode->tag;
+      int32_t currentTag = pBestNode->tag.Get();
 
       //We release the mutex to allow work to continue on the quadtree.
       //For instance, the quadtree may be cleared duting the loads below.
@@ -375,7 +375,7 @@ uint32_t vcTileRenderer_LoadThread(void *pThreadData)
       udLockMutex(pCache->pMutex);
 
       //Check if the node is still valid. If the tag is different, another thread has taken this node.
-      if (currentTag == pBestNode->tag)
+      if (currentTag == pBestNode->tag.Get())
       {
         if (canDownloadDEM)
           vcTileRenderer_HandleResponseData(DEMResult, &pBestNode->demInfo, textureDEM);

--- a/src/vcQuadTree.cpp
+++ b/src/vcQuadTree.cpp
@@ -109,10 +109,6 @@ double vcQuadTree_PointToRectDistance(udDouble3 edges[9], const udDouble3 &point
 
 void vcQuadTree_CleanupNode(vcQuadTreeNode *pNode)
 {
-  // Just to be safe
-  while (pNode->colourInfo.loadStatus.Get() == vcNodeRenderInfo::vcTLS_Downloading || pNode->demInfo.loadStatus.Get() == vcNodeRenderInfo::vcTLS_Downloading)
-    udYield();
-
   vcTexture_Destroy(&pNode->colourInfo.data.pTexture);
   udFree(pNode->colourInfo.data.pData);
 

--- a/src/vcQuadTree.h
+++ b/src/vcQuadTree.h
@@ -67,6 +67,8 @@ struct vcQuadTreeNode
   bool visible;
   volatile bool touched;
 
+  uint32_t tag;
+
   // if a node was rendered with missing information (only considers colour at the moment, includes any failed descendents)
   bool completeRender;
 

--- a/src/vcQuadTree.h
+++ b/src/vcQuadTree.h
@@ -67,7 +67,7 @@ struct vcQuadTreeNode
   bool visible;
   volatile bool touched;
 
-  uint32_t tag;
+  udInterlockedInt32 tag;
 
   // if a node was rendered with missing information (only considers colour at the moment, includes any failed descendents)
   bool completeRender;


### PR DESCRIPTION
[AB#1577](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1577)

I'm loading the tiles into a proxy before inserting them back into the quadtree. This way we can release the cache mutex, allowing other work to be done on the nodes (clearing the tree for example) without having to wait for tiles to finish loading.