### PR TITLE
Overlay Map Black fix

### DIFF
--- a/src/rendering/vcTileRenderer.cpp
+++ b/src/rendering/vcTileRenderer.cpp
@@ -1113,7 +1113,6 @@ void vcTileRenderer_Render(vcTileRenderer *pTileRenderer, const udDouble4x4 &vie
 
   if (pTileRenderer->pSettings->maptiles.blendMode == vcMTBM_Overlay)
   {
-    vcGLState_SetViewportDepthRange(0.0f, 0.0f);
     vcGLState_SetDepthStencilMode(vcGLSDM_Always, true);
   }
   else if (pTileRenderer->pSettings->maptiles.blendMode == vcMTBM_Underlay)


### PR DESCRIPTION
Fixed issue where map went black Maps & Blending Blending is set to Overlay
Resolves [AB#1510](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1510)