### PR TITLE
Fixed various Metal issues

### DIFF
--- a/src/gl/metal/vcGLState.mm
+++ b/src/gl/metal/vcGLState.mm
@@ -227,7 +227,10 @@ bool vcGLState_SetBlendMode(vcGLStateBlendMode blendMode, bool force /*= false*/
   {
     g_internalState.blendMode = blendMode;
     if (g_pCurrShader != nullptr && g_pCurrFramebuffer != nullptr)
-      [g_pCurrFramebuffer->encoder setRenderPipelineState:g_pCurrShader->pipelines[blendMode + (g_pCurrFramebuffer->pDepth != nullptr ? 0 : vcGLSBM_Count)]];
+    {
+      vcShader_UpdatePipeline(g_pCurrShader);
+      [g_pCurrFramebuffer->encoder setRenderPipelineState:g_pCurrShader->pipeline];
+    }
   }
   return true;
 }

--- a/src/gl/metal/vcMetal.h
+++ b/src/gl/metal/vcMetal.h
@@ -21,6 +21,7 @@ extern vcShader *g_pCurrShader;
 extern id<MTLBlitCommandEncoder> g_blitEncoder;
 
 void vcGLState_FlushBlit();
+void vcShader_UpdatePipeline(vcShader *pShader);
 
 enum vcRendererFramebufferActions
 {
@@ -71,7 +72,8 @@ struct vcShader
   bool inititalised;
   id<MTLLibrary> vertexLibrary;
   id<MTLLibrary> fragmentLibrary;
-  id<MTLRenderPipelineState> pipelines[vcGLSBM_Count * 2];
+  MTLRenderPipelineDescriptor *pDesc;
+  id<MTLRenderPipelineState> pipeline;
 
   vcShaderConstantBuffer bufferObjects[16];
   int numBufferObjects;

--- a/src/gl/metal/vcTexture.mm
+++ b/src/gl/metal/vcTexture.mm
@@ -355,21 +355,21 @@ bool vcTexture_EndReadPixels(vcTexture *pTexture, uint32_t x, uint32_t y, uint32
 
   udResult result = udR_Success;
   int pixelBytes = 0;
-  uint32_t *pPixelData = nullptr;
+  uint8_t *pPixelData = nullptr;
   vcTexture_GetFormatAndPixelSize(pTexture->format, &pixelBytes);
 
   if (x == 0 && y == 0 && width == (uint32_t)pTexture->width && height == (uint32_t)pTexture->height)
   {
-    pPixelData = (uint32_t*)[pTexture->blitBuffer contents];
+    pPixelData = (uint8_t*)[pTexture->blitBuffer contents];
     memcpy((uint8_t*)pPixels, pPixelData, height * width * pixelBytes);
   }
   else
   {
-    pPixelData = ((uint32_t*)[pTexture->blitBuffer contents]) + (x + y * pTexture->width);
+    pPixelData = ((uint8_t*)[pTexture->blitBuffer contents]) + (x + y * pTexture->width) * pixelBytes;
     for (int i = 0; i < (int)height; ++i)
     {
       memcpy((uint8_t*)pPixels + (i * pTexture->width * pixelBytes), pPixelData, width * pixelBytes);
-      pPixelData += pTexture->width;
+      pPixelData += pTexture->width * pixelBytes;
     }
   }
 

--- a/src/vcRender.cpp
+++ b/src/vcRender.cpp
@@ -1773,7 +1773,7 @@ vcRenderPickResult vcRender_PolygonPick(vcState *pProgramState, vcRenderContext 
   }
   else
   {
-    if (pRenderContext->previousFrameDepth > -1 && pRenderContext->previousFrameDepth < 1.0)
+    if (pRenderContext->previousFrameDepth > 0.0 && pRenderContext->previousFrameDepth < 1.0)
     {
       result.success = true;
       pickDepth = pRenderContext->previousFrameDepth;


### PR DESCRIPTION
- Metal: Framebuffers now create MTL encoder and command buffer on bind to ensure clear colour is utilized
- Metal: Shaders now create MTLRenderPipelineState on demand when certain states change
- Metal: Textures read using pixelBytes instead of assuming 4 bytes
- vcRender: Previous depth must be greater than 0.0 as depth is [0,1] not [-1,1]

Resolves [AB#1585](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1585)