### PR TITLE
Moved the watermark so it no longer overlaps the attribution text

### DIFF
--- a/src/vcRender.cpp
+++ b/src/vcRender.cpp
@@ -1315,7 +1315,7 @@ void vcRender_RenderWatermark(vcRenderContext *pRenderContext, vcTexture *pWater
   udInt2 imageSize = udInt2::zero();
   vcTexture_GetSize(pWatermark, &imageSize.x, &imageSize.y);
 
-  udFloat3 position = udFloat3::create(float(imageSize.x) / pRenderContext->sceneResolution.x - 1, float(imageSize.y) / pRenderContext->sceneResolution.y - 1, 0);
+  udFloat3 position = udFloat3::create(float(imageSize.x + 10) / pRenderContext->sceneResolution.x - 1, float(imageSize.y + 50) / pRenderContext->sceneResolution.y - 1, 0);
   udFloat3 scale = udFloat3::create(2.0f * float(imageSize.x) / pRenderContext->sceneResolution.x, -2.0f * float(imageSize.y) / pRenderContext->sceneResolution.y, 1.0);
 
 #if GRAPHICS_API_OPENGL


### PR DESCRIPTION
Fixes [AB#1536](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1536)