### PR TITLE
Maps system handles projection changes internally.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1360,7 +1360,6 @@ void vcRenderSceneUI(vcState *pProgramState, const ImVec2 &windowPos, const ImVe
           if (vcGIS_ChangeSpace(&pProgramState->gis, zone, &pProgramState->camera.position))
           {
             pProgramState->activeProject.pFolder->ChangeProjection(zone);
-            vcRender_ClearTiles(pProgramState->pRenderContext);
           }
         }
       }

--- a/src/scene/vcFolder.cpp
+++ b/src/scene/vcFolder.cpp
@@ -281,8 +281,6 @@ void vcFolder::HandleImGui(vcState *pProgramState, size_t *pItemID)
           if (vcGIS_ChangeSpace(&pProgramState->gis, *pSceneItem->m_pPreferredProjection, &pProgramState->camera.position))
           {
             pProgramState->activeProject.pFolder->ChangeProjection(*pSceneItem->m_pPreferredProjection);
-            // refresh map tiles when geozone changes
-            vcRender_ClearTiles(pProgramState->pRenderContext);
           }
         }
 

--- a/src/vcProject.cpp
+++ b/src/vcProject.cpp
@@ -14,7 +14,6 @@ void vcProject_InitBlankScene(vcState *pProgramState)
     vcProject_Deinit(pProgramState, &pProgramState->activeProject);
 
   udGeoZone zone = {};
-  vcRender_ClearTiles(pProgramState->pRenderContext);
   vcGIS_ChangeSpace(&pProgramState->gis, zone);
 
   pProgramState->camera.position = udDouble3::zero();
@@ -32,9 +31,6 @@ void vcProject_InitBlankScene(vcState *pProgramState)
 
   if (vcGIS_ChangeSpace(&pProgramState->gis, cameraZone))
     pProgramState->activeProject.pFolder->ChangeProjection(cameraZone);
-
-  // refresh map tiles when geozone changes
-  vcRender_ClearTiles(pProgramState->pRenderContext);
 
   double locations[][5] = {
     { 309281.960926, 5640790.149293, 2977479.571028, 55.74, -32.45 }, // Mount Everest
@@ -115,7 +111,6 @@ bool vcProject_InitFromURI(vcState *pProgramState, const char *pFilename)
       vcProject_Deinit(pProgramState, &pProgramState->activeProject);
 
       udGeoZone zone = {};
-      vcRender_ClearTiles(pProgramState->pRenderContext);
       vcGIS_ChangeSpace(&pProgramState->gis, zone);
 
       pProgramState->sceneExplorer.selectedItems.clear();
@@ -401,9 +396,6 @@ bool vcProject_UseProjectionFromItem(vcState *pProgramState, vcSceneItem *pItem)
 
   if (vcGIS_ChangeSpace(&pProgramState->gis, *pItem->m_pPreferredProjection))
     pProgramState->activeProject.pFolder->ChangeProjection(*pItem->m_pPreferredProjection);
-
-  // refresh map tiles when geozone changes
-  vcRender_ClearTiles(pProgramState->pRenderContext);
 
   // move camera to the new item's position
   pItem->SetCameraPosition(pProgramState);

--- a/src/vcQuadTree.cpp
+++ b/src/vcQuadTree.cpp
@@ -109,10 +109,6 @@ double vcQuadTree_PointToRectDistance(udDouble3 edges[9], const udDouble3 &point
 
 void vcQuadTree_CleanupNode(vcQuadTreeNode *pNode)
 {
-  // Just to be safe
-  while (pNode->colourInfo.loadStatus.Get() == vcNodeRenderInfo::vcTLS_Downloading || pNode->demInfo.loadStatus.Get() == vcNodeRenderInfo::vcTLS_Downloading)
-    udYield();
-
   vcTexture_Destroy(&pNode->colourInfo.data.pTexture);
   udFree(pNode->colourInfo.data.pData);
 


### PR DESCRIPTION
Removed unnecessary explicit clearing of maps on projection change, and instead letting the map system detect and handle these changes internally.

[AB#1577](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1577)