### PR TITLE
Changed the axis's ends to orange and yellow as an optimization optio…

### DIFF
--- a/src/imgui_ex/ImGuizmo.cpp
+++ b/src/imgui_ex/ImGuizmo.cpp
@@ -531,11 +531,11 @@ static void vcGizmo_DrawScaleGizmo(int type)
       if (sGizmoContext.mbUsing)
       {
         drawList->AddLine(baseSSpace, worldDirSSpaceNoScale, 0xFF404040, 3.f);
-        drawList->AddCircleFilled(worldDirSSpaceNoScale, 6.f, 0xFF404040);
+        drawList->AddCircleFilled(worldDirSSpaceNoScale, 6.f, 0xFF4080FF); // orange
       }
 
       drawList->AddLine(baseSSpace, worldDirSSpace, colors[i + 1], 3.f);
-      drawList->AddCircleFilled(worldDirSSpace, 6.f, colors[i + 1]);
+      drawList->AddCircleFilled(worldDirSSpace, 6.f, 0xFF00F2FF); // yellow
 
       if (sGizmoContext.mAxisFactor[i] < 0.0)
         vcGizmo_DrawHatchedAxis(dirAxis * scaleDisplay[i]);


### PR DESCRIPTION
For [AB#1609](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1609).
I'd like to keep the original logic of axis's colour. So I changed the axis ends to yellow/orange to make it more visible. However, I submitted it as an optimazition option.

![1](https://user-images.githubusercontent.com/11733679/80788010-62c63400-8bcb-11ea-99dc-24cc4389a4a7.png)
![2](https://user-images.githubusercontent.com/11733679/80788014-648ff780-8bcb-11ea-94ed-2bf3f7a6a6d9.png)
![3](https://user-images.githubusercontent.com/11733679/80788020-66f25180-8bcb-11ea-8435-e0333925d112.png)
