### PR TITLE
Allow to enter full-screen mode when modal windows are open.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2138,7 +2138,7 @@ void vcMain_RenderSceneWindow(vcState *pProgramState)
     vcFramebuffer_Bind(pProgramState->pDefaultFramebuffer);
   }
 
-  if (!pProgramState->modalOpen && (vcHotkey::IsPressed(vcB_Fullscreen) || ImGui::IsNavInputTest(ImGuiNavInput_TweakFast, ImGuiInputReadMode_Released)))
+  if (vcHotkey::IsPressed(vcB_Fullscreen) || ImGui::IsNavInputTest(ImGuiNavInput_TweakFast, ImGuiInputReadMode_Released))
     vcMain_PresentationMode(pProgramState);
 
   vcRenderSceneUI(pProgramState, windowPos, windowSize, &cameraMoveOffset);


### PR DESCRIPTION
Client can enter fullscreen while settings is open but can not when convert window open. Modified to make it consistent, now can both go fullscreen.