### PR TITLE
Added Multiple Render Targets to Renderer

### DIFF
--- a/src/gl/directx11/shaders/compassFragmentShader.hlsl
+++ b/src/gl/directx11/shaders/compassFragmentShader.hlsl
@@ -18,9 +18,17 @@ struct PS_INPUT
 
 struct PS_OUTPUT
 {
-  float4 Color0 : SV_Target;
+  float4 Color0 : SV_Target0;
+  float4 Normal :  SV_Target1;
   float Depth0 : SV_Depth;
 };
+
+float4 packNormal(float3 normal, float objectId, float depth)
+{
+  return float4(normal.x / (1.0 - normal.z), normal.y / (1.0 - normal.z),
+                objectId,
+	            depth);
+}
 
 PS_OUTPUT main(PS_INPUT input)
 {
@@ -37,6 +45,6 @@ PS_OUTPUT main(PS_INPUT input)
   float halfFcoef = 1.0 / log2(s_CameraFarPlane + 1.0);
   output.Depth0 = log2(input.fLogDepth.x) * halfFcoef;
 
-  output.Color0.a = output.Depth0; // depth packed here
+  output.Normal = packNormal(input.normal, 0.0, output.Depth0);
   return output;
 }

--- a/src/gl/directx11/shaders/depthOnlyFragmentShader.hlsl
+++ b/src/gl/directx11/shaders/depthOnlyFragmentShader.hlsl
@@ -13,11 +13,12 @@ struct PS_INPUT
   float3 normal : NORMAL;
   float4 colour : COLOR0;
   float2 fLogDepth : TEXCOORD1;
+  float2 objectInfo : TEXCOORD2;
 };
 
 struct PS_OUTPUT
 {
-  float4 Color0 : SV_Target;
+  float4 Color0 : SV_Target0;
   float Depth0 : SV_Depth;
 };
 
@@ -29,7 +30,6 @@ PS_OUTPUT main(PS_INPUT input)
 
   float halfFcoef = 1.0 / log2(s_CameraFarPlane + 1.0);
   output.Depth0 = log2(input.fLogDepth.x) * halfFcoef;
-
-  output.Color0.a = output.Depth0; // depth packed here
+  
   return output;
 }

--- a/src/gl/directx11/shaders/fenceFragmentShader.hlsl
+++ b/src/gl/directx11/shaders/fenceFragmentShader.hlsl
@@ -18,13 +18,20 @@ struct PS_INPUT
 //Output Format
 struct PS_OUTPUT
 {
-  float4 Color0 : SV_Target;
+  float4 Color0 : SV_Target0;
+  float4 Normal : SV_Target1;
   float Depth0 : SV_Depth;
 };
 
-
 sampler colourSampler;
 Texture2D colourTexture;
+
+float4 packNormal(float3 normal, float objectId, float depth)
+{
+  return float4(normal.x / (1.0 - normal.z), normal.y / (1.0 - normal.z),
+    objectId,
+    depth);
+}
 
 PS_OUTPUT main(PS_INPUT input)
 {
@@ -36,5 +43,6 @@ PS_OUTPUT main(PS_INPUT input)
   float halfFcoef = 1.0 / log2(s_CameraFarPlane + 1.0);
   output.Depth0 = log2(input.fLogDepth.x) * halfFcoef;
 
+  output.Normal = packNormal(float3(0.0, 0.0, 0.0), 0.0, output.Depth0);
   return output;
 }

--- a/src/gl/directx11/shaders/flatColourFragmentShader.hlsl
+++ b/src/gl/directx11/shaders/flatColourFragmentShader.hlsl
@@ -13,12 +13,12 @@ struct PS_INPUT
   float3 normal : NORMAL;
   float4 colour : COLOR0;
   float2 fLogDepth : TEXCOORD1;
+  float2 objectInfo : TEXCOORD2;
 };
 
 struct PS_OUTPUT
 {
-  float4 Color0 : SV_Target;
-  float Depth0 : SV_Depth;
+  float4 Color0 : SV_Target0;
 };
 
 PS_OUTPUT main(PS_INPUT input)
@@ -26,10 +26,5 @@ PS_OUTPUT main(PS_INPUT input)
   PS_OUTPUT output;
 
   output.Color0 = input.colour;
-  
-  float halfFcoef = 1.0 / log2(s_CameraFarPlane + 1.0);
-  output.Depth0 = log2(input.fLogDepth.x) * halfFcoef;
-
-  output.Color0.a = output.Depth0; // depth packed here
   return output;
 }

--- a/src/gl/directx11/shaders/imageRendererFragmentShader.hlsl
+++ b/src/gl/directx11/shaders/imageRendererFragmentShader.hlsl
@@ -19,9 +19,17 @@ Texture2D albedoTexture;
 
 struct PS_OUTPUT
 {
-  float4 Color0 : SV_Target;
+  float4 Color0 : SV_Target0;
+  float4 Normal : SV_Target1;
   float Depth0 : SV_Depth;
 };
+
+float4 packNormal(float3 normal, float objectId, float depth)
+{
+  return float4(normal.x / (1.0 - normal.z), normal.y / (1.0 - normal.z),
+    objectId,
+    depth);
+}
 
 PS_OUTPUT main(PS_INPUT input)
 {
@@ -32,5 +40,6 @@ PS_OUTPUT main(PS_INPUT input)
   float halfFcoef = 1.0 / log2(s_CameraFarPlane + 1.0);
   output.Depth0 = log2(input.fLogDepth.x) * halfFcoef;
 
+  output.Normal = packNormal(float3(0.0, 0.0, 0.0), 0.0, output.Depth0);
   return output;
 }

--- a/src/gl/directx11/shaders/lineFragmentShader.hlsl
+++ b/src/gl/directx11/shaders/lineFragmentShader.hlsl
@@ -17,9 +17,17 @@ struct PS_INPUT
 //Output Format
 struct PS_OUTPUT
 {
-  float4 Color0 : SV_Target;
+  float4 Color0 : SV_Target0;
+  float4 Normal : SV_Target1;
   float Depth0 : SV_Depth;
 };
+
+float4 packNormal(float3 normal, float objectId, float depth)
+{
+  return float4(normal.x / (1.0 - normal.z), normal.y / (1.0 - normal.z),
+    objectId,
+    depth);
+}
 
 PS_OUTPUT main(PS_INPUT input)
 {
@@ -30,5 +38,6 @@ PS_OUTPUT main(PS_INPUT input)
   float halfFcoef = 1.0 / log2(s_CameraFarPlane + 1.0);
   output.Depth0 = log2(input.fLogDepth.x) * halfFcoef;
 
+  output.Normal = packNormal(float3(0.0, 0.0, 0.0), 0.0, output.Depth0);
   return output;
 }

--- a/src/gl/directx11/shaders/polygonImageFragmentShader.hlsl
+++ b/src/gl/directx11/shaders/polygonImageFragmentShader.hlsl
@@ -13,16 +13,26 @@ struct PS_INPUT
   float3 normal : NORMAL;
   float4 colour : COLOR0;
   float2 fLogDepth : TEXCOORD1;
+  float2 objectInfo : TEXCOORD2;
 };
 
 struct PS_OUTPUT
 {
-  float4 Color0 : SV_Target;
+  float4 Color0 : SV_Target0;
+  float4 Normal : SV_Target1;
   float Depth0 : SV_Depth;
 };
 
 sampler albedoSampler;
 Texture2D albedoTexture;
+
+float4 packNormal(float3 normal, float objectId, float depth)
+{
+  return float4(normal.x / (1.0 - normal.z), normal.y / (1.0 - normal.z),
+    objectId,
+    depth);
+}
+
 
 PS_OUTPUT main(PS_INPUT input)
 {
@@ -33,6 +43,6 @@ PS_OUTPUT main(PS_INPUT input)
   float halfFcoef = 1.0 / log2(s_CameraFarPlane + 1.0);
   output.Depth0 = log2(input.fLogDepth.x) * halfFcoef;
 
-  output.Color0.a = output.Depth0; // depth packed here
+  output.Normal = packNormal(float3(0.0, 0.0, 0.0), input.objectInfo.x, output.Depth0);
   return output;
 }

--- a/src/gl/directx11/shaders/polygonP3N3UV2FragmentShader.hlsl
+++ b/src/gl/directx11/shaders/polygonP3N3UV2FragmentShader.hlsl
@@ -13,16 +13,25 @@ struct PS_INPUT
   float3 normal : NORMAL;
   float4 colour : COLOR0;
   float2 fLogDepth : TEXCOORD1;
+  float2 objectInfo : TEXCOORD2;
 };
 
 struct PS_OUTPUT
 {
-  float4 Color0 : SV_Target;
+  float4 Color0 : SV_Target0;
+  float4 Normal : SV_Target1;
   float Depth0 : SV_Depth;
 };
 
 sampler albedoSampler;
 Texture2D albedoTexture;
+
+float4 packNormal(float3 normal, float objectId, float depth)
+{
+  return float4(normal.x / (1.0 - normal.z), normal.y / (1.0 - normal.z),
+                objectId,
+	            depth);
+}
 
 PS_OUTPUT main(PS_INPUT input)
 {
@@ -40,6 +49,6 @@ PS_OUTPUT main(PS_INPUT input)
   float halfFcoef = 1.0 / log2(s_CameraFarPlane + 1.0);
   output.Depth0 = log2(input.fLogDepth.x) * halfFcoef;
 
-  output.Color0.a = output.Depth0; // depth packed here
+  output.Normal = packNormal(input.normal, input.objectInfo.x, output.Depth0); 
   return output;
 }

--- a/src/gl/directx11/shaders/polygonP3N3UV2VertexShader.hlsl
+++ b/src/gl/directx11/shaders/polygonP3N3UV2VertexShader.hlsl
@@ -21,6 +21,7 @@ struct PS_INPUT
   float3 normal : NORMAL;
   float4 colour : COLOR0;
   float2 fLogDepth : TEXCOORD1;
+  float2 objectInfo : TEXCOORD2;
 };
 
 cbuffer u_EveryObject : register(b0)
@@ -28,6 +29,7 @@ cbuffer u_EveryObject : register(b0)
   float4x4 u_worldViewProjectionMatrix;
   float4x4 u_worldMatrix;
   float4 u_colour;
+  float4 u_objectInfo; // id.x, (unused).yzw
 };
 
 PS_INPUT main(VS_INPUT input)
@@ -42,6 +44,7 @@ PS_INPUT main(VS_INPUT input)
   output.normal = worldNormal;
   output.colour = u_colour;// * input.colour;
   output.fLogDepth.x = 1.0 + output.pos.w;
+  output.objectInfo.x = u_objectInfo.x;
 
   return output;
 }

--- a/src/gl/directx11/shaders/tileFragmentShader.hlsl
+++ b/src/gl/directx11/shaders/tileFragmentShader.hlsl
@@ -12,15 +12,24 @@ struct PS_INPUT
   float4 colour : COLOR0;
   float2 uv : TEXCOORD0;
   float2 depth : TEXCOORD1;
+  float2 objectInfo : TEXCOORD2;
 };
 
 struct PS_OUTPUT
 {
-  float4 Color0 : SV_Target;
+  float4 Color0 : SV_Target0;
+  float4 Normal : SV_Target1;
 };
 
 sampler colourSampler;
 Texture2D colourTexture;
+
+float4 packNormal(float3 normal, float objectId, float depth)
+{
+  return float4(normal.x / (1.0 - normal.z), normal.y / (1.0 - normal.z),
+                objectId,
+	            depth);
+}
 
 PS_OUTPUT main(PS_INPUT input)
 {
@@ -31,6 +40,8 @@ PS_OUTPUT main(PS_INPUT input)
   
   float scale = 1.0 / (u_clipZFar - u_clipZNear);
   float bias = -(u_clipZNear * 0.5);
-  output.Color0.a = (input.depth.x / input.depth.y) * scale + bias; // depth packed here
+  float depth = (input.depth.x / input.depth.y) * scale + bias; // depth packed here
+  
+  output.Normal = packNormal(float3(0, 0, 0), input.objectInfo.x, depth); 
   return output;
 }

--- a/src/gl/directx11/shaders/udFragmentShader.hlsl
+++ b/src/gl/directx11/shaders/udFragmentShader.hlsl
@@ -14,7 +14,8 @@ struct PS_INPUT
 
 struct PS_OUTPUT
 {
-  float4 Color0 : SV_Target;
+  float4 Color0 : SV_Target0;
+  float4 Normal : SV_Target1;
   float Depth0 : SV_Depth;
 };
 
@@ -23,6 +24,13 @@ Texture2D sceneColourTexture;
 
 sampler sceneDepthSampler;
 Texture2D sceneDepthTexture;
+
+float4 packNormal(float3 normal, float objectId, float depth)
+{
+  return float4(normal.x / (1.0 - normal.z), normal.y / (1.0 - normal.z),
+    objectId,
+    depth);
+}
 
 PS_OUTPUT main(PS_INPUT input)
 {
@@ -34,6 +42,6 @@ PS_OUTPUT main(PS_INPUT input)
   output.Color0 = float4(col.zyx, 1.0);// UD always opaque, UD is BGRA but uploaded as RGBA
   output.Depth0 = depth;
 
-  output.Color0.a = output.Depth0; // depth packed here
+  output.Normal = packNormal(float3(0.0, 0.0, 0.0), 0.0, output.Depth0);
   return output;
 }

--- a/src/gl/directx11/shaders/viewShedFragmentShader.hlsl
+++ b/src/gl/directx11/shaders/viewShedFragmentShader.hlsl
@@ -15,7 +15,7 @@ struct PS_INPUT
 
 struct PS_OUTPUT
 {
-  float4 Color0 : SV_Target;
+  float4 Color0 : SV_Target0;
 };
 
 sampler sceneDepthSampler;
@@ -103,6 +103,5 @@ PS_OUTPUT main(PS_INPUT input)
   }
 
   output.Color0 = float4(col.xyz * col.w, 1.0); //additive
-
   return output;
 }

--- a/src/gl/directx11/shaders/visualizationFragmentShader.hlsl
+++ b/src/gl/directx11/shaders/visualizationFragmentShader.hlsl
@@ -19,12 +19,16 @@ struct PS_INPUT
 
 struct PS_OUTPUT
 {
-  float4 Color0 : SV_Target;
+  float4 Color0 : SV_Target0;
+  float4 Normal : SV_Target1;
   float Depth0 : SV_Depth;
 };
 
 sampler sceneColourSampler;
 Texture2D sceneColourTexture;
+
+sampler sceneNormalSampler;
+Texture2D sceneNormalTexture;
 
 sampler sceneDepthSampler;
 Texture2D sceneDepthTexture;
@@ -164,7 +168,9 @@ PS_OUTPUT main(PS_INPUT input)
   PS_OUTPUT output;
 
   float4 col = sceneColourTexture.Sample(sceneColourSampler, input.uv);
+  float4 packedNormal = sceneNormalTexture.Sample(sceneNormalSampler, input.uv);
   float logDepth = sceneDepthTexture.Sample(sceneDepthSampler, input.uv).x;
+	
   float depth = logToLinearDepth(logDepth);
   float clipZ = linearDepthToClipZ(depth);
 
@@ -185,9 +191,9 @@ PS_OUTPUT main(PS_INPUT input)
     logDepth = edgeResult.w; // to preserve outlines, depth written may be adjusted
   }
 
-  output.Color0 = float4(col.xyz, 1.0);// UD always opaque
+  output.Color0 = float4(col.xyz, 1.0);
   output.Depth0 = logDepth;
   
-  output.Color0.a = output.Depth0; // depth packed here
+  output.Normal = packedNormal;
   return output;
 }

--- a/src/gl/directx11/shaders/waterFragmentShader.hlsl
+++ b/src/gl/directx11/shaders/waterFragmentShader.hlsl
@@ -33,14 +33,24 @@ float2 directionToLatLong(float3 dir)
 
 sampler normalMapSampler;
 Texture2D normalMapTexture;
+
 sampler skyboxSampler;
 Texture2D skyboxTexture;
 
 struct PS_OUTPUT
 {
-  float4 Color0 : SV_Target;
+  float4 Color0 : SV_Target0;
+  float4 Normal : SV_Target1;
   float Depth0 : SV_Depth;
 };
+
+
+float4 packNormal(float3 normal, float objectId, float depth)
+{
+  return float4(normal.x / (1.0 - normal.z), normal.y / (1.0 - normal.z),
+                objectId,
+	            depth);
+}
 
 PS_OUTPUT main(PS_INPUT input)
 {
@@ -83,6 +93,6 @@ PS_OUTPUT main(PS_INPUT input)
   // dull colour until sort out ECEF water
   output.Color0 = output.Color0 * 0.3 + float4(0.2, 0.4, 0.7, 1.0);
   
-  output.Color0.a = output.Depth0; // depth packed here
+  output.Normal = packNormal(float3(0.0, 0.0, 0.0), 0.0, output.Depth0);
   return output;
 }

--- a/src/gl/metal/shaders/desktop/atmosphereFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/atmosphereFragmentShader.metal
@@ -22,11 +22,12 @@ struct type_u_fragParams
     float4x4 u_inverseProjection;
 };
 
-constant float4 _105 = {};
+constant float4 _108 = {};
 
 struct main0_out
 {
-    float4 out_var_SV_Target [[color(0)]];
+    float4 out_var_SV_Target0 [[color(0)]];
+    float4 out_var_SV_Target1 [[color(1)]];
     float gl_FragDepth [[depth(any)]];
 };
 
@@ -36,528 +37,530 @@ struct main0_in
     float3 in_var_TEXCOORD1 [[user(locn1)]];
 };
 
-fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], constant type_u_fragParams& u_fragParams [[buffer(1)]], texture2d<float> transmittanceTexture [[texture(0)]], texture3d<float> scatteringTexture [[texture(1)]], texture2d<float> irradianceTexture [[texture(2)]], texture2d<float> sceneColourTexture [[texture(3)]], texture2d<float> sceneDepthTexture [[texture(4)]], sampler transmittanceSampler [[sampler(0)]], sampler scatteringSampler [[sampler(1)]], sampler irradianceSampler [[sampler(2)]], sampler sceneColourSampler [[sampler(3)]], sampler sceneDepthSampler [[sampler(4)]])
+fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], constant type_u_fragParams& u_fragParams [[buffer(1)]], texture2d<float> transmittanceTexture [[texture(0)]], texture3d<float> scatteringTexture [[texture(1)]], texture2d<float> irradianceTexture [[texture(2)]], texture2d<float> sceneColourTexture [[texture(3)]], texture2d<float> sceneNormalTexture [[texture(4)]], texture2d<float> sceneDepthTexture [[texture(5)]], sampler transmittanceSampler [[sampler(0)]], sampler scatteringSampler [[sampler(1)]], sampler irradianceSampler [[sampler(2)]], sampler sceneColourSampler [[sampler(3)]], sampler sceneNormalSampler [[sampler(4)]], sampler sceneDepthSampler [[sampler(5)]])
 {
     main0_out out = {};
-    float _113 = u_fragParams.u_earthCenter.w + 60000.0;
-    float3 _126 = normalize(in.in_var_TEXCOORD1);
-    float4 _130 = sceneDepthTexture.sample(sceneDepthSampler, in.in_var_TEXCOORD0);
-    float _131 = _130.x;
-    float _136 = u_cameraPlaneParams.s_CameraFarPlane - u_cameraPlaneParams.s_CameraNearPlane;
-    float4 _151 = sceneColourTexture.sample(sceneColourSampler, in.in_var_TEXCOORD0);
-    float3 _154 = pow(abs(_151.xyz), float3(2.2000000476837158203125));
-    float _160 = ((2.0 * u_cameraPlaneParams.s_CameraNearPlane) / ((u_cameraPlaneParams.s_CameraFarPlane + u_cameraPlaneParams.s_CameraNearPlane) - (((u_cameraPlaneParams.s_CameraFarPlane / _136) + (((u_cameraPlaneParams.s_CameraFarPlane * u_cameraPlaneParams.s_CameraNearPlane) / (u_cameraPlaneParams.s_CameraNearPlane - u_cameraPlaneParams.s_CameraFarPlane)) / (pow(2.0, _131 * log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0)) - 1.0))) * _136))) * u_cameraPlaneParams.s_CameraFarPlane;
-    bool _163 = _131 < 0.64999997615814208984375;
-    float3 _754;
-    if (_163)
+    float _116 = u_fragParams.u_earthCenter.w + 60000.0;
+    float3 _129 = normalize(in.in_var_TEXCOORD1);
+    float4 _133 = sceneColourTexture.sample(sceneColourSampler, in.in_var_TEXCOORD0);
+    float4 _137 = sceneNormalTexture.sample(sceneNormalSampler, in.in_var_TEXCOORD0);
+    float4 _141 = sceneDepthTexture.sample(sceneDepthSampler, in.in_var_TEXCOORD0);
+    float _142 = _141.x;
+    float _147 = u_cameraPlaneParams.s_CameraFarPlane - u_cameraPlaneParams.s_CameraNearPlane;
+    float3 _161 = pow(abs(_133.xyz), float3(2.2000000476837158203125));
+    float _167 = ((2.0 * u_cameraPlaneParams.s_CameraNearPlane) / ((u_cameraPlaneParams.s_CameraFarPlane + u_cameraPlaneParams.s_CameraNearPlane) - (((u_cameraPlaneParams.s_CameraFarPlane / _147) + (((u_cameraPlaneParams.s_CameraFarPlane * u_cameraPlaneParams.s_CameraNearPlane) / (u_cameraPlaneParams.s_CameraNearPlane - u_cameraPlaneParams.s_CameraFarPlane)) / (pow(2.0, _142 * log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0)) - 1.0))) * _147))) * u_cameraPlaneParams.s_CameraFarPlane;
+    bool _170 = _142 < 0.64999997615814208984375;
+    float3 _761;
+    if (_170)
     {
-        float3 _166 = (u_fragParams.u_camera.xyz + (_126 * _160)) - u_fragParams.u_earthCenter.xyz;
-        float3 _167 = normalize(_166);
-        float _170 = length(_166);
-        float _172 = dot(_166, u_fragParams.u_sunDirection.xyz) / _170;
-        float _174 = _113 - u_fragParams.u_earthCenter.w;
-        float4 _185 = irradianceTexture.sample(irradianceSampler, float2(0.0078125 + (((_172 * 0.5) + 0.5) * 0.984375), 0.03125 + (((_170 - u_fragParams.u_earthCenter.w) / _174) * 0.9375)));
-        float _192 = u_fragParams.u_earthCenter.w / _170;
-        float _198 = _113 * _113;
-        float _199 = u_fragParams.u_earthCenter.w * u_fragParams.u_earthCenter.w;
-        float _201 = sqrt(_198 - _199);
-        float _202 = _170 * _170;
-        float _205 = sqrt(fast::max(_202 - _199, 0.0));
-        float _216 = _113 - _170;
-        float4 _229 = transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_170) * _172) + sqrt(fast::max((_202 * ((_172 * _172) - 1.0)) + _198, 0.0)), 0.0) - _216) / ((_205 + _201) - _216)) * 0.99609375), 0.0078125 + ((_205 / _201) * 0.984375)));
-        float _248 = mix(_160 * 0.64999997615814208984375, 0.0, pow(_131 * 1.53846156597137451171875, 8.0));
-        float3 _249 = u_fragParams.u_camera.xyz - u_fragParams.u_earthCenter.xyz;
-        float3 _252 = normalize(_166 - _249);
-        float _253 = length(_249);
-        float _254 = dot(_249, _252);
-        float _261 = (-_254) - sqrt(((_254 * _254) - (_253 * _253)) + _198);
-        bool _262 = _261 > 0.0;
-        float3 _268;
-        float _269;
-        if (_262)
+        float3 _173 = (u_fragParams.u_camera.xyz + (_129 * _167)) - u_fragParams.u_earthCenter.xyz;
+        float3 _174 = normalize(_173);
+        float _177 = length(_173);
+        float _179 = dot(_173, u_fragParams.u_sunDirection.xyz) / _177;
+        float _181 = _116 - u_fragParams.u_earthCenter.w;
+        float4 _192 = irradianceTexture.sample(irradianceSampler, float2(0.0078125 + (((_179 * 0.5) + 0.5) * 0.984375), 0.03125 + (((_177 - u_fragParams.u_earthCenter.w) / _181) * 0.9375)));
+        float _199 = u_fragParams.u_earthCenter.w / _177;
+        float _205 = _116 * _116;
+        float _206 = u_fragParams.u_earthCenter.w * u_fragParams.u_earthCenter.w;
+        float _208 = sqrt(_205 - _206);
+        float _209 = _177 * _177;
+        float _212 = sqrt(fast::max(_209 - _206, 0.0));
+        float _223 = _116 - _177;
+        float4 _236 = transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_177) * _179) + sqrt(fast::max((_209 * ((_179 * _179) - 1.0)) + _205, 0.0)), 0.0) - _223) / ((_212 + _208) - _223)) * 0.99609375), 0.0078125 + ((_212 / _208) * 0.984375)));
+        float _255 = mix(_167 * 0.64999997615814208984375, 0.0, pow(_142 * 1.53846156597137451171875, 8.0));
+        float3 _256 = u_fragParams.u_camera.xyz - u_fragParams.u_earthCenter.xyz;
+        float3 _259 = normalize(_173 - _256);
+        float _260 = length(_256);
+        float _261 = dot(_256, _259);
+        float _268 = (-_261) - sqrt(((_261 * _261) - (_260 * _260)) + _205);
+        bool _269 = _268 > 0.0;
+        float3 _275;
+        float _276;
+        if (_269)
         {
-            _268 = _249 + (_252 * _261);
-            _269 = _254 + _261;
+            _275 = _256 + (_259 * _268);
+            _276 = _261 + _268;
         }
         else
         {
-            _268 = _249;
-            _269 = _254;
+            _275 = _256;
+            _276 = _261;
         }
-        float _288;
-        float _270 = _262 ? _113 : _253;
-        float _271 = _269 / _270;
-        float _272 = dot(_268, u_fragParams.u_sunDirection.xyz);
-        float _273 = _272 / _270;
-        float _274 = dot(_252, u_fragParams.u_sunDirection.xyz);
-        float _276 = length(_166 - _268);
-        float _278 = _270 * _270;
-        float _281 = _278 * ((_271 * _271) - 1.0);
-        bool _284 = (_271 < 0.0) && ((_281 + _199) >= 0.0);
-        float3 _413;
+        float _295;
+        float _277 = _269 ? _116 : _260;
+        float _278 = _276 / _277;
+        float _279 = dot(_275, u_fragParams.u_sunDirection.xyz);
+        float _280 = _279 / _277;
+        float _281 = dot(_259, u_fragParams.u_sunDirection.xyz);
+        float _283 = length(_173 - _275);
+        float _285 = _277 * _277;
+        float _288 = _285 * ((_278 * _278) - 1.0);
+        bool _291 = (_278 < 0.0) && ((_288 + _206) >= 0.0);
+        float3 _420;
         switch (0u)
         {
             default:
             {
-                _288 = (2.0 * _270) * _271;
-                float _293 = fast::clamp(sqrt((_276 * (_276 + _288)) + _278), u_fragParams.u_earthCenter.w, _113);
-                float _296 = fast::clamp((_269 + _276) / _293, -1.0, 1.0);
-                if (_284)
+                _295 = (2.0 * _277) * _278;
+                float _300 = fast::clamp(sqrt((_283 * (_283 + _295)) + _285), u_fragParams.u_earthCenter.w, _116);
+                float _303 = fast::clamp((_276 + _283) / _300, -1.0, 1.0);
+                if (_291)
                 {
-                    float _354 = -_296;
-                    float _355 = _293 * _293;
-                    float _358 = sqrt(fast::max(_355 - _199, 0.0));
-                    float _369 = _113 - _293;
-                    float _383 = -_271;
-                    float _386 = sqrt(fast::max(_278 - _199, 0.0));
-                    float _397 = _113 - _270;
-                    _413 = fast::min(transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_293) * _354) + sqrt(fast::max((_355 * ((_354 * _354) - 1.0)) + _198, 0.0)), 0.0) - _369) / ((_358 + _201) - _369)) * 0.99609375), 0.0078125 + ((_358 / _201) * 0.984375))).xyz / transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_270) * _383) + sqrt(fast::max((_278 * ((_383 * _383) - 1.0)) + _198, 0.0)), 0.0) - _397) / ((_386 + _201) - _397)) * 0.99609375), 0.0078125 + ((_386 / _201) * 0.984375))).xyz, float3(1.0));
+                    float _361 = -_303;
+                    float _362 = _300 * _300;
+                    float _365 = sqrt(fast::max(_362 - _206, 0.0));
+                    float _376 = _116 - _300;
+                    float _390 = -_278;
+                    float _393 = sqrt(fast::max(_285 - _206, 0.0));
+                    float _404 = _116 - _277;
+                    _420 = fast::min(transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_300) * _361) + sqrt(fast::max((_362 * ((_361 * _361) - 1.0)) + _205, 0.0)), 0.0) - _376) / ((_365 + _208) - _376)) * 0.99609375), 0.0078125 + ((_365 / _208) * 0.984375))).xyz / transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_277) * _390) + sqrt(fast::max((_285 * ((_390 * _390) - 1.0)) + _205, 0.0)), 0.0) - _404) / ((_393 + _208) - _404)) * 0.99609375), 0.0078125 + ((_393 / _208) * 0.984375))).xyz, float3(1.0));
                     break;
                 }
                 else
                 {
-                    float _302 = sqrt(fast::max(_278 - _199, 0.0));
-                    float _310 = _113 - _270;
-                    float _324 = _293 * _293;
-                    float _327 = sqrt(fast::max(_324 - _199, 0.0));
-                    float _338 = _113 - _293;
-                    _413 = fast::min(transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_270) * _271) + sqrt(fast::max(_281 + _198, 0.0)), 0.0) - _310) / ((_302 + _201) - _310)) * 0.99609375), 0.0078125 + ((_302 / _201) * 0.984375))).xyz / transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_293) * _296) + sqrt(fast::max((_324 * ((_296 * _296) - 1.0)) + _198, 0.0)), 0.0) - _338) / ((_327 + _201) - _338)) * 0.99609375), 0.0078125 + ((_327 / _201) * 0.984375))).xyz, float3(1.0));
+                    float _309 = sqrt(fast::max(_285 - _206, 0.0));
+                    float _317 = _116 - _277;
+                    float _331 = _300 * _300;
+                    float _334 = sqrt(fast::max(_331 - _206, 0.0));
+                    float _345 = _116 - _300;
+                    _420 = fast::min(transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_277) * _278) + sqrt(fast::max(_288 + _205, 0.0)), 0.0) - _317) / ((_309 + _208) - _317)) * 0.99609375), 0.0078125 + ((_309 / _208) * 0.984375))).xyz / transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_300) * _303) + sqrt(fast::max((_331 * ((_303 * _303) - 1.0)) + _205, 0.0)), 0.0) - _345) / ((_334 + _208) - _345)) * 0.99609375), 0.0078125 + ((_334 / _208) * 0.984375))).xyz, float3(1.0));
                     break;
                 }
             }
         }
-        float _416 = sqrt(fast::max(_278 - _199, 0.0));
-        float _417 = _416 / _201;
-        float _419 = 0.015625 + (_417 * 0.96875);
-        float _422 = ((_269 * _269) - _278) + _199;
-        float _455;
-        if (_284)
+        float _423 = sqrt(fast::max(_285 - _206, 0.0));
+        float _424 = _423 / _208;
+        float _426 = 0.015625 + (_424 * 0.96875);
+        float _429 = ((_276 * _276) - _285) + _206;
+        float _462;
+        if (_291)
         {
-            float _445 = _270 - u_fragParams.u_earthCenter.w;
-            _455 = 0.5 - (0.5 * (0.0078125 + (((_416 == _445) ? 0.0 : ((((-_269) - sqrt(fast::max(_422, 0.0))) - _445) / (_416 - _445))) * 0.984375)));
+            float _452 = _277 - u_fragParams.u_earthCenter.w;
+            _462 = 0.5 - (0.5 * (0.0078125 + (((_423 == _452) ? 0.0 : ((((-_276) - sqrt(fast::max(_429, 0.0))) - _452) / (_423 - _452))) * 0.984375)));
         }
         else
         {
-            float _432 = _113 - _270;
-            _455 = 0.5 + (0.5 * (0.0078125 + (((((-_269) + sqrt(fast::max(_422 + (_201 * _201), 0.0))) - _432) / ((_416 + _201) - _432)) * 0.984375)));
+            float _439 = _116 - _277;
+            _462 = 0.5 + (0.5 * (0.0078125 + (((((-_276) + sqrt(fast::max(_429 + (_208 * _208), 0.0))) - _439) / ((_423 + _208) - _439)) * 0.984375)));
         }
-        float _460 = -u_fragParams.u_earthCenter.w;
-        float _467 = _201 - _174;
-        float _468 = (fast::max((_460 * _273) + sqrt(fast::max((_199 * ((_273 * _273) - 1.0)) + _198, 0.0)), 0.0) - _174) / _467;
-        float _470 = (0.415823996067047119140625 * u_fragParams.u_earthCenter.w) / _467;
-        float _477 = 0.015625 + ((fast::max(1.0 - (_468 / _470), 0.0) / (1.0 + _468)) * 0.96875);
-        float _479 = (_274 + 1.0) * 3.5;
-        float _480 = floor(_479);
-        float _481 = _479 - _480;
-        float _485 = _480 + 1.0;
-        float4 _491 = scatteringTexture.sample(scatteringSampler, float3((_480 + _477) * 0.125, _455, _419));
-        float _492 = 1.0 - _481;
-        float4 _495 = scatteringTexture.sample(scatteringSampler, float3((_485 + _477) * 0.125, _455, _419));
-        float4 _497 = (_491 * _492) + (_495 * _481);
-        float3 _498 = _497.xyz;
-        float3 _511;
+        float _467 = -u_fragParams.u_earthCenter.w;
+        float _474 = _208 - _181;
+        float _475 = (fast::max((_467 * _280) + sqrt(fast::max((_206 * ((_280 * _280) - 1.0)) + _205, 0.0)), 0.0) - _181) / _474;
+        float _477 = (0.415823996067047119140625 * u_fragParams.u_earthCenter.w) / _474;
+        float _484 = 0.015625 + ((fast::max(1.0 - (_475 / _477), 0.0) / (1.0 + _475)) * 0.96875);
+        float _486 = (_281 + 1.0) * 3.5;
+        float _487 = floor(_486);
+        float _488 = _486 - _487;
+        float _492 = _487 + 1.0;
+        float4 _498 = scatteringTexture.sample(scatteringSampler, float3((_487 + _484) * 0.125, _462, _426));
+        float _499 = 1.0 - _488;
+        float4 _502 = scatteringTexture.sample(scatteringSampler, float3((_492 + _484) * 0.125, _462, _426));
+        float4 _504 = (_498 * _499) + (_502 * _488);
+        float3 _505 = _504.xyz;
+        float3 _518;
         switch (0u)
         {
             default:
             {
-                float _501 = _497.x;
-                if (_501 == 0.0)
+                float _508 = _504.x;
+                if (_508 == 0.0)
                 {
-                    _511 = float3(0.0);
+                    _518 = float3(0.0);
                     break;
                 }
-                _511 = (((_498 * _497.w) / float3(_501)) * 1.5) * float3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
+                _518 = (((_505 * _504.w) / float3(_508)) * 1.5) * float3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
                 break;
             }
         }
-        float _513 = fast::max(_276 - _248, 0.0);
-        float _518 = fast::clamp(sqrt((_513 * (_513 + _288)) + _278), u_fragParams.u_earthCenter.w, _113);
-        float _519 = _269 + _513;
-        float _522 = (_272 + (_513 * _274)) / _518;
-        float _523 = _518 * _518;
-        float _526 = sqrt(fast::max(_523 - _199, 0.0));
-        float _527 = _526 / _201;
-        float _529 = 0.015625 + (_527 * 0.96875);
-        float _532 = ((_519 * _519) - _523) + _199;
-        float _565;
-        if (_284)
+        float _520 = fast::max(_283 - _255, 0.0);
+        float _525 = fast::clamp(sqrt((_520 * (_520 + _295)) + _285), u_fragParams.u_earthCenter.w, _116);
+        float _526 = _276 + _520;
+        float _529 = (_279 + (_520 * _281)) / _525;
+        float _530 = _525 * _525;
+        float _533 = sqrt(fast::max(_530 - _206, 0.0));
+        float _534 = _533 / _208;
+        float _536 = 0.015625 + (_534 * 0.96875);
+        float _539 = ((_526 * _526) - _530) + _206;
+        float _572;
+        if (_291)
         {
-            float _555 = _518 - u_fragParams.u_earthCenter.w;
-            _565 = 0.5 - (0.5 * (0.0078125 + (((_526 == _555) ? 0.0 : ((((-_519) - sqrt(fast::max(_532, 0.0))) - _555) / (_526 - _555))) * 0.984375)));
+            float _562 = _525 - u_fragParams.u_earthCenter.w;
+            _572 = 0.5 - (0.5 * (0.0078125 + (((_533 == _562) ? 0.0 : ((((-_526) - sqrt(fast::max(_539, 0.0))) - _562) / (_533 - _562))) * 0.984375)));
         }
         else
         {
-            float _542 = _113 - _518;
-            _565 = 0.5 + (0.5 * (0.0078125 + (((((-_519) + sqrt(fast::max(_532 + (_201 * _201), 0.0))) - _542) / ((_526 + _201) - _542)) * 0.984375)));
+            float _549 = _116 - _525;
+            _572 = 0.5 + (0.5 * (0.0078125 + (((((-_526) + sqrt(fast::max(_539 + (_208 * _208), 0.0))) - _549) / ((_533 + _208) - _549)) * 0.984375)));
         }
-        float _576 = (fast::max((_460 * _522) + sqrt(fast::max((_199 * ((_522 * _522) - 1.0)) + _198, 0.0)), 0.0) - _174) / _467;
-        float _583 = 0.015625 + ((fast::max(1.0 - (_576 / _470), 0.0) / (1.0 + _576)) * 0.96875);
-        float4 _591 = scatteringTexture.sample(scatteringSampler, float3((_480 + _583) * 0.125, _565, _529));
-        float4 _594 = scatteringTexture.sample(scatteringSampler, float3((_485 + _583) * 0.125, _565, _529));
-        float4 _596 = (_591 * _492) + (_594 * _481);
-        float3 _597 = _596.xyz;
-        float3 _610;
+        float _583 = (fast::max((_467 * _529) + sqrt(fast::max((_206 * ((_529 * _529) - 1.0)) + _205, 0.0)), 0.0) - _181) / _474;
+        float _590 = 0.015625 + ((fast::max(1.0 - (_583 / _477), 0.0) / (1.0 + _583)) * 0.96875);
+        float4 _598 = scatteringTexture.sample(scatteringSampler, float3((_487 + _590) * 0.125, _572, _536));
+        float4 _601 = scatteringTexture.sample(scatteringSampler, float3((_492 + _590) * 0.125, _572, _536));
+        float4 _603 = (_598 * _499) + (_601 * _488);
+        float3 _604 = _603.xyz;
+        float3 _617;
         switch (0u)
         {
             default:
             {
-                float _600 = _596.x;
-                if (_600 == 0.0)
+                float _607 = _603.x;
+                if (_607 == 0.0)
                 {
-                    _610 = float3(0.0);
+                    _617 = float3(0.0);
                     break;
                 }
-                _610 = (((_597 * _596.w) / float3(_600)) * 1.5) * float3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
+                _617 = (((_604 * _603.w) / float3(_607)) * 1.5) * float3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
                 break;
             }
         }
-        float3 _717;
-        if (_248 > 0.0)
+        float3 _724;
+        if (_255 > 0.0)
         {
-            float3 _716;
+            float3 _723;
             switch (0u)
             {
                 default:
                 {
-                    float _617 = fast::clamp(_519 / _518, -1.0, 1.0);
-                    if (_284)
+                    float _624 = fast::clamp(_526 / _525, -1.0, 1.0);
+                    if (_291)
                     {
-                        float _666 = -_617;
-                        float _677 = _113 - _518;
-                        float _690 = -_271;
-                        float _701 = _113 - _270;
-                        _716 = fast::min(transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_518) * _666) + sqrt(fast::max((_523 * ((_666 * _666) - 1.0)) + _198, 0.0)), 0.0) - _677) / ((_526 + _201) - _677)) * 0.99609375), 0.0078125 + (_527 * 0.984375))).xyz / transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_270) * _690) + sqrt(fast::max((_278 * ((_690 * _690) - 1.0)) + _198, 0.0)), 0.0) - _701) / ((_416 + _201) - _701)) * 0.99609375), 0.0078125 + (_417 * 0.984375))).xyz, float3(1.0));
+                        float _673 = -_624;
+                        float _684 = _116 - _525;
+                        float _697 = -_278;
+                        float _708 = _116 - _277;
+                        _723 = fast::min(transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_525) * _673) + sqrt(fast::max((_530 * ((_673 * _673) - 1.0)) + _205, 0.0)), 0.0) - _684) / ((_533 + _208) - _684)) * 0.99609375), 0.0078125 + (_534 * 0.984375))).xyz / transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_277) * _697) + sqrt(fast::max((_285 * ((_697 * _697) - 1.0)) + _205, 0.0)), 0.0) - _708) / ((_423 + _208) - _708)) * 0.99609375), 0.0078125 + (_424 * 0.984375))).xyz, float3(1.0));
                         break;
                     }
                     else
                     {
-                        float _628 = _113 - _270;
-                        float _651 = _113 - _518;
-                        _716 = fast::min(transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_270) * _271) + sqrt(fast::max(_281 + _198, 0.0)), 0.0) - _628) / ((_416 + _201) - _628)) * 0.99609375), 0.0078125 + (_417 * 0.984375))).xyz / transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_518) * _617) + sqrt(fast::max((_523 * ((_617 * _617) - 1.0)) + _198, 0.0)), 0.0) - _651) / ((_526 + _201) - _651)) * 0.99609375), 0.0078125 + (_527 * 0.984375))).xyz, float3(1.0));
+                        float _635 = _116 - _277;
+                        float _658 = _116 - _525;
+                        _723 = fast::min(transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_277) * _278) + sqrt(fast::max(_288 + _205, 0.0)), 0.0) - _635) / ((_423 + _208) - _635)) * 0.99609375), 0.0078125 + (_424 * 0.984375))).xyz / transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_525) * _624) + sqrt(fast::max((_530 * ((_624 * _624) - 1.0)) + _205, 0.0)), 0.0) - _658) / ((_533 + _208) - _658)) * 0.99609375), 0.0078125 + (_534 * 0.984375))).xyz, float3(1.0));
                         break;
                     }
                 }
             }
-            _717 = _716;
+            _724 = _723;
         }
         else
         {
-            _717 = _413;
+            _724 = _420;
         }
-        float3 _719 = _498 - (_717 * _597);
-        float3 _721 = _511 - (_717 * _610);
-        float _722 = _721.x;
-        float _723 = _719.x;
-        float3 _738;
+        float3 _726 = _505 - (_724 * _604);
+        float3 _728 = _518 - (_724 * _617);
+        float _729 = _728.x;
+        float _730 = _726.x;
+        float3 _745;
         switch (0u)
         {
             default:
             {
-                if (_723 == 0.0)
+                if (_730 == 0.0)
                 {
-                    _738 = float3(0.0);
+                    _745 = float3(0.0);
                     break;
                 }
-                _738 = (((float4(_723, _719.yz, _722).xyz * _722) / float3(_723)) * 1.5) * float3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
+                _745 = (((float4(_730, _726.yz, _729).xyz * _729) / float3(_730)) * 1.5) * float3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
                 break;
             }
         }
-        float _742 = 1.0 + (_274 * _274);
-        _754 = (((_154.xyz * 0.3183098733425140380859375) * ((float3(1.47399997711181640625, 1.85039997100830078125, 1.91198003292083740234375) * fast::max((_229.xyz * smoothstep(_192 * (-0.004674999974668025970458984375), _192 * 0.004674999974668025970458984375, _172 - (-sqrt(fast::max(1.0 - (_192 * _192), 0.0))))) * fast::max(dot(_167, u_fragParams.u_sunDirection.xyz), 0.0), float3(0.001000000047497451305389404296875))) + ((_185.xyz * (1.0 + (dot(_167, _166) / _170))) * 0.5))) * _413) + ((_719 * (0.0596831031143665313720703125 * _742)) + ((_738 * smoothstep(0.0, 0.00999999977648258209228515625, _273)) * ((0.01627720706164836883544921875 * _742) / pow(1.6400001049041748046875 - (1.60000002384185791015625 * _274), 1.5))));
+        float _749 = 1.0 + (_281 * _281);
+        _761 = (((_161.xyz * 0.3183098733425140380859375) * ((float3(1.47399997711181640625, 1.85039997100830078125, 1.91198003292083740234375) * fast::max((_236.xyz * smoothstep(_199 * (-0.004674999974668025970458984375), _199 * 0.004674999974668025970458984375, _179 - (-sqrt(fast::max(1.0 - (_199 * _199), 0.0))))) * fast::max(dot(_174, u_fragParams.u_sunDirection.xyz), 0.0), float3(0.001000000047497451305389404296875))) + ((_192.xyz * (1.0 + (dot(_174, _173) / _177))) * 0.5))) * _420) + ((_726 * (0.0596831031143665313720703125 * _749)) + ((_745 * smoothstep(0.0, 0.00999999977648258209228515625, _280)) * ((0.01627720706164836883544921875 * _749) / pow(1.6400001049041748046875 - (1.60000002384185791015625 * _281), 1.5))));
     }
     else
     {
-        _754 = float3(0.0);
+        _761 = float3(0.0);
     }
-    float3 _756 = u_fragParams.u_camera.xyz - u_fragParams.u_earthCenter.xyz;
-    float _757 = dot(_756, _126);
-    float _759 = _757 * _757;
-    float _761 = -_757;
-    float _762 = u_fragParams.u_earthCenter.w * u_fragParams.u_earthCenter.w;
-    float _765 = _761 - sqrt(_762 - (dot(_756, _756) - _759));
-    bool _766 = _765 > 0.0;
-    float3 _1245;
-    if (_766)
+    float3 _763 = u_fragParams.u_camera.xyz - u_fragParams.u_earthCenter.xyz;
+    float _764 = dot(_763, _129);
+    float _766 = _764 * _764;
+    float _768 = -_764;
+    float _769 = u_fragParams.u_earthCenter.w * u_fragParams.u_earthCenter.w;
+    float _772 = _768 - sqrt(_769 - (dot(_763, _763) - _766));
+    bool _773 = _772 > 0.0;
+    float3 _1252;
+    if (_773)
     {
-        float3 _771 = (u_fragParams.u_camera.xyz + (_126 * _765)) - u_fragParams.u_earthCenter.xyz;
-        float3 _772 = normalize(_771);
-        float _775 = length(_771);
-        float _777 = dot(_771, u_fragParams.u_sunDirection.xyz) / _775;
-        float _779 = _113 - u_fragParams.u_earthCenter.w;
-        float4 _790 = irradianceTexture.sample(irradianceSampler, float2(0.0078125 + (((_777 * 0.5) + 0.5) * 0.984375), 0.03125 + (((_775 - u_fragParams.u_earthCenter.w) / _779) * 0.9375)));
-        float _797 = u_fragParams.u_earthCenter.w / _775;
-        float _803 = _113 * _113;
-        float _805 = sqrt(_803 - _762);
-        float _806 = _775 * _775;
-        float _809 = sqrt(fast::max(_806 - _762, 0.0));
-        float _820 = _113 - _775;
-        float4 _833 = transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_775) * _777) + sqrt(fast::max((_806 * ((_777 * _777) - 1.0)) + _803, 0.0)), 0.0) - _820) / ((_809 + _805) - _820)) * 0.99609375), 0.0078125 + ((_809 / _805) * 0.984375)));
-        float3 _851 = normalize(_771 - _756);
-        float _852 = length(_756);
-        float _853 = dot(_756, _851);
-        float _860 = (-_853) - sqrt(((_853 * _853) - (_852 * _852)) + _803);
-        bool _861 = _860 > 0.0;
-        float3 _867;
-        float _868;
-        if (_861)
+        float3 _778 = (u_fragParams.u_camera.xyz + (_129 * _772)) - u_fragParams.u_earthCenter.xyz;
+        float3 _779 = normalize(_778);
+        float _782 = length(_778);
+        float _784 = dot(_778, u_fragParams.u_sunDirection.xyz) / _782;
+        float _786 = _116 - u_fragParams.u_earthCenter.w;
+        float4 _797 = irradianceTexture.sample(irradianceSampler, float2(0.0078125 + (((_784 * 0.5) + 0.5) * 0.984375), 0.03125 + (((_782 - u_fragParams.u_earthCenter.w) / _786) * 0.9375)));
+        float _804 = u_fragParams.u_earthCenter.w / _782;
+        float _810 = _116 * _116;
+        float _812 = sqrt(_810 - _769);
+        float _813 = _782 * _782;
+        float _816 = sqrt(fast::max(_813 - _769, 0.0));
+        float _827 = _116 - _782;
+        float4 _840 = transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_782) * _784) + sqrt(fast::max((_813 * ((_784 * _784) - 1.0)) + _810, 0.0)), 0.0) - _827) / ((_816 + _812) - _827)) * 0.99609375), 0.0078125 + ((_816 / _812) * 0.984375)));
+        float3 _858 = normalize(_778 - _763);
+        float _859 = length(_763);
+        float _860 = dot(_763, _858);
+        float _867 = (-_860) - sqrt(((_860 * _860) - (_859 * _859)) + _810);
+        bool _868 = _867 > 0.0;
+        float3 _874;
+        float _875;
+        if (_868)
         {
-            _867 = _756 + (_851 * _860);
-            _868 = _853 + _860;
+            _874 = _763 + (_858 * _867);
+            _875 = _860 + _867;
         }
         else
         {
-            _867 = _756;
-            _868 = _853;
+            _874 = _763;
+            _875 = _860;
         }
-        float _887;
-        float _869 = _861 ? _113 : _852;
-        float _870 = _868 / _869;
-        float _871 = dot(_867, u_fragParams.u_sunDirection.xyz);
-        float _872 = _871 / _869;
-        float _873 = dot(_851, u_fragParams.u_sunDirection.xyz);
-        float _875 = length(_771 - _867);
-        float _877 = _869 * _869;
-        float _880 = _877 * ((_870 * _870) - 1.0);
-        bool _883 = (_870 < 0.0) && ((_880 + _762) >= 0.0);
-        float3 _1012;
+        float _894;
+        float _876 = _868 ? _116 : _859;
+        float _877 = _875 / _876;
+        float _878 = dot(_874, u_fragParams.u_sunDirection.xyz);
+        float _879 = _878 / _876;
+        float _880 = dot(_858, u_fragParams.u_sunDirection.xyz);
+        float _882 = length(_778 - _874);
+        float _884 = _876 * _876;
+        float _887 = _884 * ((_877 * _877) - 1.0);
+        bool _890 = (_877 < 0.0) && ((_887 + _769) >= 0.0);
+        float3 _1019;
         switch (0u)
         {
             default:
             {
-                _887 = (2.0 * _869) * _870;
-                float _892 = fast::clamp(sqrt((_875 * (_875 + _887)) + _877), u_fragParams.u_earthCenter.w, _113);
-                float _895 = fast::clamp((_868 + _875) / _892, -1.0, 1.0);
-                if (_883)
+                _894 = (2.0 * _876) * _877;
+                float _899 = fast::clamp(sqrt((_882 * (_882 + _894)) + _884), u_fragParams.u_earthCenter.w, _116);
+                float _902 = fast::clamp((_875 + _882) / _899, -1.0, 1.0);
+                if (_890)
                 {
-                    float _953 = -_895;
-                    float _954 = _892 * _892;
-                    float _957 = sqrt(fast::max(_954 - _762, 0.0));
-                    float _968 = _113 - _892;
-                    float _982 = -_870;
-                    float _985 = sqrt(fast::max(_877 - _762, 0.0));
-                    float _996 = _113 - _869;
-                    _1012 = fast::min(transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_892) * _953) + sqrt(fast::max((_954 * ((_953 * _953) - 1.0)) + _803, 0.0)), 0.0) - _968) / ((_957 + _805) - _968)) * 0.99609375), 0.0078125 + ((_957 / _805) * 0.984375))).xyz / transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_869) * _982) + sqrt(fast::max((_877 * ((_982 * _982) - 1.0)) + _803, 0.0)), 0.0) - _996) / ((_985 + _805) - _996)) * 0.99609375), 0.0078125 + ((_985 / _805) * 0.984375))).xyz, float3(1.0));
+                    float _960 = -_902;
+                    float _961 = _899 * _899;
+                    float _964 = sqrt(fast::max(_961 - _769, 0.0));
+                    float _975 = _116 - _899;
+                    float _989 = -_877;
+                    float _992 = sqrt(fast::max(_884 - _769, 0.0));
+                    float _1003 = _116 - _876;
+                    _1019 = fast::min(transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_899) * _960) + sqrt(fast::max((_961 * ((_960 * _960) - 1.0)) + _810, 0.0)), 0.0) - _975) / ((_964 + _812) - _975)) * 0.99609375), 0.0078125 + ((_964 / _812) * 0.984375))).xyz / transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_876) * _989) + sqrt(fast::max((_884 * ((_989 * _989) - 1.0)) + _810, 0.0)), 0.0) - _1003) / ((_992 + _812) - _1003)) * 0.99609375), 0.0078125 + ((_992 / _812) * 0.984375))).xyz, float3(1.0));
                     break;
                 }
                 else
                 {
-                    float _901 = sqrt(fast::max(_877 - _762, 0.0));
-                    float _909 = _113 - _869;
-                    float _923 = _892 * _892;
-                    float _926 = sqrt(fast::max(_923 - _762, 0.0));
-                    float _937 = _113 - _892;
-                    _1012 = fast::min(transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_869) * _870) + sqrt(fast::max(_880 + _803, 0.0)), 0.0) - _909) / ((_901 + _805) - _909)) * 0.99609375), 0.0078125 + ((_901 / _805) * 0.984375))).xyz / transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_892) * _895) + sqrt(fast::max((_923 * ((_895 * _895) - 1.0)) + _803, 0.0)), 0.0) - _937) / ((_926 + _805) - _937)) * 0.99609375), 0.0078125 + ((_926 / _805) * 0.984375))).xyz, float3(1.0));
+                    float _908 = sqrt(fast::max(_884 - _769, 0.0));
+                    float _916 = _116 - _876;
+                    float _930 = _899 * _899;
+                    float _933 = sqrt(fast::max(_930 - _769, 0.0));
+                    float _944 = _116 - _899;
+                    _1019 = fast::min(transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_876) * _877) + sqrt(fast::max(_887 + _810, 0.0)), 0.0) - _916) / ((_908 + _812) - _916)) * 0.99609375), 0.0078125 + ((_908 / _812) * 0.984375))).xyz / transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_899) * _902) + sqrt(fast::max((_930 * ((_902 * _902) - 1.0)) + _810, 0.0)), 0.0) - _944) / ((_933 + _812) - _944)) * 0.99609375), 0.0078125 + ((_933 / _812) * 0.984375))).xyz, float3(1.0));
                     break;
                 }
             }
         }
-        float _1015 = sqrt(fast::max(_877 - _762, 0.0));
-        float _1018 = 0.015625 + ((_1015 / _805) * 0.96875);
-        float _1021 = ((_868 * _868) - _877) + _762;
-        float _1054;
-        if (_883)
+        float _1022 = sqrt(fast::max(_884 - _769, 0.0));
+        float _1025 = 0.015625 + ((_1022 / _812) * 0.96875);
+        float _1028 = ((_875 * _875) - _884) + _769;
+        float _1061;
+        if (_890)
         {
-            float _1044 = _869 - u_fragParams.u_earthCenter.w;
-            _1054 = 0.5 - (0.5 * (0.0078125 + (((_1015 == _1044) ? 0.0 : ((((-_868) - sqrt(fast::max(_1021, 0.0))) - _1044) / (_1015 - _1044))) * 0.984375)));
+            float _1051 = _876 - u_fragParams.u_earthCenter.w;
+            _1061 = 0.5 - (0.5 * (0.0078125 + (((_1022 == _1051) ? 0.0 : ((((-_875) - sqrt(fast::max(_1028, 0.0))) - _1051) / (_1022 - _1051))) * 0.984375)));
         }
         else
         {
-            float _1031 = _113 - _869;
-            _1054 = 0.5 + (0.5 * (0.0078125 + (((((-_868) + sqrt(fast::max(_1021 + (_805 * _805), 0.0))) - _1031) / ((_1015 + _805) - _1031)) * 0.984375)));
+            float _1038 = _116 - _876;
+            _1061 = 0.5 + (0.5 * (0.0078125 + (((((-_875) + sqrt(fast::max(_1028 + (_812 * _812), 0.0))) - _1038) / ((_1022 + _812) - _1038)) * 0.984375)));
         }
-        float _1059 = -u_fragParams.u_earthCenter.w;
-        float _1066 = _805 - _779;
-        float _1067 = (fast::max((_1059 * _872) + sqrt(fast::max((_762 * ((_872 * _872) - 1.0)) + _803, 0.0)), 0.0) - _779) / _1066;
-        float _1069 = (0.415823996067047119140625 * u_fragParams.u_earthCenter.w) / _1066;
-        float _1076 = 0.015625 + ((fast::max(1.0 - (_1067 / _1069), 0.0) / (1.0 + _1067)) * 0.96875);
-        float _1078 = (_873 + 1.0) * 3.5;
-        float _1079 = floor(_1078);
-        float _1080 = _1078 - _1079;
-        float _1084 = _1079 + 1.0;
-        float4 _1090 = scatteringTexture.sample(scatteringSampler, float3((_1079 + _1076) * 0.125, _1054, _1018));
-        float _1091 = 1.0 - _1080;
-        float4 _1094 = scatteringTexture.sample(scatteringSampler, float3((_1084 + _1076) * 0.125, _1054, _1018));
-        float4 _1096 = (_1090 * _1091) + (_1094 * _1080);
-        float3 _1097 = _1096.xyz;
-        float3 _1110;
+        float _1066 = -u_fragParams.u_earthCenter.w;
+        float _1073 = _812 - _786;
+        float _1074 = (fast::max((_1066 * _879) + sqrt(fast::max((_769 * ((_879 * _879) - 1.0)) + _810, 0.0)), 0.0) - _786) / _1073;
+        float _1076 = (0.415823996067047119140625 * u_fragParams.u_earthCenter.w) / _1073;
+        float _1083 = 0.015625 + ((fast::max(1.0 - (_1074 / _1076), 0.0) / (1.0 + _1074)) * 0.96875);
+        float _1085 = (_880 + 1.0) * 3.5;
+        float _1086 = floor(_1085);
+        float _1087 = _1085 - _1086;
+        float _1091 = _1086 + 1.0;
+        float4 _1097 = scatteringTexture.sample(scatteringSampler, float3((_1086 + _1083) * 0.125, _1061, _1025));
+        float _1098 = 1.0 - _1087;
+        float4 _1101 = scatteringTexture.sample(scatteringSampler, float3((_1091 + _1083) * 0.125, _1061, _1025));
+        float4 _1103 = (_1097 * _1098) + (_1101 * _1087);
+        float3 _1104 = _1103.xyz;
+        float3 _1117;
         switch (0u)
         {
             default:
             {
-                float _1100 = _1096.x;
-                if (_1100 == 0.0)
+                float _1107 = _1103.x;
+                if (_1107 == 0.0)
                 {
-                    _1110 = float3(0.0);
+                    _1117 = float3(0.0);
                     break;
                 }
-                _1110 = (((_1097 * _1096.w) / float3(_1100)) * 1.5) * float3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
+                _1117 = (((_1104 * _1103.w) / float3(_1107)) * 1.5) * float3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
                 break;
             }
         }
-        float _1111 = fast::max(_875, 0.0);
-        float _1116 = fast::clamp(sqrt((_1111 * (_1111 + _887)) + _877), u_fragParams.u_earthCenter.w, _113);
-        float _1117 = _868 + _1111;
-        float _1120 = (_871 + (_1111 * _873)) / _1116;
-        float _1121 = _1116 * _1116;
-        float _1124 = sqrt(fast::max(_1121 - _762, 0.0));
-        float _1127 = 0.015625 + ((_1124 / _805) * 0.96875);
-        float _1130 = ((_1117 * _1117) - _1121) + _762;
-        float _1163;
-        if (_883)
+        float _1118 = fast::max(_882, 0.0);
+        float _1123 = fast::clamp(sqrt((_1118 * (_1118 + _894)) + _884), u_fragParams.u_earthCenter.w, _116);
+        float _1124 = _875 + _1118;
+        float _1127 = (_878 + (_1118 * _880)) / _1123;
+        float _1128 = _1123 * _1123;
+        float _1131 = sqrt(fast::max(_1128 - _769, 0.0));
+        float _1134 = 0.015625 + ((_1131 / _812) * 0.96875);
+        float _1137 = ((_1124 * _1124) - _1128) + _769;
+        float _1170;
+        if (_890)
         {
-            float _1153 = _1116 - u_fragParams.u_earthCenter.w;
-            _1163 = 0.5 - (0.5 * (0.0078125 + (((_1124 == _1153) ? 0.0 : ((((-_1117) - sqrt(fast::max(_1130, 0.0))) - _1153) / (_1124 - _1153))) * 0.984375)));
+            float _1160 = _1123 - u_fragParams.u_earthCenter.w;
+            _1170 = 0.5 - (0.5 * (0.0078125 + (((_1131 == _1160) ? 0.0 : ((((-_1124) - sqrt(fast::max(_1137, 0.0))) - _1160) / (_1131 - _1160))) * 0.984375)));
         }
         else
         {
-            float _1140 = _113 - _1116;
-            _1163 = 0.5 + (0.5 * (0.0078125 + (((((-_1117) + sqrt(fast::max(_1130 + (_805 * _805), 0.0))) - _1140) / ((_1124 + _805) - _1140)) * 0.984375)));
+            float _1147 = _116 - _1123;
+            _1170 = 0.5 + (0.5 * (0.0078125 + (((((-_1124) + sqrt(fast::max(_1137 + (_812 * _812), 0.0))) - _1147) / ((_1131 + _812) - _1147)) * 0.984375)));
         }
-        float _1174 = (fast::max((_1059 * _1120) + sqrt(fast::max((_762 * ((_1120 * _1120) - 1.0)) + _803, 0.0)), 0.0) - _779) / _1066;
-        float _1181 = 0.015625 + ((fast::max(1.0 - (_1174 / _1069), 0.0) / (1.0 + _1174)) * 0.96875);
-        float4 _1189 = scatteringTexture.sample(scatteringSampler, float3((_1079 + _1181) * 0.125, _1163, _1127));
-        float4 _1192 = scatteringTexture.sample(scatteringSampler, float3((_1084 + _1181) * 0.125, _1163, _1127));
-        float4 _1194 = (_1189 * _1091) + (_1192 * _1080);
-        float3 _1195 = _1194.xyz;
-        float3 _1208;
+        float _1181 = (fast::max((_1066 * _1127) + sqrt(fast::max((_769 * ((_1127 * _1127) - 1.0)) + _810, 0.0)), 0.0) - _786) / _1073;
+        float _1188 = 0.015625 + ((fast::max(1.0 - (_1181 / _1076), 0.0) / (1.0 + _1181)) * 0.96875);
+        float4 _1196 = scatteringTexture.sample(scatteringSampler, float3((_1086 + _1188) * 0.125, _1170, _1134));
+        float4 _1199 = scatteringTexture.sample(scatteringSampler, float3((_1091 + _1188) * 0.125, _1170, _1134));
+        float4 _1201 = (_1196 * _1098) + (_1199 * _1087);
+        float3 _1202 = _1201.xyz;
+        float3 _1215;
         switch (0u)
         {
             default:
             {
-                float _1198 = _1194.x;
-                if (_1198 == 0.0)
+                float _1205 = _1201.x;
+                if (_1205 == 0.0)
                 {
-                    _1208 = float3(0.0);
+                    _1215 = float3(0.0);
                     break;
                 }
-                _1208 = (((_1195 * _1194.w) / float3(_1198)) * 1.5) * float3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
+                _1215 = (((_1202 * _1201.w) / float3(_1205)) * 1.5) * float3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
                 break;
             }
         }
-        float3 _1210 = _1097 - (_1012 * _1195);
-        float3 _1212 = _1110 - (_1012 * _1208);
-        float _1213 = _1212.x;
-        float _1214 = _1210.x;
-        float3 _1229;
+        float3 _1217 = _1104 - (_1019 * _1202);
+        float3 _1219 = _1117 - (_1019 * _1215);
+        float _1220 = _1219.x;
+        float _1221 = _1217.x;
+        float3 _1236;
         switch (0u)
         {
             default:
             {
-                if (_1214 == 0.0)
+                if (_1221 == 0.0)
                 {
-                    _1229 = float3(0.0);
+                    _1236 = float3(0.0);
                     break;
                 }
-                _1229 = (((float4(_1214, _1210.yz, _1213).xyz * _1213) / float3(_1214)) * 1.5) * float3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
+                _1236 = (((float4(_1221, _1217.yz, _1220).xyz * _1220) / float3(_1221)) * 1.5) * float3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
                 break;
             }
         }
-        float _1233 = 1.0 + (_873 * _873);
-        _1245 = (((_154.xyz * 0.3183098733425140380859375) * ((float3(1.47399997711181640625, 1.85039997100830078125, 1.91198003292083740234375) * fast::max((_833.xyz * smoothstep(_797 * (-0.004674999974668025970458984375), _797 * 0.004674999974668025970458984375, _777 - (-sqrt(fast::max(1.0 - (_797 * _797), 0.0))))) * fast::max(dot(_772, u_fragParams.u_sunDirection.xyz), 0.0), float3(0.001000000047497451305389404296875))) + ((_790.xyz * (1.0 + (dot(_772, _771) / _775))) * 0.5))) * _1012) + ((_1210 * (0.0596831031143665313720703125 * _1233)) + ((_1229 * smoothstep(0.0, 0.00999999977648258209228515625, _872)) * ((0.01627720706164836883544921875 * _1233) / pow(1.6400001049041748046875 - (1.60000002384185791015625 * _873), 1.5))));
+        float _1240 = 1.0 + (_880 * _880);
+        _1252 = (((_161.xyz * 0.3183098733425140380859375) * ((float3(1.47399997711181640625, 1.85039997100830078125, 1.91198003292083740234375) * fast::max((_840.xyz * smoothstep(_804 * (-0.004674999974668025970458984375), _804 * 0.004674999974668025970458984375, _784 - (-sqrt(fast::max(1.0 - (_804 * _804), 0.0))))) * fast::max(dot(_779, u_fragParams.u_sunDirection.xyz), 0.0), float3(0.001000000047497451305389404296875))) + ((_797.xyz * (1.0 + (dot(_779, _778) / _782))) * 0.5))) * _1019) + ((_1217 * (0.0596831031143665313720703125 * _1240)) + ((_1236 * smoothstep(0.0, 0.00999999977648258209228515625, _879)) * ((0.01627720706164836883544921875 * _1240) / pow(1.6400001049041748046875 - (1.60000002384185791015625 * _880), 1.5))));
     }
     else
     {
-        _1245 = float3(0.0);
+        _1252 = float3(0.0);
     }
-    float3 _1415;
-    float3 _1416;
+    float3 _1422;
+    float3 _1423;
     switch (0u)
     {
         default:
         {
-            float _1251 = length(_756);
-            float _1254 = _113 * _113;
-            float _1257 = _761 - sqrt((_759 - (_1251 * _1251)) + _1254);
-            bool _1258 = _1257 > 0.0;
-            float3 _1268;
-            float _1269;
-            if (_1258)
+            float _1258 = length(_763);
+            float _1261 = _116 * _116;
+            float _1264 = _768 - sqrt((_766 - (_1258 * _1258)) + _1261);
+            bool _1265 = _1264 > 0.0;
+            float3 _1275;
+            float _1276;
+            if (_1265)
             {
-                _1268 = _756 + (_126 * _1257);
-                _1269 = _757 + _1257;
+                _1275 = _763 + (_129 * _1264);
+                _1276 = _764 + _1264;
             }
             else
             {
-                if (_1251 > _113)
+                if (_1258 > _116)
                 {
-                    _1415 = float3(1.0);
-                    _1416 = float3(0.0);
+                    _1422 = float3(1.0);
+                    _1423 = float3(0.0);
                     break;
                 }
-                _1268 = _756;
-                _1269 = _757;
+                _1275 = _763;
+                _1276 = _764;
             }
-            float _1270 = _1258 ? _113 : _1251;
-            float _1271 = _1269 / _1270;
-            float _1273 = dot(_1268, u_fragParams.u_sunDirection.xyz) / _1270;
-            float _1274 = dot(_126, u_fragParams.u_sunDirection.xyz);
-            float _1276 = _1270 * _1270;
-            float _1279 = _1276 * ((_1271 * _1271) - 1.0);
-            bool _1282 = (_1271 < 0.0) && ((_1279 + _762) >= 0.0);
-            float _1284 = sqrt(_1254 - _762);
-            float _1287 = sqrt(fast::max(_1276 - _762, 0.0));
-            float _1295 = _113 - _1270;
-            float _1298 = (_1287 + _1284) - _1295;
-            float _1300 = _1287 / _1284;
-            float4 _1308 = transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_1270) * _1271) + sqrt(fast::max(_1279 + _1254, 0.0)), 0.0) - _1295) / _1298) * 0.99609375), 0.0078125 + (_1300 * 0.984375)));
-            float _1313 = 0.015625 + (_1300 * 0.96875);
-            float _1316 = ((_1269 * _1269) - _1276) + _762;
-            float _1346;
-            if (_1282)
+            float _1277 = _1265 ? _116 : _1258;
+            float _1278 = _1276 / _1277;
+            float _1280 = dot(_1275, u_fragParams.u_sunDirection.xyz) / _1277;
+            float _1281 = dot(_129, u_fragParams.u_sunDirection.xyz);
+            float _1283 = _1277 * _1277;
+            float _1286 = _1283 * ((_1278 * _1278) - 1.0);
+            bool _1289 = (_1278 < 0.0) && ((_1286 + _769) >= 0.0);
+            float _1291 = sqrt(_1261 - _769);
+            float _1294 = sqrt(fast::max(_1283 - _769, 0.0));
+            float _1302 = _116 - _1277;
+            float _1305 = (_1294 + _1291) - _1302;
+            float _1307 = _1294 / _1291;
+            float4 _1315 = transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_1277) * _1278) + sqrt(fast::max(_1286 + _1261, 0.0)), 0.0) - _1302) / _1305) * 0.99609375), 0.0078125 + (_1307 * 0.984375)));
+            float _1320 = 0.015625 + (_1307 * 0.96875);
+            float _1323 = ((_1276 * _1276) - _1283) + _769;
+            float _1353;
+            if (_1289)
             {
-                float _1336 = _1270 - u_fragParams.u_earthCenter.w;
-                _1346 = 0.5 - (0.5 * (0.0078125 + (((_1287 == _1336) ? 0.0 : ((((-_1269) - sqrt(fast::max(_1316, 0.0))) - _1336) / (_1287 - _1336))) * 0.984375)));
+                float _1343 = _1277 - u_fragParams.u_earthCenter.w;
+                _1353 = 0.5 - (0.5 * (0.0078125 + (((_1294 == _1343) ? 0.0 : ((((-_1276) - sqrt(fast::max(_1323, 0.0))) - _1343) / (_1294 - _1343))) * 0.984375)));
             }
             else
             {
-                _1346 = 0.5 + (0.5 * (0.0078125 + (((((-_1269) + sqrt(fast::max(_1316 + (_1284 * _1284), 0.0))) - _1295) / _1298) * 0.984375)));
+                _1353 = 0.5 + (0.5 * (0.0078125 + (((((-_1276) + sqrt(fast::max(_1323 + (_1291 * _1291), 0.0))) - _1302) / _1305) * 0.984375)));
             }
-            float _1357 = _113 - u_fragParams.u_earthCenter.w;
-            float _1359 = _1284 - _1357;
-            float _1360 = (fast::max(((-u_fragParams.u_earthCenter.w) * _1273) + sqrt(fast::max((_762 * ((_1273 * _1273) - 1.0)) + _1254, 0.0)), 0.0) - _1357) / _1359;
-            float _1369 = 0.015625 + ((fast::max(1.0 - (_1360 / ((0.415823996067047119140625 * u_fragParams.u_earthCenter.w) / _1359)), 0.0) / (1.0 + _1360)) * 0.96875);
-            float _1371 = (_1274 + 1.0) * 3.5;
-            float _1372 = floor(_1371);
-            float _1373 = _1371 - _1372;
-            float4 _1383 = scatteringTexture.sample(scatteringSampler, float3((_1372 + _1369) * 0.125, _1346, _1313));
-            float4 _1387 = scatteringTexture.sample(scatteringSampler, float3(((_1372 + 1.0) + _1369) * 0.125, _1346, _1313));
-            float4 _1389 = (_1383 * (1.0 - _1373)) + (_1387 * _1373);
-            float3 _1390 = _1389.xyz;
-            float3 _1403;
+            float _1364 = _116 - u_fragParams.u_earthCenter.w;
+            float _1366 = _1291 - _1364;
+            float _1367 = (fast::max(((-u_fragParams.u_earthCenter.w) * _1280) + sqrt(fast::max((_769 * ((_1280 * _1280) - 1.0)) + _1261, 0.0)), 0.0) - _1364) / _1366;
+            float _1376 = 0.015625 + ((fast::max(1.0 - (_1367 / ((0.415823996067047119140625 * u_fragParams.u_earthCenter.w) / _1366)), 0.0) / (1.0 + _1367)) * 0.96875);
+            float _1378 = (_1281 + 1.0) * 3.5;
+            float _1379 = floor(_1378);
+            float _1380 = _1378 - _1379;
+            float4 _1390 = scatteringTexture.sample(scatteringSampler, float3((_1379 + _1376) * 0.125, _1353, _1320));
+            float4 _1394 = scatteringTexture.sample(scatteringSampler, float3(((_1379 + 1.0) + _1376) * 0.125, _1353, _1320));
+            float4 _1396 = (_1390 * (1.0 - _1380)) + (_1394 * _1380);
+            float3 _1397 = _1396.xyz;
+            float3 _1410;
             switch (0u)
             {
                 default:
                 {
-                    float _1393 = _1389.x;
-                    if (_1393 == 0.0)
+                    float _1400 = _1396.x;
+                    if (_1400 == 0.0)
                     {
-                        _1403 = float3(0.0);
+                        _1410 = float3(0.0);
                         break;
                     }
-                    _1403 = (((_1390 * _1389.w) / float3(_1393)) * 1.5) * float3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
+                    _1410 = (((_1397 * _1396.w) / float3(_1400)) * 1.5) * float3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
                     break;
                 }
             }
-            float _1405 = 1.0 + (_1274 * _1274);
-            _1415 = select(_1308.xyz, float3(0.0), bool3(_1282));
-            _1416 = (_1390 * (0.0596831031143665313720703125 * _1405)) + (_1403 * ((0.01627720706164836883544921875 * _1405) / pow(1.6400001049041748046875 - (1.60000002384185791015625 * _1274), 1.5)));
+            float _1412 = 1.0 + (_1281 * _1281);
+            _1422 = select(_1315.xyz, float3(0.0), bool3(_1289));
+            _1423 = (_1397 * (0.0596831031143665313720703125 * _1412)) + (_1410 * ((0.01627720706164836883544921875 * _1412) / pow(1.6400001049041748046875 - (1.60000002384185791015625 * _1281), 1.5)));
             break;
         }
     }
-    float3 _1424;
-    if (dot(_126, u_fragParams.u_sunDirection.xyz) > u_fragParams.u_sunSize.y)
+    float3 _1431;
+    if (dot(_129, u_fragParams.u_sunDirection.xyz) > u_fragParams.u_sunSize.y)
     {
-        _1424 = _1416 + (_1415 * float3(21467.642578125, 26949.611328125, 27846.474609375));
+        _1431 = _1423 + (_1422 * float3(21467.642578125, 26949.611328125, 27846.474609375));
     }
     else
     {
-        _1424 = _1416;
+        _1431 = _1423;
     }
-    float3 _1438 = pow(abs(float3(1.0) - exp(((-mix(mix(_1424, _1245, float3(float(_766))), _754, float3(float(_163)))) / u_fragParams.u_whitePoint.xyz) * u_fragParams.u_camera.w)), float3(0.4545454680919647216796875));
-    float4 _1440 = float4(_1438.x, _1438.y, _1438.z, _105.w);
-    _1440.w = 1.0;
-    out.out_var_SV_Target = _1440;
-    out.gl_FragDepth = _131;
+    float3 _1445 = pow(abs(float3(1.0) - exp(((-mix(mix(_1431, _1252, float3(float(_773))), _761, float3(float(_170)))) / u_fragParams.u_whitePoint.xyz) * u_fragParams.u_camera.w)), float3(0.4545454680919647216796875));
+    float4 _1447 = float4(_1445.x, _1445.y, _1445.z, _108.w);
+    _1447.w = 1.0;
+    out.out_var_SV_Target0 = _1447;
+    out.out_var_SV_Target1 = _137;
+    out.gl_FragDepth = _142;
     return out;
 }
 

--- a/src/gl/metal/shaders/desktop/compassFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/compassFragmentShader.metal
@@ -13,7 +13,8 @@ struct type_u_cameraPlaneParams
 
 struct main0_out
 {
-    float4 out_var_SV_Target [[color(0)]];
+    float4 out_var_SV_Target0 [[color(0)]];
+    float4 out_var_SV_Target1 [[color(1)]];
     float gl_FragDepth [[depth(any)]];
 };
 
@@ -29,12 +30,12 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]])
 {
     main0_out out = {};
-    float3 _50 = (in.in_var_COLOR0 * float3(2.0)) - float3(1.0);
-    float _76 = log2(in.in_var_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
-    float4 _77 = float4(((in.in_var_COLOR1.xyz * (0.5 + (dot(in.in_var_COLOR2, _50) * (-0.5)))) + (float3(1.0, 1.0, 0.89999997615814208984375) * pow(fast::max(0.0, -dot(-normalize(in.in_var_COLOR3.xyz / float3(in.in_var_COLOR3.w)), _50)), 60.0))) * in.in_var_COLOR1.w, 1.0);
-    _77.w = _76;
-    out.out_var_SV_Target = _77;
-    out.gl_FragDepth = _76;
+    float3 _51 = (in.in_var_COLOR0 * float3(2.0)) - float3(1.0);
+    float _77 = log2(in.in_var_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _80 = 1.0 - in.in_var_COLOR0.z;
+    out.out_var_SV_Target0 = float4(((in.in_var_COLOR1.xyz * (0.5 + (dot(in.in_var_COLOR2, _51) * (-0.5)))) + (float3(1.0, 1.0, 0.89999997615814208984375) * pow(fast::max(0.0, -dot(-normalize(in.in_var_COLOR3.xyz / float3(in.in_var_COLOR3.w)), _51)), 60.0))) * in.in_var_COLOR1.w, 1.0);
+    out.out_var_SV_Target1 = float4(in.in_var_COLOR0.x / _80, in.in_var_COLOR0.y / _80, 0.0, _77);
+    out.gl_FragDepth = _77;
     return out;
 }
 

--- a/src/gl/metal/shaders/desktop/depthOnlyFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/depthOnlyFragmentShader.metal
@@ -13,7 +13,7 @@ struct type_u_cameraPlaneParams
 
 struct main0_out
 {
-    float4 out_var_SV_Target [[color(0)]];
+    float4 out_var_SV_Target0 [[color(0)]];
     float gl_FragDepth [[depth(any)]];
 };
 
@@ -25,11 +25,8 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]])
 {
     main0_out out = {};
-    float _39 = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
-    float4 _40 = float4(0.0);
-    _40.w = _39;
-    out.out_var_SV_Target = _40;
-    out.gl_FragDepth = _39;
+    out.out_var_SV_Target0 = float4(0.0);
+    out.gl_FragDepth = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
     return out;
 }
 

--- a/src/gl/metal/shaders/desktop/fenceFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/fenceFragmentShader.metal
@@ -13,7 +13,8 @@ struct type_u_cameraPlaneParams
 
 struct main0_out
 {
-    float4 out_var_SV_Target [[color(0)]];
+    float4 out_var_SV_Target0 [[color(0)]];
+    float4 out_var_SV_Target1 [[color(1)]];
     float gl_FragDepth [[depth(any)]];
 };
 
@@ -27,9 +28,11 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], texture2d<float> colourTexture [[texture(0)]], sampler colourSampler [[sampler(0)]])
 {
     main0_out out = {};
-    float4 _40 = colourTexture.sample(colourSampler, in.in_var_TEXCOORD0);
-    out.out_var_SV_Target = float4(_40.xyz * in.in_var_COLOR0.xyz, _40.w * in.in_var_COLOR0.w);
-    out.gl_FragDepth = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float4 _42 = colourTexture.sample(colourSampler, in.in_var_TEXCOORD0);
+    float _60 = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    out.out_var_SV_Target0 = float4(_42.xyz * in.in_var_COLOR0.xyz, _42.w * in.in_var_COLOR0.w);
+    out.out_var_SV_Target1 = float4(0.0, 0.0, 0.0, _60);
+    out.gl_FragDepth = _60;
     return out;
 }
 

--- a/src/gl/metal/shaders/desktop/flatColourFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/flatColourFragmentShader.metal
@@ -3,34 +3,20 @@
 
 using namespace metal;
 
-struct type_u_cameraPlaneParams
-{
-    float s_CameraNearPlane;
-    float s_CameraFarPlane;
-    float u_clipZNear;
-    float u_clipZFar;
-};
-
 struct main0_out
 {
-    float4 out_var_SV_Target [[color(0)]];
-    float gl_FragDepth [[depth(any)]];
+    float4 out_var_SV_Target0 [[color(0)]];
 };
 
 struct main0_in
 {
     float4 in_var_COLOR0 [[user(locn2)]];
-    float2 in_var_TEXCOORD1 [[user(locn3)]];
 };
 
-fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]])
+fragment main0_out main0(main0_in in [[stage_in]])
 {
     main0_out out = {};
-    float _38 = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
-    float4 _39 = in.in_var_COLOR0;
-    _39.w = _38;
-    out.out_var_SV_Target = _39;
-    out.gl_FragDepth = _38;
+    out.out_var_SV_Target0 = in.in_var_COLOR0;
     return out;
 }
 

--- a/src/gl/metal/shaders/desktop/imageRendererFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/imageRendererFragmentShader.metal
@@ -13,7 +13,8 @@ struct type_u_cameraPlaneParams
 
 struct main0_out
 {
-    float4 out_var_SV_Target [[color(0)]];
+    float4 out_var_SV_Target0 [[color(0)]];
+    float4 out_var_SV_Target1 [[color(1)]];
     float gl_FragDepth [[depth(any)]];
 };
 
@@ -27,8 +28,10 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], texture2d<float> albedoTexture [[texture(0)]], sampler albedoSampler [[sampler(0)]])
 {
     main0_out out = {};
-    out.out_var_SV_Target = albedoTexture.sample(albedoSampler, in.in_var_TEXCOORD0) * in.in_var_COLOR0;
-    out.gl_FragDepth = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _50 = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    out.out_var_SV_Target0 = albedoTexture.sample(albedoSampler, in.in_var_TEXCOORD0) * in.in_var_COLOR0;
+    out.out_var_SV_Target1 = float4(0.0, 0.0, 0.0, _50);
+    out.gl_FragDepth = _50;
     return out;
 }
 

--- a/src/gl/metal/shaders/desktop/lineFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/lineFragmentShader.metal
@@ -13,7 +13,8 @@ struct type_u_cameraPlaneParams
 
 struct main0_out
 {
-    float4 out_var_SV_Target [[color(0)]];
+    float4 out_var_SV_Target0 [[color(0)]];
+    float4 out_var_SV_Target1 [[color(1)]];
     float gl_FragDepth [[depth(any)]];
 };
 
@@ -26,8 +27,10 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]])
 {
     main0_out out = {};
-    out.out_var_SV_Target = in.in_var_COLOR0;
-    out.gl_FragDepth = log2(in.in_var_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _36 = log2(in.in_var_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    out.out_var_SV_Target0 = in.in_var_COLOR0;
+    out.out_var_SV_Target1 = float4(0.0, 0.0, 0.0, _36);
+    out.gl_FragDepth = _36;
     return out;
 }
 

--- a/src/gl/metal/shaders/desktop/polygonImageFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/polygonImageFragmentShader.metal
@@ -13,7 +13,8 @@ struct type_u_cameraPlaneParams
 
 struct main0_out
 {
-    float4 out_var_SV_Target [[color(0)]];
+    float4 out_var_SV_Target0 [[color(0)]];
+    float4 out_var_SV_Target1 [[color(1)]];
     float gl_FragDepth [[depth(any)]];
 };
 
@@ -22,16 +23,16 @@ struct main0_in
     float2 in_var_TEXCOORD0 [[user(locn0)]];
     float4 in_var_COLOR0 [[user(locn2)]];
     float2 in_var_TEXCOORD1 [[user(locn3)]];
+    float2 in_var_TEXCOORD2 [[user(locn4)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], texture2d<float> albedoTexture [[texture(0)]], sampler albedoSampler [[sampler(0)]])
 {
     main0_out out = {};
-    float _51 = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
-    float4 _52 = albedoTexture.sample(albedoSampler, in.in_var_TEXCOORD0) * in.in_var_COLOR0;
-    _52.w = _51;
-    out.out_var_SV_Target = _52;
-    out.gl_FragDepth = _51;
+    float _55 = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    out.out_var_SV_Target0 = albedoTexture.sample(albedoSampler, in.in_var_TEXCOORD0) * in.in_var_COLOR0;
+    out.out_var_SV_Target1 = float4(0.0, 0.0, in.in_var_TEXCOORD2.x, _55);
+    out.gl_FragDepth = _55;
     return out;
 }
 

--- a/src/gl/metal/shaders/desktop/polygonP3N3UV2FragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/polygonP3N3UV2FragmentShader.metal
@@ -11,11 +11,10 @@ struct type_u_cameraPlaneParams
     float u_clipZFar;
 };
 
-constant float _39 = {};
-
 struct main0_out
 {
-    float4 out_var_SV_Target [[color(0)]];
+    float4 out_var_SV_Target0 [[color(0)]];
+    float4 out_var_SV_Target1 [[color(1)]];
     float gl_FragDepth [[depth(any)]];
 };
 
@@ -25,16 +24,18 @@ struct main0_in
     float3 in_var_NORMAL [[user(locn1)]];
     float4 in_var_COLOR0 [[user(locn2)]];
     float2 in_var_TEXCOORD1 [[user(locn3)]];
+    float2 in_var_TEXCOORD2 [[user(locn4)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], texture2d<float> albedoTexture [[texture(0)]], sampler albedoSampler [[sampler(0)]])
 {
     main0_out out = {};
-    float _67 = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
-    float4 _68 = float4((albedoTexture.sample(albedoSampler, in.in_var_TEXCOORD0) * in.in_var_COLOR0).xyz * ((dot(in.in_var_NORMAL, normalize(float3(0.85000002384185791015625, 0.1500000059604644775390625, 0.5))) * 0.5) + 0.5), _39);
-    _68.w = _67;
-    out.out_var_SV_Target = _68;
-    out.gl_FragDepth = _67;
+    float4 _51 = albedoTexture.sample(albedoSampler, in.in_var_TEXCOORD0) * in.in_var_COLOR0;
+    float _70 = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _74 = 1.0 - in.in_var_NORMAL.z;
+    out.out_var_SV_Target0 = float4(_51.xyz * ((dot(in.in_var_NORMAL, normalize(float3(0.85000002384185791015625, 0.1500000059604644775390625, 0.5))) * 0.5) + 0.5), _51.w);
+    out.out_var_SV_Target1 = float4(in.in_var_NORMAL.x / _74, in.in_var_NORMAL.y / _74, in.in_var_TEXCOORD2.x, _70);
+    out.gl_FragDepth = _70;
     return out;
 }
 

--- a/src/gl/metal/shaders/desktop/polygonP3N3UV2VertexShader.metal
+++ b/src/gl/metal/shaders/desktop/polygonP3N3UV2VertexShader.metal
@@ -8,9 +8,10 @@ struct type_u_EveryObject
     float4x4 u_worldViewProjectionMatrix;
     float4x4 u_worldMatrix;
     float4 u_colour;
+    float4 u_objectInfo;
 };
 
-constant float2 _34 = {};
+constant float2 _37 = {};
 
 struct main0_out
 {
@@ -18,6 +19,7 @@ struct main0_out
     float3 out_var_NORMAL [[user(locn1)]];
     float4 out_var_COLOR0 [[user(locn2)]];
     float2 out_var_TEXCOORD1 [[user(locn3)]];
+    float2 out_var_TEXCOORD2 [[user(locn4)]];
     float4 gl_Position [[position]];
 };
 
@@ -31,14 +33,17 @@ struct main0_in
 vertex main0_out main0(main0_in in [[stage_in]], constant type_u_EveryObject& u_EveryObject [[buffer(0)]])
 {
     main0_out out = {};
-    float4 _54 = u_EveryObject.u_worldViewProjectionMatrix * float4(in.in_var_POSITION, 1.0);
-    float2 _59 = _34;
-    _59.x = 1.0 + _54.w;
-    out.gl_Position = _54;
+    float4 _57 = u_EveryObject.u_worldViewProjectionMatrix * float4(in.in_var_POSITION, 1.0);
+    float2 _62 = _37;
+    _62.x = 1.0 + _57.w;
+    float2 _65 = _37;
+    _65.x = u_EveryObject.u_objectInfo.x;
+    out.gl_Position = _57;
     out.out_var_TEXCOORD0 = in.in_var_TEXCOORD0;
     out.out_var_NORMAL = normalize((u_EveryObject.u_worldMatrix * float4(in.in_var_NORMAL, 0.0)).xyz);
     out.out_var_COLOR0 = u_EveryObject.u_colour;
-    out.out_var_TEXCOORD1 = _59;
+    out.out_var_TEXCOORD1 = _62;
+    out.out_var_TEXCOORD2 = _65;
     return out;
 }
 

--- a/src/gl/metal/shaders/desktop/tileFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/tileFragmentShader.metal
@@ -11,11 +11,10 @@ struct type_u_cameraPlaneParams
     float u_clipZFar;
 };
 
-constant float _32 = {};
-
 struct main0_out
 {
-    float4 out_var_SV_Target [[color(0)]];
+    float4 out_var_SV_Target0 [[color(0)]];
+    float4 out_var_SV_Target1 [[color(1)]];
 };
 
 struct main0_in
@@ -23,14 +22,14 @@ struct main0_in
     float4 in_var_COLOR0 [[user(locn0)]];
     float2 in_var_TEXCOORD0 [[user(locn1)]];
     float2 in_var_TEXCOORD1 [[user(locn2)]];
+    float2 in_var_TEXCOORD2 [[user(locn3)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], texture2d<float> colourTexture [[texture(0)]], sampler colourSampler [[sampler(0)]])
 {
     main0_out out = {};
-    float4 _60 = float4(colourTexture.sample(colourSampler, in.in_var_TEXCOORD0).xyz * in.in_var_COLOR0.xyz, _32);
-    _60.w = ((in.in_var_TEXCOORD1.x / in.in_var_TEXCOORD1.y) * (1.0 / (u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear))) + (u_cameraPlaneParams.u_clipZNear * (-0.5));
-    out.out_var_SV_Target = _60;
+    out.out_var_SV_Target0 = float4(colourTexture.sample(colourSampler, in.in_var_TEXCOORD0).xyz * in.in_var_COLOR0.xyz, in.in_var_COLOR0.w);
+    out.out_var_SV_Target1 = float4(0.0, 0.0, in.in_var_TEXCOORD2.x, ((in.in_var_TEXCOORD1.x / in.in_var_TEXCOORD1.y) * (1.0 / (u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear))) + (u_cameraPlaneParams.u_clipZNear * (-0.5)));
     return out;
 }
 

--- a/src/gl/metal/shaders/desktop/tileVertexShader.metal
+++ b/src/gl/metal/shaders/desktop/tileVertexShader.metal
@@ -17,16 +17,20 @@ struct type_u_EveryObject
     float4x4 u_view;
     float4 u_eyePositions[9];
     float4 u_colour;
+    float4 u_objectInfo;
     float4 u_uvOffsetScale;
     float4 u_demUVOffsetScale;
     float4 u_tileNormal;
 };
+
+constant float2 _55 = {};
 
 struct main0_out
 {
     float4 out_var_COLOR0 [[user(locn0)]];
     float2 out_var_TEXCOORD0 [[user(locn1)]];
     float2 out_var_TEXCOORD1 [[user(locn2)]];
+    float2 out_var_TEXCOORD2 [[user(locn3)]];
     float4 gl_Position [[position]];
 };
 
@@ -38,28 +42,31 @@ struct main0_in
 vertex main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], constant type_u_EveryObject& u_EveryObject [[buffer(1)]], texture2d<float> demTexture [[texture(0)]], sampler demSampler [[sampler(0)]])
 {
     main0_out out = {};
-    float2 _57 = in.in_var_POSITION.xy * 2.0;
-    float _58 = _57.x;
-    float _59 = floor(_58);
-    float _60 = _57.y;
-    float _61 = floor(_60);
-    float _63 = fast::min(2.0, _59 + 1.0);
-    float _66 = _58 - _59;
-    float _68 = _61 * 3.0;
-    int _70 = int(_68 + _59);
-    float _77 = fast::min(2.0, _61 + 1.0) * 3.0;
-    int _79 = int(_77 + _59);
-    float4 _88 = u_EveryObject.u_eyePositions[_70] + ((u_EveryObject.u_eyePositions[int(_68 + _63)] - u_EveryObject.u_eyePositions[_70]) * _66);
-    float4 _104 = demTexture.sample(demSampler, (u_EveryObject.u_demUVOffsetScale.xy + (u_EveryObject.u_demUVOffsetScale.zw * in.in_var_POSITION.xy)), level(0.0));
-    float4 _127 = u_EveryObject.u_projection * ((_88 + (((u_EveryObject.u_eyePositions[_79] + ((u_EveryObject.u_eyePositions[int(_77 + _63)] - u_EveryObject.u_eyePositions[_79]) * _66)) - _88) * (_60 - _61))) + ((u_EveryObject.u_view * float4(u_EveryObject.u_tileNormal.xyz * (((_104.x * 255.0) + (_104.y * 65280.0)) - 32768.0), 1.0)) - (u_EveryObject.u_view * float4(0.0, 0.0, 0.0, 1.0))));
-    float _138 = _127.w;
-    float _144 = ((log2(fast::max(9.9999999747524270787835121154785e-07, 1.0 + _138)) * ((u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear) / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0))) + u_cameraPlaneParams.u_clipZNear) * _138;
-    float4 _145 = _127;
-    _145.z = _144;
-    out.gl_Position = _145;
+    float2 _60 = in.in_var_POSITION.xy * 2.0;
+    float _61 = _60.x;
+    float _62 = floor(_61);
+    float _63 = _60.y;
+    float _64 = floor(_63);
+    float _66 = fast::min(2.0, _62 + 1.0);
+    float _69 = _61 - _62;
+    float _71 = _64 * 3.0;
+    int _73 = int(_71 + _62);
+    float _80 = fast::min(2.0, _64 + 1.0) * 3.0;
+    int _82 = int(_80 + _62);
+    float4 _91 = u_EveryObject.u_eyePositions[_73] + ((u_EveryObject.u_eyePositions[int(_71 + _66)] - u_EveryObject.u_eyePositions[_73]) * _69);
+    float4 _107 = demTexture.sample(demSampler, (u_EveryObject.u_demUVOffsetScale.xy + (u_EveryObject.u_demUVOffsetScale.zw * in.in_var_POSITION.xy)), level(0.0));
+    float4 _130 = u_EveryObject.u_projection * ((_91 + (((u_EveryObject.u_eyePositions[_82] + ((u_EveryObject.u_eyePositions[int(_80 + _66)] - u_EveryObject.u_eyePositions[_82]) * _69)) - _91) * (_63 - _64))) + ((u_EveryObject.u_view * float4(u_EveryObject.u_tileNormal.xyz * (((_107.x * 255.0) + (_107.y * 65280.0)) - 32768.0), 1.0)) - (u_EveryObject.u_view * float4(0.0, 0.0, 0.0, 1.0))));
+    float _141 = _130.w;
+    float _147 = ((log2(fast::max(9.9999999747524270787835121154785e-07, 1.0 + _141)) * ((u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear) / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0))) + u_cameraPlaneParams.u_clipZNear) * _141;
+    float4 _148 = _130;
+    _148.z = _147;
+    float2 _160 = _55;
+    _160.x = u_EveryObject.u_objectInfo.x;
+    out.gl_Position = _148;
     out.out_var_COLOR0 = u_EveryObject.u_colour;
     out.out_var_TEXCOORD0 = u_EveryObject.u_uvOffsetScale.xy + (u_EveryObject.u_uvOffsetScale.zw * in.in_var_POSITION.xy);
-    out.out_var_TEXCOORD1 = float2(_144, _138);
+    out.out_var_TEXCOORD1 = float2(_147, _141);
+    out.out_var_TEXCOORD2 = _160;
     return out;
 }
 

--- a/src/gl/metal/shaders/desktop/udFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/udFragmentShader.metal
@@ -5,7 +5,8 @@ using namespace metal;
 
 struct main0_out
 {
-    float4 out_var_SV_Target [[color(0)]];
+    float4 out_var_SV_Target0 [[color(0)]];
+    float4 out_var_SV_Target1 [[color(1)]];
     float gl_FragDepth [[depth(any)]];
 };
 
@@ -17,12 +18,11 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> sceneColourTexture [[texture(0)]], texture2d<float> sceneDepthTexture [[texture(1)]], sampler sceneColourSampler [[sampler(0)]], sampler sceneDepthSampler [[sampler(1)]])
 {
     main0_out out = {};
-    float4 _34 = sceneDepthTexture.sample(sceneDepthSampler, in.in_var_TEXCOORD0);
-    float _35 = _34.x;
-    float4 _40 = float4(sceneColourTexture.sample(sceneColourSampler, in.in_var_TEXCOORD0).zyx, 1.0);
-    _40.w = _35;
-    out.out_var_SV_Target = _40;
-    out.gl_FragDepth = _35;
+    float4 _36 = sceneDepthTexture.sample(sceneDepthSampler, in.in_var_TEXCOORD0);
+    float _37 = _36.x;
+    out.out_var_SV_Target0 = float4(sceneColourTexture.sample(sceneColourSampler, in.in_var_TEXCOORD0).zyx, 1.0);
+    out.out_var_SV_Target1 = float4(0.0, 0.0, 0.0, _37);
+    out.gl_FragDepth = _37;
     return out;
 }
 

--- a/src/gl/metal/shaders/desktop/viewShedFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/viewShedFragmentShader.metal
@@ -22,7 +22,7 @@ struct type_u_params
 
 struct main0_out
 {
-    float4 out_var_SV_Target [[color(0)]];
+    float4 out_var_SV_Target0 [[color(0)]];
 };
 
 struct main0_in
@@ -67,7 +67,7 @@ fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlanePa
     {
         _225 = float4(0.0);
     }
-    out.out_var_SV_Target = float4(_225.xyz * _225.w, 1.0);
+    out.out_var_SV_Target0 = float4(_225.xyz * _225.w, 1.0);
     return out;
 }
 

--- a/src/gl/metal/shaders/desktop/visualizationFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/visualizationFragmentShader.metal
@@ -32,7 +32,8 @@ struct type_u_fragParams
 
 struct main0_out
 {
-    float4 out_var_SV_Target [[color(0)]];
+    float4 out_var_SV_Target0 [[color(0)]];
+    float4 out_var_SV_Target1 [[color(1)]];
     float gl_FragDepth [[depth(any)]];
 };
 
@@ -53,55 +54,55 @@ inline Tx mod(Tx x, Ty y)
     return x - y * floor(x / y);
 }
 
-fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], constant type_u_fragParams& u_fragParams [[buffer(1)]], texture2d<float> sceneColourTexture [[texture(0)]], texture2d<float> sceneDepthTexture [[texture(1)]], sampler sceneColourSampler [[sampler(0)]], sampler sceneDepthSampler [[sampler(1)]])
+fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], constant type_u_fragParams& u_fragParams [[buffer(1)]], texture2d<float> sceneColourTexture [[texture(0)]], texture2d<float> sceneNormalTexture [[texture(1)]], texture2d<float> sceneDepthTexture [[texture(2)]], sampler sceneColourSampler [[sampler(0)]], sampler sceneNormalSampler [[sampler(1)]], sampler sceneDepthSampler [[sampler(2)]])
 {
     main0_out out = {};
-    float4 _78 = sceneColourTexture.sample(sceneColourSampler, in.in_var_TEXCOORD1);
-    float4 _82 = sceneDepthTexture.sample(sceneDepthSampler, in.in_var_TEXCOORD1);
-    float _83 = _82.x;
-    float _89 = u_cameraPlaneParams.s_CameraFarPlane / (u_cameraPlaneParams.s_CameraFarPlane - u_cameraPlaneParams.s_CameraNearPlane);
-    float _92 = (u_cameraPlaneParams.s_CameraFarPlane * u_cameraPlaneParams.s_CameraNearPlane) / (u_cameraPlaneParams.s_CameraNearPlane - u_cameraPlaneParams.s_CameraFarPlane);
-    float _94 = log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0);
-    float _104 = u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear;
-    float _106 = ((_89 + (_92 / (pow(2.0, _83 * _94) - 1.0))) * _104) + u_cameraPlaneParams.u_clipZNear;
-    float4 _112 = u_fragParams.u_inverseProjection * float4(in.in_var_TEXCOORD0.xy, _106, 1.0);
-    float3 _116 = _78.xyz;
-    float3 _117 = (_112 / float4(_112.w)).xyz;
-    float _124 = dot(u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz, u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz);
-    float3 _126 = u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz * (dot(_117, u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz) / _124);
-    float _132 = mix(length(u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz - _126), 0.0, float(dot(_126, _126) > _124));
-    float3 _207 = mix(mix(mix(mix(mix(_116, u_fragParams.u_colourizeHeightColourMin.xyz, float3(u_fragParams.u_colourizeHeightColourMin.w)), mix(_116, u_fragParams.u_colourizeHeightColourMax.xyz, float3(u_fragParams.u_colourizeHeightColourMax.w)), float3(fast::clamp((_132 - u_fragParams.u_colourizeHeightParams.x) / (u_fragParams.u_colourizeHeightParams.y - u_fragParams.u_colourizeHeightParams.x), 0.0, 1.0))).xyz, u_fragParams.u_colourizeDepthColour.xyz, float3(fast::clamp((length(_117) - u_fragParams.u_colourizeDepthParams.x) / (u_fragParams.u_colourizeDepthParams.y - u_fragParams.u_colourizeDepthParams.x), 0.0, 1.0) * u_fragParams.u_colourizeDepthColour.w)).xyz, fast::clamp(abs((fract(float3(_132 * (1.0 / u_fragParams.u_contourParams.z), 1.0, 1.0).xxx + float3(1.0, 0.666666686534881591796875, 0.3333333432674407958984375)) * 6.0) - float3(3.0)) - float3(1.0), float3(0.0), float3(1.0)) * 1.0, float3(u_fragParams.u_contourParams.w)), u_fragParams.u_contourColour.xyz, float3((1.0 - step(u_fragParams.u_contourParams.y, mod(abs(_132), u_fragParams.u_contourParams.x))) * u_fragParams.u_contourColour.w));
-    float _357;
-    float4 _358;
+    float4 _81 = sceneColourTexture.sample(sceneColourSampler, in.in_var_TEXCOORD1);
+    float4 _85 = sceneNormalTexture.sample(sceneNormalSampler, in.in_var_TEXCOORD1);
+    float4 _89 = sceneDepthTexture.sample(sceneDepthSampler, in.in_var_TEXCOORD1);
+    float _90 = _89.x;
+    float _96 = u_cameraPlaneParams.s_CameraFarPlane / (u_cameraPlaneParams.s_CameraFarPlane - u_cameraPlaneParams.s_CameraNearPlane);
+    float _99 = (u_cameraPlaneParams.s_CameraFarPlane * u_cameraPlaneParams.s_CameraNearPlane) / (u_cameraPlaneParams.s_CameraNearPlane - u_cameraPlaneParams.s_CameraFarPlane);
+    float _101 = log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0);
+    float _111 = u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear;
+    float _113 = ((_96 + (_99 / (pow(2.0, _90 * _101) - 1.0))) * _111) + u_cameraPlaneParams.u_clipZNear;
+    float4 _119 = u_fragParams.u_inverseProjection * float4(in.in_var_TEXCOORD0.xy, _113, 1.0);
+    float3 _123 = _81.xyz;
+    float3 _124 = (_119 / float4(_119.w)).xyz;
+    float _131 = dot(u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz, u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz);
+    float3 _133 = u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz * (dot(_124, u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz) / _131);
+    float _139 = mix(length(u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz - _133), 0.0, float(dot(_133, _133) > _131));
+    float3 _214 = mix(mix(mix(mix(mix(_123, u_fragParams.u_colourizeHeightColourMin.xyz, float3(u_fragParams.u_colourizeHeightColourMin.w)), mix(_123, u_fragParams.u_colourizeHeightColourMax.xyz, float3(u_fragParams.u_colourizeHeightColourMax.w)), float3(fast::clamp((_139 - u_fragParams.u_colourizeHeightParams.x) / (u_fragParams.u_colourizeHeightParams.y - u_fragParams.u_colourizeHeightParams.x), 0.0, 1.0))).xyz, u_fragParams.u_colourizeDepthColour.xyz, float3(fast::clamp((length(_124) - u_fragParams.u_colourizeDepthParams.x) / (u_fragParams.u_colourizeDepthParams.y - u_fragParams.u_colourizeDepthParams.x), 0.0, 1.0) * u_fragParams.u_colourizeDepthColour.w)).xyz, fast::clamp(abs((fract(float3(_139 * (1.0 / u_fragParams.u_contourParams.z), 1.0, 1.0).xxx + float3(1.0, 0.666666686534881591796875, 0.3333333432674407958984375)) * 6.0) - float3(3.0)) - float3(1.0), float3(0.0), float3(1.0)) * 1.0, float3(u_fragParams.u_contourParams.w)), u_fragParams.u_contourColour.xyz, float3((1.0 - step(u_fragParams.u_contourParams.y, mod(abs(_139), u_fragParams.u_contourParams.x))) * u_fragParams.u_contourColour.w));
+    float _364;
+    float4 _365;
     if ((u_fragParams.u_outlineParams.x > 0.0) && (u_fragParams.u_outlineColour.w > 0.0))
     {
-        float4 _229 = u_fragParams.u_inverseProjection * float4((in.in_var_TEXCOORD1.x * 2.0) - 1.0, (in.in_var_TEXCOORD1.y * 2.0) - 1.0, _106, 1.0);
-        float4 _234 = sceneDepthTexture.sample(sceneDepthSampler, in.in_var_TEXCOORD2);
-        float _235 = _234.x;
-        float4 _237 = sceneDepthTexture.sample(sceneDepthSampler, in.in_var_TEXCOORD3);
-        float _238 = _237.x;
-        float4 _240 = sceneDepthTexture.sample(sceneDepthSampler, in.in_var_TEXCOORD4);
-        float _241 = _240.x;
-        float4 _243 = sceneDepthTexture.sample(sceneDepthSampler, in.in_var_TEXCOORD5);
-        float _244 = _243.x;
-        float4 _259 = u_fragParams.u_inverseProjection * float4((in.in_var_TEXCOORD2.x * 2.0) - 1.0, (in.in_var_TEXCOORD2.y * 2.0) - 1.0, ((_89 + (_92 / (pow(2.0, _235 * _94) - 1.0))) * _104) + u_cameraPlaneParams.u_clipZNear, 1.0);
-        float4 _274 = u_fragParams.u_inverseProjection * float4((in.in_var_TEXCOORD3.x * 2.0) - 1.0, (in.in_var_TEXCOORD3.y * 2.0) - 1.0, ((_89 + (_92 / (pow(2.0, _238 * _94) - 1.0))) * _104) + u_cameraPlaneParams.u_clipZNear, 1.0);
-        float4 _289 = u_fragParams.u_inverseProjection * float4((in.in_var_TEXCOORD4.x * 2.0) - 1.0, (in.in_var_TEXCOORD4.y * 2.0) - 1.0, ((_89 + (_92 / (pow(2.0, _241 * _94) - 1.0))) * _104) + u_cameraPlaneParams.u_clipZNear, 1.0);
-        float4 _304 = u_fragParams.u_inverseProjection * float4((in.in_var_TEXCOORD5.x * 2.0) - 1.0, (in.in_var_TEXCOORD5.y * 2.0) - 1.0, ((_89 + (_92 / (pow(2.0, _244 * _94) - 1.0))) * _104) + u_cameraPlaneParams.u_clipZNear, 1.0);
-        float3 _317 = (_229 / float4(_229.w)).xyz;
-        float4 _354 = mix(float4(_207, _83), float4(mix(_207.xyz, u_fragParams.u_outlineColour.xyz, float3(u_fragParams.u_outlineColour.w)), fast::min(fast::min(fast::min(_235, _238), _241), _244)), float4(1.0 - (((step(length(_317 - (_259 / float4(_259.w)).xyz), u_fragParams.u_outlineParams.y) * step(length(_317 - (_274 / float4(_274.w)).xyz), u_fragParams.u_outlineParams.y)) * step(length(_317 - (_289 / float4(_289.w)).xyz), u_fragParams.u_outlineParams.y)) * step(length(_317 - (_304 / float4(_304.w)).xyz), u_fragParams.u_outlineParams.y))));
-        _357 = _354.w;
-        _358 = float4(_354.x, _354.y, _354.z, _78.w);
+        float4 _236 = u_fragParams.u_inverseProjection * float4((in.in_var_TEXCOORD1.x * 2.0) - 1.0, (in.in_var_TEXCOORD1.y * 2.0) - 1.0, _113, 1.0);
+        float4 _241 = sceneDepthTexture.sample(sceneDepthSampler, in.in_var_TEXCOORD2);
+        float _242 = _241.x;
+        float4 _244 = sceneDepthTexture.sample(sceneDepthSampler, in.in_var_TEXCOORD3);
+        float _245 = _244.x;
+        float4 _247 = sceneDepthTexture.sample(sceneDepthSampler, in.in_var_TEXCOORD4);
+        float _248 = _247.x;
+        float4 _250 = sceneDepthTexture.sample(sceneDepthSampler, in.in_var_TEXCOORD5);
+        float _251 = _250.x;
+        float4 _266 = u_fragParams.u_inverseProjection * float4((in.in_var_TEXCOORD2.x * 2.0) - 1.0, (in.in_var_TEXCOORD2.y * 2.0) - 1.0, ((_96 + (_99 / (pow(2.0, _242 * _101) - 1.0))) * _111) + u_cameraPlaneParams.u_clipZNear, 1.0);
+        float4 _281 = u_fragParams.u_inverseProjection * float4((in.in_var_TEXCOORD3.x * 2.0) - 1.0, (in.in_var_TEXCOORD3.y * 2.0) - 1.0, ((_96 + (_99 / (pow(2.0, _245 * _101) - 1.0))) * _111) + u_cameraPlaneParams.u_clipZNear, 1.0);
+        float4 _296 = u_fragParams.u_inverseProjection * float4((in.in_var_TEXCOORD4.x * 2.0) - 1.0, (in.in_var_TEXCOORD4.y * 2.0) - 1.0, ((_96 + (_99 / (pow(2.0, _248 * _101) - 1.0))) * _111) + u_cameraPlaneParams.u_clipZNear, 1.0);
+        float4 _311 = u_fragParams.u_inverseProjection * float4((in.in_var_TEXCOORD5.x * 2.0) - 1.0, (in.in_var_TEXCOORD5.y * 2.0) - 1.0, ((_96 + (_99 / (pow(2.0, _251 * _101) - 1.0))) * _111) + u_cameraPlaneParams.u_clipZNear, 1.0);
+        float3 _324 = (_236 / float4(_236.w)).xyz;
+        float4 _361 = mix(float4(_214, _90), float4(mix(_214.xyz, u_fragParams.u_outlineColour.xyz, float3(u_fragParams.u_outlineColour.w)), fast::min(fast::min(fast::min(_242, _245), _248), _251)), float4(1.0 - (((step(length(_324 - (_266 / float4(_266.w)).xyz), u_fragParams.u_outlineParams.y) * step(length(_324 - (_281 / float4(_281.w)).xyz), u_fragParams.u_outlineParams.y)) * step(length(_324 - (_296 / float4(_296.w)).xyz), u_fragParams.u_outlineParams.y)) * step(length(_324 - (_311 / float4(_311.w)).xyz), u_fragParams.u_outlineParams.y))));
+        _364 = _361.w;
+        _365 = float4(_361.x, _361.y, _361.z, _81.w);
     }
     else
     {
-        _357 = _83;
-        _358 = float4(_207.x, _207.y, _207.z, _78.w);
+        _364 = _90;
+        _365 = float4(_214.x, _214.y, _214.z, _81.w);
     }
-    float4 _363 = float4(_358.xyz, 1.0);
-    _363.w = _357;
-    out.out_var_SV_Target = _363;
-    out.gl_FragDepth = _357;
+    out.out_var_SV_Target0 = float4(_365.xyz, 1.0);
+    out.out_var_SV_Target1 = _85;
+    out.gl_FragDepth = _364;
     return out;
 }
 

--- a/src/gl/metal/shaders/desktop/waterFragmentShader.metal
+++ b/src/gl/metal/shaders/desktop/waterFragmentShader.metal
@@ -20,7 +20,8 @@ struct type_u_EveryFrameFrag
 
 struct main0_out
 {
-    float4 out_var_SV_Target [[color(0)]];
+    float4 out_var_SV_Target0 [[color(0)]];
+    float4 out_var_SV_Target1 [[color(1)]];
     float gl_FragDepth [[depth(any)]];
 };
 
@@ -36,16 +37,15 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], constant type_u_EveryFrameFrag& u_EveryFrameFrag [[buffer(1)]], texture2d<float> normalMapTexture [[texture(0)]], texture2d<float> skyboxTexture [[texture(1)]], sampler normalMapSampler [[sampler(0)]], sampler skyboxSampler [[sampler(1)]])
 {
     main0_out out = {};
-    float3 _90 = normalize(((normalMapTexture.sample(normalMapSampler, in.in_var_TEXCOORD0).xyz * float3(2.0)) - float3(1.0)) + ((normalMapTexture.sample(normalMapSampler, in.in_var_TEXCOORD1).xyz * float3(2.0)) - float3(1.0)));
-    float3 _92 = normalize(in.in_var_COLOR0.xyz);
-    float3 _108 = normalize((u_EveryFrameFrag.u_eyeNormalMatrix * float4(_90, 0.0)).xyz);
-    float3 _110 = normalize(reflect(_92, _108));
-    float3 _134 = normalize((u_EveryFrameFrag.u_inverseViewMatrix * float4(_110, 0.0)).xyz);
-    float _162 = log2(in.in_var_TEXCOORD2.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
-    float4 _165 = (float4(mix(skyboxTexture.sample(skyboxSampler, (float2(atan2(_134.x, _134.y) + 3.1415927410125732421875, acos(_134.z)) * float2(0.15915493667125701904296875, 0.3183098733425140380859375))).xyz, in.in_var_COLOR1.xyz * mix(float3(1.0, 1.0, 0.60000002384185791015625), float3(0.3499999940395355224609375), float3(pow(fast::max(0.0, _90.z), 5.0))), float3(((dot(_108, _92) * (-0.5)) + 0.5) * 0.75)) + float3(pow(abs(dot(_110, normalize((u_EveryFrameFrag.u_eyeNormalMatrix * float4(normalize(u_EveryFrameFrag.u_specularDir.xyz), 0.0)).xyz))), 50.0) * 0.5), 1.0) * 0.300000011920928955078125) + float4(0.20000000298023223876953125, 0.4000000059604644775390625, 0.699999988079071044921875, 1.0);
-    _165.w = _162;
-    out.out_var_SV_Target = _165;
-    out.gl_FragDepth = _162;
+    float3 _91 = normalize(((normalMapTexture.sample(normalMapSampler, in.in_var_TEXCOORD0).xyz * float3(2.0)) - float3(1.0)) + ((normalMapTexture.sample(normalMapSampler, in.in_var_TEXCOORD1).xyz * float3(2.0)) - float3(1.0)));
+    float3 _93 = normalize(in.in_var_COLOR0.xyz);
+    float3 _109 = normalize((u_EveryFrameFrag.u_eyeNormalMatrix * float4(_91, 0.0)).xyz);
+    float3 _111 = normalize(reflect(_93, _109));
+    float3 _135 = normalize((u_EveryFrameFrag.u_inverseViewMatrix * float4(_111, 0.0)).xyz);
+    float _163 = log2(in.in_var_TEXCOORD2.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    out.out_var_SV_Target0 = (float4(mix(skyboxTexture.sample(skyboxSampler, (float2(atan2(_135.x, _135.y) + 3.1415927410125732421875, acos(_135.z)) * float2(0.15915493667125701904296875, 0.3183098733425140380859375))).xyz, in.in_var_COLOR1.xyz * mix(float3(1.0, 1.0, 0.60000002384185791015625), float3(0.3499999940395355224609375), float3(pow(fast::max(0.0, _91.z), 5.0))), float3(((dot(_109, _93) * (-0.5)) + 0.5) * 0.75)) + float3(pow(abs(dot(_111, normalize((u_EveryFrameFrag.u_eyeNormalMatrix * float4(normalize(u_EveryFrameFrag.u_specularDir.xyz), 0.0)).xyz))), 50.0) * 0.5), 1.0) * 0.300000011920928955078125) + float4(0.20000000298023223876953125, 0.4000000059604644775390625, 0.699999988079071044921875, 1.0);
+    out.out_var_SV_Target1 = float4(0.0, 0.0, 0.0, _163);
+    out.gl_FragDepth = _163;
     return out;
 }
 

--- a/src/gl/metal/shaders/mobile/atmosphereFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/atmosphereFragmentShader.metal
@@ -22,11 +22,12 @@ struct type_u_fragParams
     float4x4 u_inverseProjection;
 };
 
-constant float4 _105 = {};
+constant float4 _108 = {};
 
 struct main0_out
 {
-    float4 out_var_SV_Target [[color(0)]];
+    float4 out_var_SV_Target0 [[color(0)]];
+    float4 out_var_SV_Target1 [[color(1)]];
     float gl_FragDepth [[depth(any)]];
 };
 
@@ -36,528 +37,530 @@ struct main0_in
     float3 in_var_TEXCOORD1 [[user(locn1)]];
 };
 
-fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], constant type_u_fragParams& u_fragParams [[buffer(1)]], texture2d<float> transmittanceTexture [[texture(0)]], texture3d<float> scatteringTexture [[texture(1)]], texture2d<float> irradianceTexture [[texture(2)]], texture2d<float> sceneColourTexture [[texture(3)]], texture2d<float> sceneDepthTexture [[texture(4)]], sampler transmittanceSampler [[sampler(0)]], sampler scatteringSampler [[sampler(1)]], sampler irradianceSampler [[sampler(2)]], sampler sceneColourSampler [[sampler(3)]], sampler sceneDepthSampler [[sampler(4)]])
+fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], constant type_u_fragParams& u_fragParams [[buffer(1)]], texture2d<float> transmittanceTexture [[texture(0)]], texture3d<float> scatteringTexture [[texture(1)]], texture2d<float> irradianceTexture [[texture(2)]], texture2d<float> sceneColourTexture [[texture(3)]], texture2d<float> sceneNormalTexture [[texture(4)]], texture2d<float> sceneDepthTexture [[texture(5)]], sampler transmittanceSampler [[sampler(0)]], sampler scatteringSampler [[sampler(1)]], sampler irradianceSampler [[sampler(2)]], sampler sceneColourSampler [[sampler(3)]], sampler sceneNormalSampler [[sampler(4)]], sampler sceneDepthSampler [[sampler(5)]])
 {
     main0_out out = {};
-    float _113 = u_fragParams.u_earthCenter.w + 60000.0;
-    float3 _126 = normalize(in.in_var_TEXCOORD1);
-    float4 _130 = sceneDepthTexture.sample(sceneDepthSampler, in.in_var_TEXCOORD0);
-    float _131 = _130.x;
-    float _136 = u_cameraPlaneParams.s_CameraFarPlane - u_cameraPlaneParams.s_CameraNearPlane;
-    float4 _151 = sceneColourTexture.sample(sceneColourSampler, in.in_var_TEXCOORD0);
-    float3 _154 = pow(abs(_151.xyz), float3(2.2000000476837158203125));
-    float _160 = ((2.0 * u_cameraPlaneParams.s_CameraNearPlane) / ((u_cameraPlaneParams.s_CameraFarPlane + u_cameraPlaneParams.s_CameraNearPlane) - (((u_cameraPlaneParams.s_CameraFarPlane / _136) + (((u_cameraPlaneParams.s_CameraFarPlane * u_cameraPlaneParams.s_CameraNearPlane) / (u_cameraPlaneParams.s_CameraNearPlane - u_cameraPlaneParams.s_CameraFarPlane)) / (pow(2.0, _131 * log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0)) - 1.0))) * _136))) * u_cameraPlaneParams.s_CameraFarPlane;
-    bool _163 = _131 < 0.64999997615814208984375;
-    float3 _754;
-    if (_163)
+    float _116 = u_fragParams.u_earthCenter.w + 60000.0;
+    float3 _129 = normalize(in.in_var_TEXCOORD1);
+    float4 _133 = sceneColourTexture.sample(sceneColourSampler, in.in_var_TEXCOORD0);
+    float4 _137 = sceneNormalTexture.sample(sceneNormalSampler, in.in_var_TEXCOORD0);
+    float4 _141 = sceneDepthTexture.sample(sceneDepthSampler, in.in_var_TEXCOORD0);
+    float _142 = _141.x;
+    float _147 = u_cameraPlaneParams.s_CameraFarPlane - u_cameraPlaneParams.s_CameraNearPlane;
+    float3 _161 = pow(abs(_133.xyz), float3(2.2000000476837158203125));
+    float _167 = ((2.0 * u_cameraPlaneParams.s_CameraNearPlane) / ((u_cameraPlaneParams.s_CameraFarPlane + u_cameraPlaneParams.s_CameraNearPlane) - (((u_cameraPlaneParams.s_CameraFarPlane / _147) + (((u_cameraPlaneParams.s_CameraFarPlane * u_cameraPlaneParams.s_CameraNearPlane) / (u_cameraPlaneParams.s_CameraNearPlane - u_cameraPlaneParams.s_CameraFarPlane)) / (pow(2.0, _142 * log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0)) - 1.0))) * _147))) * u_cameraPlaneParams.s_CameraFarPlane;
+    bool _170 = _142 < 0.64999997615814208984375;
+    float3 _761;
+    if (_170)
     {
-        float3 _166 = (u_fragParams.u_camera.xyz + (_126 * _160)) - u_fragParams.u_earthCenter.xyz;
-        float3 _167 = normalize(_166);
-        float _170 = length(_166);
-        float _172 = dot(_166, u_fragParams.u_sunDirection.xyz) / _170;
-        float _174 = _113 - u_fragParams.u_earthCenter.w;
-        float4 _185 = irradianceTexture.sample(irradianceSampler, float2(0.0078125 + (((_172 * 0.5) + 0.5) * 0.984375), 0.03125 + (((_170 - u_fragParams.u_earthCenter.w) / _174) * 0.9375)));
-        float _192 = u_fragParams.u_earthCenter.w / _170;
-        float _198 = _113 * _113;
-        float _199 = u_fragParams.u_earthCenter.w * u_fragParams.u_earthCenter.w;
-        float _201 = sqrt(_198 - _199);
-        float _202 = _170 * _170;
-        float _205 = sqrt(fast::max(_202 - _199, 0.0));
-        float _216 = _113 - _170;
-        float4 _229 = transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_170) * _172) + sqrt(fast::max((_202 * ((_172 * _172) - 1.0)) + _198, 0.0)), 0.0) - _216) / ((_205 + _201) - _216)) * 0.99609375), 0.0078125 + ((_205 / _201) * 0.984375)));
-        float _248 = mix(_160 * 0.64999997615814208984375, 0.0, pow(_131 * 1.53846156597137451171875, 8.0));
-        float3 _249 = u_fragParams.u_camera.xyz - u_fragParams.u_earthCenter.xyz;
-        float3 _252 = normalize(_166 - _249);
-        float _253 = length(_249);
-        float _254 = dot(_249, _252);
-        float _261 = (-_254) - sqrt(((_254 * _254) - (_253 * _253)) + _198);
-        bool _262 = _261 > 0.0;
-        float3 _268;
-        float _269;
-        if (_262)
+        float3 _173 = (u_fragParams.u_camera.xyz + (_129 * _167)) - u_fragParams.u_earthCenter.xyz;
+        float3 _174 = normalize(_173);
+        float _177 = length(_173);
+        float _179 = dot(_173, u_fragParams.u_sunDirection.xyz) / _177;
+        float _181 = _116 - u_fragParams.u_earthCenter.w;
+        float4 _192 = irradianceTexture.sample(irradianceSampler, float2(0.0078125 + (((_179 * 0.5) + 0.5) * 0.984375), 0.03125 + (((_177 - u_fragParams.u_earthCenter.w) / _181) * 0.9375)));
+        float _199 = u_fragParams.u_earthCenter.w / _177;
+        float _205 = _116 * _116;
+        float _206 = u_fragParams.u_earthCenter.w * u_fragParams.u_earthCenter.w;
+        float _208 = sqrt(_205 - _206);
+        float _209 = _177 * _177;
+        float _212 = sqrt(fast::max(_209 - _206, 0.0));
+        float _223 = _116 - _177;
+        float4 _236 = transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_177) * _179) + sqrt(fast::max((_209 * ((_179 * _179) - 1.0)) + _205, 0.0)), 0.0) - _223) / ((_212 + _208) - _223)) * 0.99609375), 0.0078125 + ((_212 / _208) * 0.984375)));
+        float _255 = mix(_167 * 0.64999997615814208984375, 0.0, pow(_142 * 1.53846156597137451171875, 8.0));
+        float3 _256 = u_fragParams.u_camera.xyz - u_fragParams.u_earthCenter.xyz;
+        float3 _259 = normalize(_173 - _256);
+        float _260 = length(_256);
+        float _261 = dot(_256, _259);
+        float _268 = (-_261) - sqrt(((_261 * _261) - (_260 * _260)) + _205);
+        bool _269 = _268 > 0.0;
+        float3 _275;
+        float _276;
+        if (_269)
         {
-            _268 = _249 + (_252 * _261);
-            _269 = _254 + _261;
+            _275 = _256 + (_259 * _268);
+            _276 = _261 + _268;
         }
         else
         {
-            _268 = _249;
-            _269 = _254;
+            _275 = _256;
+            _276 = _261;
         }
-        float _288;
-        float _270 = _262 ? _113 : _253;
-        float _271 = _269 / _270;
-        float _272 = dot(_268, u_fragParams.u_sunDirection.xyz);
-        float _273 = _272 / _270;
-        float _274 = dot(_252, u_fragParams.u_sunDirection.xyz);
-        float _276 = length(_166 - _268);
-        float _278 = _270 * _270;
-        float _281 = _278 * ((_271 * _271) - 1.0);
-        bool _284 = (_271 < 0.0) && ((_281 + _199) >= 0.0);
-        float3 _413;
+        float _295;
+        float _277 = _269 ? _116 : _260;
+        float _278 = _276 / _277;
+        float _279 = dot(_275, u_fragParams.u_sunDirection.xyz);
+        float _280 = _279 / _277;
+        float _281 = dot(_259, u_fragParams.u_sunDirection.xyz);
+        float _283 = length(_173 - _275);
+        float _285 = _277 * _277;
+        float _288 = _285 * ((_278 * _278) - 1.0);
+        bool _291 = (_278 < 0.0) && ((_288 + _206) >= 0.0);
+        float3 _420;
         switch (0u)
         {
             default:
             {
-                _288 = (2.0 * _270) * _271;
-                float _293 = fast::clamp(sqrt((_276 * (_276 + _288)) + _278), u_fragParams.u_earthCenter.w, _113);
-                float _296 = fast::clamp((_269 + _276) / _293, -1.0, 1.0);
-                if (_284)
+                _295 = (2.0 * _277) * _278;
+                float _300 = fast::clamp(sqrt((_283 * (_283 + _295)) + _285), u_fragParams.u_earthCenter.w, _116);
+                float _303 = fast::clamp((_276 + _283) / _300, -1.0, 1.0);
+                if (_291)
                 {
-                    float _354 = -_296;
-                    float _355 = _293 * _293;
-                    float _358 = sqrt(fast::max(_355 - _199, 0.0));
-                    float _369 = _113 - _293;
-                    float _383 = -_271;
-                    float _386 = sqrt(fast::max(_278 - _199, 0.0));
-                    float _397 = _113 - _270;
-                    _413 = fast::min(transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_293) * _354) + sqrt(fast::max((_355 * ((_354 * _354) - 1.0)) + _198, 0.0)), 0.0) - _369) / ((_358 + _201) - _369)) * 0.99609375), 0.0078125 + ((_358 / _201) * 0.984375))).xyz / transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_270) * _383) + sqrt(fast::max((_278 * ((_383 * _383) - 1.0)) + _198, 0.0)), 0.0) - _397) / ((_386 + _201) - _397)) * 0.99609375), 0.0078125 + ((_386 / _201) * 0.984375))).xyz, float3(1.0));
+                    float _361 = -_303;
+                    float _362 = _300 * _300;
+                    float _365 = sqrt(fast::max(_362 - _206, 0.0));
+                    float _376 = _116 - _300;
+                    float _390 = -_278;
+                    float _393 = sqrt(fast::max(_285 - _206, 0.0));
+                    float _404 = _116 - _277;
+                    _420 = fast::min(transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_300) * _361) + sqrt(fast::max((_362 * ((_361 * _361) - 1.0)) + _205, 0.0)), 0.0) - _376) / ((_365 + _208) - _376)) * 0.99609375), 0.0078125 + ((_365 / _208) * 0.984375))).xyz / transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_277) * _390) + sqrt(fast::max((_285 * ((_390 * _390) - 1.0)) + _205, 0.0)), 0.0) - _404) / ((_393 + _208) - _404)) * 0.99609375), 0.0078125 + ((_393 / _208) * 0.984375))).xyz, float3(1.0));
                     break;
                 }
                 else
                 {
-                    float _302 = sqrt(fast::max(_278 - _199, 0.0));
-                    float _310 = _113 - _270;
-                    float _324 = _293 * _293;
-                    float _327 = sqrt(fast::max(_324 - _199, 0.0));
-                    float _338 = _113 - _293;
-                    _413 = fast::min(transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_270) * _271) + sqrt(fast::max(_281 + _198, 0.0)), 0.0) - _310) / ((_302 + _201) - _310)) * 0.99609375), 0.0078125 + ((_302 / _201) * 0.984375))).xyz / transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_293) * _296) + sqrt(fast::max((_324 * ((_296 * _296) - 1.0)) + _198, 0.0)), 0.0) - _338) / ((_327 + _201) - _338)) * 0.99609375), 0.0078125 + ((_327 / _201) * 0.984375))).xyz, float3(1.0));
+                    float _309 = sqrt(fast::max(_285 - _206, 0.0));
+                    float _317 = _116 - _277;
+                    float _331 = _300 * _300;
+                    float _334 = sqrt(fast::max(_331 - _206, 0.0));
+                    float _345 = _116 - _300;
+                    _420 = fast::min(transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_277) * _278) + sqrt(fast::max(_288 + _205, 0.0)), 0.0) - _317) / ((_309 + _208) - _317)) * 0.99609375), 0.0078125 + ((_309 / _208) * 0.984375))).xyz / transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_300) * _303) + sqrt(fast::max((_331 * ((_303 * _303) - 1.0)) + _205, 0.0)), 0.0) - _345) / ((_334 + _208) - _345)) * 0.99609375), 0.0078125 + ((_334 / _208) * 0.984375))).xyz, float3(1.0));
                     break;
                 }
             }
         }
-        float _416 = sqrt(fast::max(_278 - _199, 0.0));
-        float _417 = _416 / _201;
-        float _419 = 0.015625 + (_417 * 0.96875);
-        float _422 = ((_269 * _269) - _278) + _199;
-        float _455;
-        if (_284)
+        float _423 = sqrt(fast::max(_285 - _206, 0.0));
+        float _424 = _423 / _208;
+        float _426 = 0.015625 + (_424 * 0.96875);
+        float _429 = ((_276 * _276) - _285) + _206;
+        float _462;
+        if (_291)
         {
-            float _445 = _270 - u_fragParams.u_earthCenter.w;
-            _455 = 0.5 - (0.5 * (0.0078125 + (((_416 == _445) ? 0.0 : ((((-_269) - sqrt(fast::max(_422, 0.0))) - _445) / (_416 - _445))) * 0.984375)));
+            float _452 = _277 - u_fragParams.u_earthCenter.w;
+            _462 = 0.5 - (0.5 * (0.0078125 + (((_423 == _452) ? 0.0 : ((((-_276) - sqrt(fast::max(_429, 0.0))) - _452) / (_423 - _452))) * 0.984375)));
         }
         else
         {
-            float _432 = _113 - _270;
-            _455 = 0.5 + (0.5 * (0.0078125 + (((((-_269) + sqrt(fast::max(_422 + (_201 * _201), 0.0))) - _432) / ((_416 + _201) - _432)) * 0.984375)));
+            float _439 = _116 - _277;
+            _462 = 0.5 + (0.5 * (0.0078125 + (((((-_276) + sqrt(fast::max(_429 + (_208 * _208), 0.0))) - _439) / ((_423 + _208) - _439)) * 0.984375)));
         }
-        float _460 = -u_fragParams.u_earthCenter.w;
-        float _467 = _201 - _174;
-        float _468 = (fast::max((_460 * _273) + sqrt(fast::max((_199 * ((_273 * _273) - 1.0)) + _198, 0.0)), 0.0) - _174) / _467;
-        float _470 = (0.415823996067047119140625 * u_fragParams.u_earthCenter.w) / _467;
-        float _477 = 0.015625 + ((fast::max(1.0 - (_468 / _470), 0.0) / (1.0 + _468)) * 0.96875);
-        float _479 = (_274 + 1.0) * 3.5;
-        float _480 = floor(_479);
-        float _481 = _479 - _480;
-        float _485 = _480 + 1.0;
-        float4 _491 = scatteringTexture.sample(scatteringSampler, float3((_480 + _477) * 0.125, _455, _419));
-        float _492 = 1.0 - _481;
-        float4 _495 = scatteringTexture.sample(scatteringSampler, float3((_485 + _477) * 0.125, _455, _419));
-        float4 _497 = (_491 * _492) + (_495 * _481);
-        float3 _498 = _497.xyz;
-        float3 _511;
+        float _467 = -u_fragParams.u_earthCenter.w;
+        float _474 = _208 - _181;
+        float _475 = (fast::max((_467 * _280) + sqrt(fast::max((_206 * ((_280 * _280) - 1.0)) + _205, 0.0)), 0.0) - _181) / _474;
+        float _477 = (0.415823996067047119140625 * u_fragParams.u_earthCenter.w) / _474;
+        float _484 = 0.015625 + ((fast::max(1.0 - (_475 / _477), 0.0) / (1.0 + _475)) * 0.96875);
+        float _486 = (_281 + 1.0) * 3.5;
+        float _487 = floor(_486);
+        float _488 = _486 - _487;
+        float _492 = _487 + 1.0;
+        float4 _498 = scatteringTexture.sample(scatteringSampler, float3((_487 + _484) * 0.125, _462, _426));
+        float _499 = 1.0 - _488;
+        float4 _502 = scatteringTexture.sample(scatteringSampler, float3((_492 + _484) * 0.125, _462, _426));
+        float4 _504 = (_498 * _499) + (_502 * _488);
+        float3 _505 = _504.xyz;
+        float3 _518;
         switch (0u)
         {
             default:
             {
-                float _501 = _497.x;
-                if (_501 == 0.0)
+                float _508 = _504.x;
+                if (_508 == 0.0)
                 {
-                    _511 = float3(0.0);
+                    _518 = float3(0.0);
                     break;
                 }
-                _511 = (((_498 * _497.w) / float3(_501)) * 1.5) * float3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
+                _518 = (((_505 * _504.w) / float3(_508)) * 1.5) * float3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
                 break;
             }
         }
-        float _513 = fast::max(_276 - _248, 0.0);
-        float _518 = fast::clamp(sqrt((_513 * (_513 + _288)) + _278), u_fragParams.u_earthCenter.w, _113);
-        float _519 = _269 + _513;
-        float _522 = (_272 + (_513 * _274)) / _518;
-        float _523 = _518 * _518;
-        float _526 = sqrt(fast::max(_523 - _199, 0.0));
-        float _527 = _526 / _201;
-        float _529 = 0.015625 + (_527 * 0.96875);
-        float _532 = ((_519 * _519) - _523) + _199;
-        float _565;
-        if (_284)
+        float _520 = fast::max(_283 - _255, 0.0);
+        float _525 = fast::clamp(sqrt((_520 * (_520 + _295)) + _285), u_fragParams.u_earthCenter.w, _116);
+        float _526 = _276 + _520;
+        float _529 = (_279 + (_520 * _281)) / _525;
+        float _530 = _525 * _525;
+        float _533 = sqrt(fast::max(_530 - _206, 0.0));
+        float _534 = _533 / _208;
+        float _536 = 0.015625 + (_534 * 0.96875);
+        float _539 = ((_526 * _526) - _530) + _206;
+        float _572;
+        if (_291)
         {
-            float _555 = _518 - u_fragParams.u_earthCenter.w;
-            _565 = 0.5 - (0.5 * (0.0078125 + (((_526 == _555) ? 0.0 : ((((-_519) - sqrt(fast::max(_532, 0.0))) - _555) / (_526 - _555))) * 0.984375)));
+            float _562 = _525 - u_fragParams.u_earthCenter.w;
+            _572 = 0.5 - (0.5 * (0.0078125 + (((_533 == _562) ? 0.0 : ((((-_526) - sqrt(fast::max(_539, 0.0))) - _562) / (_533 - _562))) * 0.984375)));
         }
         else
         {
-            float _542 = _113 - _518;
-            _565 = 0.5 + (0.5 * (0.0078125 + (((((-_519) + sqrt(fast::max(_532 + (_201 * _201), 0.0))) - _542) / ((_526 + _201) - _542)) * 0.984375)));
+            float _549 = _116 - _525;
+            _572 = 0.5 + (0.5 * (0.0078125 + (((((-_526) + sqrt(fast::max(_539 + (_208 * _208), 0.0))) - _549) / ((_533 + _208) - _549)) * 0.984375)));
         }
-        float _576 = (fast::max((_460 * _522) + sqrt(fast::max((_199 * ((_522 * _522) - 1.0)) + _198, 0.0)), 0.0) - _174) / _467;
-        float _583 = 0.015625 + ((fast::max(1.0 - (_576 / _470), 0.0) / (1.0 + _576)) * 0.96875);
-        float4 _591 = scatteringTexture.sample(scatteringSampler, float3((_480 + _583) * 0.125, _565, _529));
-        float4 _594 = scatteringTexture.sample(scatteringSampler, float3((_485 + _583) * 0.125, _565, _529));
-        float4 _596 = (_591 * _492) + (_594 * _481);
-        float3 _597 = _596.xyz;
-        float3 _610;
+        float _583 = (fast::max((_467 * _529) + sqrt(fast::max((_206 * ((_529 * _529) - 1.0)) + _205, 0.0)), 0.0) - _181) / _474;
+        float _590 = 0.015625 + ((fast::max(1.0 - (_583 / _477), 0.0) / (1.0 + _583)) * 0.96875);
+        float4 _598 = scatteringTexture.sample(scatteringSampler, float3((_487 + _590) * 0.125, _572, _536));
+        float4 _601 = scatteringTexture.sample(scatteringSampler, float3((_492 + _590) * 0.125, _572, _536));
+        float4 _603 = (_598 * _499) + (_601 * _488);
+        float3 _604 = _603.xyz;
+        float3 _617;
         switch (0u)
         {
             default:
             {
-                float _600 = _596.x;
-                if (_600 == 0.0)
+                float _607 = _603.x;
+                if (_607 == 0.0)
                 {
-                    _610 = float3(0.0);
+                    _617 = float3(0.0);
                     break;
                 }
-                _610 = (((_597 * _596.w) / float3(_600)) * 1.5) * float3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
+                _617 = (((_604 * _603.w) / float3(_607)) * 1.5) * float3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
                 break;
             }
         }
-        float3 _717;
-        if (_248 > 0.0)
+        float3 _724;
+        if (_255 > 0.0)
         {
-            float3 _716;
+            float3 _723;
             switch (0u)
             {
                 default:
                 {
-                    float _617 = fast::clamp(_519 / _518, -1.0, 1.0);
-                    if (_284)
+                    float _624 = fast::clamp(_526 / _525, -1.0, 1.0);
+                    if (_291)
                     {
-                        float _666 = -_617;
-                        float _677 = _113 - _518;
-                        float _690 = -_271;
-                        float _701 = _113 - _270;
-                        _716 = fast::min(transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_518) * _666) + sqrt(fast::max((_523 * ((_666 * _666) - 1.0)) + _198, 0.0)), 0.0) - _677) / ((_526 + _201) - _677)) * 0.99609375), 0.0078125 + (_527 * 0.984375))).xyz / transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_270) * _690) + sqrt(fast::max((_278 * ((_690 * _690) - 1.0)) + _198, 0.0)), 0.0) - _701) / ((_416 + _201) - _701)) * 0.99609375), 0.0078125 + (_417 * 0.984375))).xyz, float3(1.0));
+                        float _673 = -_624;
+                        float _684 = _116 - _525;
+                        float _697 = -_278;
+                        float _708 = _116 - _277;
+                        _723 = fast::min(transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_525) * _673) + sqrt(fast::max((_530 * ((_673 * _673) - 1.0)) + _205, 0.0)), 0.0) - _684) / ((_533 + _208) - _684)) * 0.99609375), 0.0078125 + (_534 * 0.984375))).xyz / transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_277) * _697) + sqrt(fast::max((_285 * ((_697 * _697) - 1.0)) + _205, 0.0)), 0.0) - _708) / ((_423 + _208) - _708)) * 0.99609375), 0.0078125 + (_424 * 0.984375))).xyz, float3(1.0));
                         break;
                     }
                     else
                     {
-                        float _628 = _113 - _270;
-                        float _651 = _113 - _518;
-                        _716 = fast::min(transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_270) * _271) + sqrt(fast::max(_281 + _198, 0.0)), 0.0) - _628) / ((_416 + _201) - _628)) * 0.99609375), 0.0078125 + (_417 * 0.984375))).xyz / transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_518) * _617) + sqrt(fast::max((_523 * ((_617 * _617) - 1.0)) + _198, 0.0)), 0.0) - _651) / ((_526 + _201) - _651)) * 0.99609375), 0.0078125 + (_527 * 0.984375))).xyz, float3(1.0));
+                        float _635 = _116 - _277;
+                        float _658 = _116 - _525;
+                        _723 = fast::min(transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_277) * _278) + sqrt(fast::max(_288 + _205, 0.0)), 0.0) - _635) / ((_423 + _208) - _635)) * 0.99609375), 0.0078125 + (_424 * 0.984375))).xyz / transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_525) * _624) + sqrt(fast::max((_530 * ((_624 * _624) - 1.0)) + _205, 0.0)), 0.0) - _658) / ((_533 + _208) - _658)) * 0.99609375), 0.0078125 + (_534 * 0.984375))).xyz, float3(1.0));
                         break;
                     }
                 }
             }
-            _717 = _716;
+            _724 = _723;
         }
         else
         {
-            _717 = _413;
+            _724 = _420;
         }
-        float3 _719 = _498 - (_717 * _597);
-        float3 _721 = _511 - (_717 * _610);
-        float _722 = _721.x;
-        float _723 = _719.x;
-        float3 _738;
+        float3 _726 = _505 - (_724 * _604);
+        float3 _728 = _518 - (_724 * _617);
+        float _729 = _728.x;
+        float _730 = _726.x;
+        float3 _745;
         switch (0u)
         {
             default:
             {
-                if (_723 == 0.0)
+                if (_730 == 0.0)
                 {
-                    _738 = float3(0.0);
+                    _745 = float3(0.0);
                     break;
                 }
-                _738 = (((float4(_723, _719.yz, _722).xyz * _722) / float3(_723)) * 1.5) * float3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
+                _745 = (((float4(_730, _726.yz, _729).xyz * _729) / float3(_730)) * 1.5) * float3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
                 break;
             }
         }
-        float _742 = 1.0 + (_274 * _274);
-        _754 = (((_154.xyz * 0.3183098733425140380859375) * ((float3(1.47399997711181640625, 1.85039997100830078125, 1.91198003292083740234375) * fast::max((_229.xyz * smoothstep(_192 * (-0.004674999974668025970458984375), _192 * 0.004674999974668025970458984375, _172 - (-sqrt(fast::max(1.0 - (_192 * _192), 0.0))))) * fast::max(dot(_167, u_fragParams.u_sunDirection.xyz), 0.0), float3(0.001000000047497451305389404296875))) + ((_185.xyz * (1.0 + (dot(_167, _166) / _170))) * 0.5))) * _413) + ((_719 * (0.0596831031143665313720703125 * _742)) + ((_738 * smoothstep(0.0, 0.00999999977648258209228515625, _273)) * ((0.01627720706164836883544921875 * _742) / pow(1.6400001049041748046875 - (1.60000002384185791015625 * _274), 1.5))));
+        float _749 = 1.0 + (_281 * _281);
+        _761 = (((_161.xyz * 0.3183098733425140380859375) * ((float3(1.47399997711181640625, 1.85039997100830078125, 1.91198003292083740234375) * fast::max((_236.xyz * smoothstep(_199 * (-0.004674999974668025970458984375), _199 * 0.004674999974668025970458984375, _179 - (-sqrt(fast::max(1.0 - (_199 * _199), 0.0))))) * fast::max(dot(_174, u_fragParams.u_sunDirection.xyz), 0.0), float3(0.001000000047497451305389404296875))) + ((_192.xyz * (1.0 + (dot(_174, _173) / _177))) * 0.5))) * _420) + ((_726 * (0.0596831031143665313720703125 * _749)) + ((_745 * smoothstep(0.0, 0.00999999977648258209228515625, _280)) * ((0.01627720706164836883544921875 * _749) / pow(1.6400001049041748046875 - (1.60000002384185791015625 * _281), 1.5))));
     }
     else
     {
-        _754 = float3(0.0);
+        _761 = float3(0.0);
     }
-    float3 _756 = u_fragParams.u_camera.xyz - u_fragParams.u_earthCenter.xyz;
-    float _757 = dot(_756, _126);
-    float _759 = _757 * _757;
-    float _761 = -_757;
-    float _762 = u_fragParams.u_earthCenter.w * u_fragParams.u_earthCenter.w;
-    float _765 = _761 - sqrt(_762 - (dot(_756, _756) - _759));
-    bool _766 = _765 > 0.0;
-    float3 _1245;
-    if (_766)
+    float3 _763 = u_fragParams.u_camera.xyz - u_fragParams.u_earthCenter.xyz;
+    float _764 = dot(_763, _129);
+    float _766 = _764 * _764;
+    float _768 = -_764;
+    float _769 = u_fragParams.u_earthCenter.w * u_fragParams.u_earthCenter.w;
+    float _772 = _768 - sqrt(_769 - (dot(_763, _763) - _766));
+    bool _773 = _772 > 0.0;
+    float3 _1252;
+    if (_773)
     {
-        float3 _771 = (u_fragParams.u_camera.xyz + (_126 * _765)) - u_fragParams.u_earthCenter.xyz;
-        float3 _772 = normalize(_771);
-        float _775 = length(_771);
-        float _777 = dot(_771, u_fragParams.u_sunDirection.xyz) / _775;
-        float _779 = _113 - u_fragParams.u_earthCenter.w;
-        float4 _790 = irradianceTexture.sample(irradianceSampler, float2(0.0078125 + (((_777 * 0.5) + 0.5) * 0.984375), 0.03125 + (((_775 - u_fragParams.u_earthCenter.w) / _779) * 0.9375)));
-        float _797 = u_fragParams.u_earthCenter.w / _775;
-        float _803 = _113 * _113;
-        float _805 = sqrt(_803 - _762);
-        float _806 = _775 * _775;
-        float _809 = sqrt(fast::max(_806 - _762, 0.0));
-        float _820 = _113 - _775;
-        float4 _833 = transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_775) * _777) + sqrt(fast::max((_806 * ((_777 * _777) - 1.0)) + _803, 0.0)), 0.0) - _820) / ((_809 + _805) - _820)) * 0.99609375), 0.0078125 + ((_809 / _805) * 0.984375)));
-        float3 _851 = normalize(_771 - _756);
-        float _852 = length(_756);
-        float _853 = dot(_756, _851);
-        float _860 = (-_853) - sqrt(((_853 * _853) - (_852 * _852)) + _803);
-        bool _861 = _860 > 0.0;
-        float3 _867;
-        float _868;
-        if (_861)
+        float3 _778 = (u_fragParams.u_camera.xyz + (_129 * _772)) - u_fragParams.u_earthCenter.xyz;
+        float3 _779 = normalize(_778);
+        float _782 = length(_778);
+        float _784 = dot(_778, u_fragParams.u_sunDirection.xyz) / _782;
+        float _786 = _116 - u_fragParams.u_earthCenter.w;
+        float4 _797 = irradianceTexture.sample(irradianceSampler, float2(0.0078125 + (((_784 * 0.5) + 0.5) * 0.984375), 0.03125 + (((_782 - u_fragParams.u_earthCenter.w) / _786) * 0.9375)));
+        float _804 = u_fragParams.u_earthCenter.w / _782;
+        float _810 = _116 * _116;
+        float _812 = sqrt(_810 - _769);
+        float _813 = _782 * _782;
+        float _816 = sqrt(fast::max(_813 - _769, 0.0));
+        float _827 = _116 - _782;
+        float4 _840 = transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_782) * _784) + sqrt(fast::max((_813 * ((_784 * _784) - 1.0)) + _810, 0.0)), 0.0) - _827) / ((_816 + _812) - _827)) * 0.99609375), 0.0078125 + ((_816 / _812) * 0.984375)));
+        float3 _858 = normalize(_778 - _763);
+        float _859 = length(_763);
+        float _860 = dot(_763, _858);
+        float _867 = (-_860) - sqrt(((_860 * _860) - (_859 * _859)) + _810);
+        bool _868 = _867 > 0.0;
+        float3 _874;
+        float _875;
+        if (_868)
         {
-            _867 = _756 + (_851 * _860);
-            _868 = _853 + _860;
+            _874 = _763 + (_858 * _867);
+            _875 = _860 + _867;
         }
         else
         {
-            _867 = _756;
-            _868 = _853;
+            _874 = _763;
+            _875 = _860;
         }
-        float _887;
-        float _869 = _861 ? _113 : _852;
-        float _870 = _868 / _869;
-        float _871 = dot(_867, u_fragParams.u_sunDirection.xyz);
-        float _872 = _871 / _869;
-        float _873 = dot(_851, u_fragParams.u_sunDirection.xyz);
-        float _875 = length(_771 - _867);
-        float _877 = _869 * _869;
-        float _880 = _877 * ((_870 * _870) - 1.0);
-        bool _883 = (_870 < 0.0) && ((_880 + _762) >= 0.0);
-        float3 _1012;
+        float _894;
+        float _876 = _868 ? _116 : _859;
+        float _877 = _875 / _876;
+        float _878 = dot(_874, u_fragParams.u_sunDirection.xyz);
+        float _879 = _878 / _876;
+        float _880 = dot(_858, u_fragParams.u_sunDirection.xyz);
+        float _882 = length(_778 - _874);
+        float _884 = _876 * _876;
+        float _887 = _884 * ((_877 * _877) - 1.0);
+        bool _890 = (_877 < 0.0) && ((_887 + _769) >= 0.0);
+        float3 _1019;
         switch (0u)
         {
             default:
             {
-                _887 = (2.0 * _869) * _870;
-                float _892 = fast::clamp(sqrt((_875 * (_875 + _887)) + _877), u_fragParams.u_earthCenter.w, _113);
-                float _895 = fast::clamp((_868 + _875) / _892, -1.0, 1.0);
-                if (_883)
+                _894 = (2.0 * _876) * _877;
+                float _899 = fast::clamp(sqrt((_882 * (_882 + _894)) + _884), u_fragParams.u_earthCenter.w, _116);
+                float _902 = fast::clamp((_875 + _882) / _899, -1.0, 1.0);
+                if (_890)
                 {
-                    float _953 = -_895;
-                    float _954 = _892 * _892;
-                    float _957 = sqrt(fast::max(_954 - _762, 0.0));
-                    float _968 = _113 - _892;
-                    float _982 = -_870;
-                    float _985 = sqrt(fast::max(_877 - _762, 0.0));
-                    float _996 = _113 - _869;
-                    _1012 = fast::min(transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_892) * _953) + sqrt(fast::max((_954 * ((_953 * _953) - 1.0)) + _803, 0.0)), 0.0) - _968) / ((_957 + _805) - _968)) * 0.99609375), 0.0078125 + ((_957 / _805) * 0.984375))).xyz / transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_869) * _982) + sqrt(fast::max((_877 * ((_982 * _982) - 1.0)) + _803, 0.0)), 0.0) - _996) / ((_985 + _805) - _996)) * 0.99609375), 0.0078125 + ((_985 / _805) * 0.984375))).xyz, float3(1.0));
+                    float _960 = -_902;
+                    float _961 = _899 * _899;
+                    float _964 = sqrt(fast::max(_961 - _769, 0.0));
+                    float _975 = _116 - _899;
+                    float _989 = -_877;
+                    float _992 = sqrt(fast::max(_884 - _769, 0.0));
+                    float _1003 = _116 - _876;
+                    _1019 = fast::min(transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_899) * _960) + sqrt(fast::max((_961 * ((_960 * _960) - 1.0)) + _810, 0.0)), 0.0) - _975) / ((_964 + _812) - _975)) * 0.99609375), 0.0078125 + ((_964 / _812) * 0.984375))).xyz / transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_876) * _989) + sqrt(fast::max((_884 * ((_989 * _989) - 1.0)) + _810, 0.0)), 0.0) - _1003) / ((_992 + _812) - _1003)) * 0.99609375), 0.0078125 + ((_992 / _812) * 0.984375))).xyz, float3(1.0));
                     break;
                 }
                 else
                 {
-                    float _901 = sqrt(fast::max(_877 - _762, 0.0));
-                    float _909 = _113 - _869;
-                    float _923 = _892 * _892;
-                    float _926 = sqrt(fast::max(_923 - _762, 0.0));
-                    float _937 = _113 - _892;
-                    _1012 = fast::min(transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_869) * _870) + sqrt(fast::max(_880 + _803, 0.0)), 0.0) - _909) / ((_901 + _805) - _909)) * 0.99609375), 0.0078125 + ((_901 / _805) * 0.984375))).xyz / transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_892) * _895) + sqrt(fast::max((_923 * ((_895 * _895) - 1.0)) + _803, 0.0)), 0.0) - _937) / ((_926 + _805) - _937)) * 0.99609375), 0.0078125 + ((_926 / _805) * 0.984375))).xyz, float3(1.0));
+                    float _908 = sqrt(fast::max(_884 - _769, 0.0));
+                    float _916 = _116 - _876;
+                    float _930 = _899 * _899;
+                    float _933 = sqrt(fast::max(_930 - _769, 0.0));
+                    float _944 = _116 - _899;
+                    _1019 = fast::min(transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_876) * _877) + sqrt(fast::max(_887 + _810, 0.0)), 0.0) - _916) / ((_908 + _812) - _916)) * 0.99609375), 0.0078125 + ((_908 / _812) * 0.984375))).xyz / transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_899) * _902) + sqrt(fast::max((_930 * ((_902 * _902) - 1.0)) + _810, 0.0)), 0.0) - _944) / ((_933 + _812) - _944)) * 0.99609375), 0.0078125 + ((_933 / _812) * 0.984375))).xyz, float3(1.0));
                     break;
                 }
             }
         }
-        float _1015 = sqrt(fast::max(_877 - _762, 0.0));
-        float _1018 = 0.015625 + ((_1015 / _805) * 0.96875);
-        float _1021 = ((_868 * _868) - _877) + _762;
-        float _1054;
-        if (_883)
+        float _1022 = sqrt(fast::max(_884 - _769, 0.0));
+        float _1025 = 0.015625 + ((_1022 / _812) * 0.96875);
+        float _1028 = ((_875 * _875) - _884) + _769;
+        float _1061;
+        if (_890)
         {
-            float _1044 = _869 - u_fragParams.u_earthCenter.w;
-            _1054 = 0.5 - (0.5 * (0.0078125 + (((_1015 == _1044) ? 0.0 : ((((-_868) - sqrt(fast::max(_1021, 0.0))) - _1044) / (_1015 - _1044))) * 0.984375)));
+            float _1051 = _876 - u_fragParams.u_earthCenter.w;
+            _1061 = 0.5 - (0.5 * (0.0078125 + (((_1022 == _1051) ? 0.0 : ((((-_875) - sqrt(fast::max(_1028, 0.0))) - _1051) / (_1022 - _1051))) * 0.984375)));
         }
         else
         {
-            float _1031 = _113 - _869;
-            _1054 = 0.5 + (0.5 * (0.0078125 + (((((-_868) + sqrt(fast::max(_1021 + (_805 * _805), 0.0))) - _1031) / ((_1015 + _805) - _1031)) * 0.984375)));
+            float _1038 = _116 - _876;
+            _1061 = 0.5 + (0.5 * (0.0078125 + (((((-_875) + sqrt(fast::max(_1028 + (_812 * _812), 0.0))) - _1038) / ((_1022 + _812) - _1038)) * 0.984375)));
         }
-        float _1059 = -u_fragParams.u_earthCenter.w;
-        float _1066 = _805 - _779;
-        float _1067 = (fast::max((_1059 * _872) + sqrt(fast::max((_762 * ((_872 * _872) - 1.0)) + _803, 0.0)), 0.0) - _779) / _1066;
-        float _1069 = (0.415823996067047119140625 * u_fragParams.u_earthCenter.w) / _1066;
-        float _1076 = 0.015625 + ((fast::max(1.0 - (_1067 / _1069), 0.0) / (1.0 + _1067)) * 0.96875);
-        float _1078 = (_873 + 1.0) * 3.5;
-        float _1079 = floor(_1078);
-        float _1080 = _1078 - _1079;
-        float _1084 = _1079 + 1.0;
-        float4 _1090 = scatteringTexture.sample(scatteringSampler, float3((_1079 + _1076) * 0.125, _1054, _1018));
-        float _1091 = 1.0 - _1080;
-        float4 _1094 = scatteringTexture.sample(scatteringSampler, float3((_1084 + _1076) * 0.125, _1054, _1018));
-        float4 _1096 = (_1090 * _1091) + (_1094 * _1080);
-        float3 _1097 = _1096.xyz;
-        float3 _1110;
+        float _1066 = -u_fragParams.u_earthCenter.w;
+        float _1073 = _812 - _786;
+        float _1074 = (fast::max((_1066 * _879) + sqrt(fast::max((_769 * ((_879 * _879) - 1.0)) + _810, 0.0)), 0.0) - _786) / _1073;
+        float _1076 = (0.415823996067047119140625 * u_fragParams.u_earthCenter.w) / _1073;
+        float _1083 = 0.015625 + ((fast::max(1.0 - (_1074 / _1076), 0.0) / (1.0 + _1074)) * 0.96875);
+        float _1085 = (_880 + 1.0) * 3.5;
+        float _1086 = floor(_1085);
+        float _1087 = _1085 - _1086;
+        float _1091 = _1086 + 1.0;
+        float4 _1097 = scatteringTexture.sample(scatteringSampler, float3((_1086 + _1083) * 0.125, _1061, _1025));
+        float _1098 = 1.0 - _1087;
+        float4 _1101 = scatteringTexture.sample(scatteringSampler, float3((_1091 + _1083) * 0.125, _1061, _1025));
+        float4 _1103 = (_1097 * _1098) + (_1101 * _1087);
+        float3 _1104 = _1103.xyz;
+        float3 _1117;
         switch (0u)
         {
             default:
             {
-                float _1100 = _1096.x;
-                if (_1100 == 0.0)
+                float _1107 = _1103.x;
+                if (_1107 == 0.0)
                 {
-                    _1110 = float3(0.0);
+                    _1117 = float3(0.0);
                     break;
                 }
-                _1110 = (((_1097 * _1096.w) / float3(_1100)) * 1.5) * float3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
+                _1117 = (((_1104 * _1103.w) / float3(_1107)) * 1.5) * float3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
                 break;
             }
         }
-        float _1111 = fast::max(_875, 0.0);
-        float _1116 = fast::clamp(sqrt((_1111 * (_1111 + _887)) + _877), u_fragParams.u_earthCenter.w, _113);
-        float _1117 = _868 + _1111;
-        float _1120 = (_871 + (_1111 * _873)) / _1116;
-        float _1121 = _1116 * _1116;
-        float _1124 = sqrt(fast::max(_1121 - _762, 0.0));
-        float _1127 = 0.015625 + ((_1124 / _805) * 0.96875);
-        float _1130 = ((_1117 * _1117) - _1121) + _762;
-        float _1163;
-        if (_883)
+        float _1118 = fast::max(_882, 0.0);
+        float _1123 = fast::clamp(sqrt((_1118 * (_1118 + _894)) + _884), u_fragParams.u_earthCenter.w, _116);
+        float _1124 = _875 + _1118;
+        float _1127 = (_878 + (_1118 * _880)) / _1123;
+        float _1128 = _1123 * _1123;
+        float _1131 = sqrt(fast::max(_1128 - _769, 0.0));
+        float _1134 = 0.015625 + ((_1131 / _812) * 0.96875);
+        float _1137 = ((_1124 * _1124) - _1128) + _769;
+        float _1170;
+        if (_890)
         {
-            float _1153 = _1116 - u_fragParams.u_earthCenter.w;
-            _1163 = 0.5 - (0.5 * (0.0078125 + (((_1124 == _1153) ? 0.0 : ((((-_1117) - sqrt(fast::max(_1130, 0.0))) - _1153) / (_1124 - _1153))) * 0.984375)));
+            float _1160 = _1123 - u_fragParams.u_earthCenter.w;
+            _1170 = 0.5 - (0.5 * (0.0078125 + (((_1131 == _1160) ? 0.0 : ((((-_1124) - sqrt(fast::max(_1137, 0.0))) - _1160) / (_1131 - _1160))) * 0.984375)));
         }
         else
         {
-            float _1140 = _113 - _1116;
-            _1163 = 0.5 + (0.5 * (0.0078125 + (((((-_1117) + sqrt(fast::max(_1130 + (_805 * _805), 0.0))) - _1140) / ((_1124 + _805) - _1140)) * 0.984375)));
+            float _1147 = _116 - _1123;
+            _1170 = 0.5 + (0.5 * (0.0078125 + (((((-_1124) + sqrt(fast::max(_1137 + (_812 * _812), 0.0))) - _1147) / ((_1131 + _812) - _1147)) * 0.984375)));
         }
-        float _1174 = (fast::max((_1059 * _1120) + sqrt(fast::max((_762 * ((_1120 * _1120) - 1.0)) + _803, 0.0)), 0.0) - _779) / _1066;
-        float _1181 = 0.015625 + ((fast::max(1.0 - (_1174 / _1069), 0.0) / (1.0 + _1174)) * 0.96875);
-        float4 _1189 = scatteringTexture.sample(scatteringSampler, float3((_1079 + _1181) * 0.125, _1163, _1127));
-        float4 _1192 = scatteringTexture.sample(scatteringSampler, float3((_1084 + _1181) * 0.125, _1163, _1127));
-        float4 _1194 = (_1189 * _1091) + (_1192 * _1080);
-        float3 _1195 = _1194.xyz;
-        float3 _1208;
+        float _1181 = (fast::max((_1066 * _1127) + sqrt(fast::max((_769 * ((_1127 * _1127) - 1.0)) + _810, 0.0)), 0.0) - _786) / _1073;
+        float _1188 = 0.015625 + ((fast::max(1.0 - (_1181 / _1076), 0.0) / (1.0 + _1181)) * 0.96875);
+        float4 _1196 = scatteringTexture.sample(scatteringSampler, float3((_1086 + _1188) * 0.125, _1170, _1134));
+        float4 _1199 = scatteringTexture.sample(scatteringSampler, float3((_1091 + _1188) * 0.125, _1170, _1134));
+        float4 _1201 = (_1196 * _1098) + (_1199 * _1087);
+        float3 _1202 = _1201.xyz;
+        float3 _1215;
         switch (0u)
         {
             default:
             {
-                float _1198 = _1194.x;
-                if (_1198 == 0.0)
+                float _1205 = _1201.x;
+                if (_1205 == 0.0)
                 {
-                    _1208 = float3(0.0);
+                    _1215 = float3(0.0);
                     break;
                 }
-                _1208 = (((_1195 * _1194.w) / float3(_1198)) * 1.5) * float3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
+                _1215 = (((_1202 * _1201.w) / float3(_1205)) * 1.5) * float3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
                 break;
             }
         }
-        float3 _1210 = _1097 - (_1012 * _1195);
-        float3 _1212 = _1110 - (_1012 * _1208);
-        float _1213 = _1212.x;
-        float _1214 = _1210.x;
-        float3 _1229;
+        float3 _1217 = _1104 - (_1019 * _1202);
+        float3 _1219 = _1117 - (_1019 * _1215);
+        float _1220 = _1219.x;
+        float _1221 = _1217.x;
+        float3 _1236;
         switch (0u)
         {
             default:
             {
-                if (_1214 == 0.0)
+                if (_1221 == 0.0)
                 {
-                    _1229 = float3(0.0);
+                    _1236 = float3(0.0);
                     break;
                 }
-                _1229 = (((float4(_1214, _1210.yz, _1213).xyz * _1213) / float3(_1214)) * 1.5) * float3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
+                _1236 = (((float4(_1221, _1217.yz, _1220).xyz * _1220) / float3(_1221)) * 1.5) * float3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
                 break;
             }
         }
-        float _1233 = 1.0 + (_873 * _873);
-        _1245 = (((_154.xyz * 0.3183098733425140380859375) * ((float3(1.47399997711181640625, 1.85039997100830078125, 1.91198003292083740234375) * fast::max((_833.xyz * smoothstep(_797 * (-0.004674999974668025970458984375), _797 * 0.004674999974668025970458984375, _777 - (-sqrt(fast::max(1.0 - (_797 * _797), 0.0))))) * fast::max(dot(_772, u_fragParams.u_sunDirection.xyz), 0.0), float3(0.001000000047497451305389404296875))) + ((_790.xyz * (1.0 + (dot(_772, _771) / _775))) * 0.5))) * _1012) + ((_1210 * (0.0596831031143665313720703125 * _1233)) + ((_1229 * smoothstep(0.0, 0.00999999977648258209228515625, _872)) * ((0.01627720706164836883544921875 * _1233) / pow(1.6400001049041748046875 - (1.60000002384185791015625 * _873), 1.5))));
+        float _1240 = 1.0 + (_880 * _880);
+        _1252 = (((_161.xyz * 0.3183098733425140380859375) * ((float3(1.47399997711181640625, 1.85039997100830078125, 1.91198003292083740234375) * fast::max((_840.xyz * smoothstep(_804 * (-0.004674999974668025970458984375), _804 * 0.004674999974668025970458984375, _784 - (-sqrt(fast::max(1.0 - (_804 * _804), 0.0))))) * fast::max(dot(_779, u_fragParams.u_sunDirection.xyz), 0.0), float3(0.001000000047497451305389404296875))) + ((_797.xyz * (1.0 + (dot(_779, _778) / _782))) * 0.5))) * _1019) + ((_1217 * (0.0596831031143665313720703125 * _1240)) + ((_1236 * smoothstep(0.0, 0.00999999977648258209228515625, _879)) * ((0.01627720706164836883544921875 * _1240) / pow(1.6400001049041748046875 - (1.60000002384185791015625 * _880), 1.5))));
     }
     else
     {
-        _1245 = float3(0.0);
+        _1252 = float3(0.0);
     }
-    float3 _1415;
-    float3 _1416;
+    float3 _1422;
+    float3 _1423;
     switch (0u)
     {
         default:
         {
-            float _1251 = length(_756);
-            float _1254 = _113 * _113;
-            float _1257 = _761 - sqrt((_759 - (_1251 * _1251)) + _1254);
-            bool _1258 = _1257 > 0.0;
-            float3 _1268;
-            float _1269;
-            if (_1258)
+            float _1258 = length(_763);
+            float _1261 = _116 * _116;
+            float _1264 = _768 - sqrt((_766 - (_1258 * _1258)) + _1261);
+            bool _1265 = _1264 > 0.0;
+            float3 _1275;
+            float _1276;
+            if (_1265)
             {
-                _1268 = _756 + (_126 * _1257);
-                _1269 = _757 + _1257;
+                _1275 = _763 + (_129 * _1264);
+                _1276 = _764 + _1264;
             }
             else
             {
-                if (_1251 > _113)
+                if (_1258 > _116)
                 {
-                    _1415 = float3(1.0);
-                    _1416 = float3(0.0);
+                    _1422 = float3(1.0);
+                    _1423 = float3(0.0);
                     break;
                 }
-                _1268 = _756;
-                _1269 = _757;
+                _1275 = _763;
+                _1276 = _764;
             }
-            float _1270 = _1258 ? _113 : _1251;
-            float _1271 = _1269 / _1270;
-            float _1273 = dot(_1268, u_fragParams.u_sunDirection.xyz) / _1270;
-            float _1274 = dot(_126, u_fragParams.u_sunDirection.xyz);
-            float _1276 = _1270 * _1270;
-            float _1279 = _1276 * ((_1271 * _1271) - 1.0);
-            bool _1282 = (_1271 < 0.0) && ((_1279 + _762) >= 0.0);
-            float _1284 = sqrt(_1254 - _762);
-            float _1287 = sqrt(fast::max(_1276 - _762, 0.0));
-            float _1295 = _113 - _1270;
-            float _1298 = (_1287 + _1284) - _1295;
-            float _1300 = _1287 / _1284;
-            float4 _1308 = transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_1270) * _1271) + sqrt(fast::max(_1279 + _1254, 0.0)), 0.0) - _1295) / _1298) * 0.99609375), 0.0078125 + (_1300 * 0.984375)));
-            float _1313 = 0.015625 + (_1300 * 0.96875);
-            float _1316 = ((_1269 * _1269) - _1276) + _762;
-            float _1346;
-            if (_1282)
+            float _1277 = _1265 ? _116 : _1258;
+            float _1278 = _1276 / _1277;
+            float _1280 = dot(_1275, u_fragParams.u_sunDirection.xyz) / _1277;
+            float _1281 = dot(_129, u_fragParams.u_sunDirection.xyz);
+            float _1283 = _1277 * _1277;
+            float _1286 = _1283 * ((_1278 * _1278) - 1.0);
+            bool _1289 = (_1278 < 0.0) && ((_1286 + _769) >= 0.0);
+            float _1291 = sqrt(_1261 - _769);
+            float _1294 = sqrt(fast::max(_1283 - _769, 0.0));
+            float _1302 = _116 - _1277;
+            float _1305 = (_1294 + _1291) - _1302;
+            float _1307 = _1294 / _1291;
+            float4 _1315 = transmittanceTexture.sample(transmittanceSampler, float2(0.001953125 + (((fast::max(((-_1277) * _1278) + sqrt(fast::max(_1286 + _1261, 0.0)), 0.0) - _1302) / _1305) * 0.99609375), 0.0078125 + (_1307 * 0.984375)));
+            float _1320 = 0.015625 + (_1307 * 0.96875);
+            float _1323 = ((_1276 * _1276) - _1283) + _769;
+            float _1353;
+            if (_1289)
             {
-                float _1336 = _1270 - u_fragParams.u_earthCenter.w;
-                _1346 = 0.5 - (0.5 * (0.0078125 + (((_1287 == _1336) ? 0.0 : ((((-_1269) - sqrt(fast::max(_1316, 0.0))) - _1336) / (_1287 - _1336))) * 0.984375)));
+                float _1343 = _1277 - u_fragParams.u_earthCenter.w;
+                _1353 = 0.5 - (0.5 * (0.0078125 + (((_1294 == _1343) ? 0.0 : ((((-_1276) - sqrt(fast::max(_1323, 0.0))) - _1343) / (_1294 - _1343))) * 0.984375)));
             }
             else
             {
-                _1346 = 0.5 + (0.5 * (0.0078125 + (((((-_1269) + sqrt(fast::max(_1316 + (_1284 * _1284), 0.0))) - _1295) / _1298) * 0.984375)));
+                _1353 = 0.5 + (0.5 * (0.0078125 + (((((-_1276) + sqrt(fast::max(_1323 + (_1291 * _1291), 0.0))) - _1302) / _1305) * 0.984375)));
             }
-            float _1357 = _113 - u_fragParams.u_earthCenter.w;
-            float _1359 = _1284 - _1357;
-            float _1360 = (fast::max(((-u_fragParams.u_earthCenter.w) * _1273) + sqrt(fast::max((_762 * ((_1273 * _1273) - 1.0)) + _1254, 0.0)), 0.0) - _1357) / _1359;
-            float _1369 = 0.015625 + ((fast::max(1.0 - (_1360 / ((0.415823996067047119140625 * u_fragParams.u_earthCenter.w) / _1359)), 0.0) / (1.0 + _1360)) * 0.96875);
-            float _1371 = (_1274 + 1.0) * 3.5;
-            float _1372 = floor(_1371);
-            float _1373 = _1371 - _1372;
-            float4 _1383 = scatteringTexture.sample(scatteringSampler, float3((_1372 + _1369) * 0.125, _1346, _1313));
-            float4 _1387 = scatteringTexture.sample(scatteringSampler, float3(((_1372 + 1.0) + _1369) * 0.125, _1346, _1313));
-            float4 _1389 = (_1383 * (1.0 - _1373)) + (_1387 * _1373);
-            float3 _1390 = _1389.xyz;
-            float3 _1403;
+            float _1364 = _116 - u_fragParams.u_earthCenter.w;
+            float _1366 = _1291 - _1364;
+            float _1367 = (fast::max(((-u_fragParams.u_earthCenter.w) * _1280) + sqrt(fast::max((_769 * ((_1280 * _1280) - 1.0)) + _1261, 0.0)), 0.0) - _1364) / _1366;
+            float _1376 = 0.015625 + ((fast::max(1.0 - (_1367 / ((0.415823996067047119140625 * u_fragParams.u_earthCenter.w) / _1366)), 0.0) / (1.0 + _1367)) * 0.96875);
+            float _1378 = (_1281 + 1.0) * 3.5;
+            float _1379 = floor(_1378);
+            float _1380 = _1378 - _1379;
+            float4 _1390 = scatteringTexture.sample(scatteringSampler, float3((_1379 + _1376) * 0.125, _1353, _1320));
+            float4 _1394 = scatteringTexture.sample(scatteringSampler, float3(((_1379 + 1.0) + _1376) * 0.125, _1353, _1320));
+            float4 _1396 = (_1390 * (1.0 - _1380)) + (_1394 * _1380);
+            float3 _1397 = _1396.xyz;
+            float3 _1410;
             switch (0u)
             {
                 default:
                 {
-                    float _1393 = _1389.x;
-                    if (_1393 == 0.0)
+                    float _1400 = _1396.x;
+                    if (_1400 == 0.0)
                     {
-                        _1403 = float3(0.0);
+                        _1410 = float3(0.0);
                         break;
                     }
-                    _1403 = (((_1390 * _1389.w) / float3(_1393)) * 1.5) * float3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
+                    _1410 = (((_1397 * _1396.w) / float3(_1400)) * 1.5) * float3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
                     break;
                 }
             }
-            float _1405 = 1.0 + (_1274 * _1274);
-            _1415 = select(_1308.xyz, float3(0.0), bool3(_1282));
-            _1416 = (_1390 * (0.0596831031143665313720703125 * _1405)) + (_1403 * ((0.01627720706164836883544921875 * _1405) / pow(1.6400001049041748046875 - (1.60000002384185791015625 * _1274), 1.5)));
+            float _1412 = 1.0 + (_1281 * _1281);
+            _1422 = select(_1315.xyz, float3(0.0), bool3(_1289));
+            _1423 = (_1397 * (0.0596831031143665313720703125 * _1412)) + (_1410 * ((0.01627720706164836883544921875 * _1412) / pow(1.6400001049041748046875 - (1.60000002384185791015625 * _1281), 1.5)));
             break;
         }
     }
-    float3 _1424;
-    if (dot(_126, u_fragParams.u_sunDirection.xyz) > u_fragParams.u_sunSize.y)
+    float3 _1431;
+    if (dot(_129, u_fragParams.u_sunDirection.xyz) > u_fragParams.u_sunSize.y)
     {
-        _1424 = _1416 + (_1415 * float3(21467.642578125, 26949.611328125, 27846.474609375));
+        _1431 = _1423 + (_1422 * float3(21467.642578125, 26949.611328125, 27846.474609375));
     }
     else
     {
-        _1424 = _1416;
+        _1431 = _1423;
     }
-    float3 _1438 = pow(abs(float3(1.0) - exp(((-mix(mix(_1424, _1245, float3(float(_766))), _754, float3(float(_163)))) / u_fragParams.u_whitePoint.xyz) * u_fragParams.u_camera.w)), float3(0.4545454680919647216796875));
-    float4 _1440 = float4(_1438.x, _1438.y, _1438.z, _105.w);
-    _1440.w = 1.0;
-    out.out_var_SV_Target = _1440;
-    out.gl_FragDepth = _131;
+    float3 _1445 = pow(abs(float3(1.0) - exp(((-mix(mix(_1431, _1252, float3(float(_773))), _761, float3(float(_170)))) / u_fragParams.u_whitePoint.xyz) * u_fragParams.u_camera.w)), float3(0.4545454680919647216796875));
+    float4 _1447 = float4(_1445.x, _1445.y, _1445.z, _108.w);
+    _1447.w = 1.0;
+    out.out_var_SV_Target0 = _1447;
+    out.out_var_SV_Target1 = _137;
+    out.gl_FragDepth = _142;
     return out;
 }
 

--- a/src/gl/metal/shaders/mobile/compassFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/compassFragmentShader.metal
@@ -13,7 +13,8 @@ struct type_u_cameraPlaneParams
 
 struct main0_out
 {
-    float4 out_var_SV_Target [[color(0)]];
+    float4 out_var_SV_Target0 [[color(0)]];
+    float4 out_var_SV_Target1 [[color(1)]];
     float gl_FragDepth [[depth(any)]];
 };
 
@@ -29,12 +30,12 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]])
 {
     main0_out out = {};
-    float3 _50 = (in.in_var_COLOR0 * float3(2.0)) - float3(1.0);
-    float _76 = log2(in.in_var_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
-    float4 _77 = float4(((in.in_var_COLOR1.xyz * (0.5 + (dot(in.in_var_COLOR2, _50) * (-0.5)))) + (float3(1.0, 1.0, 0.89999997615814208984375) * pow(fast::max(0.0, -dot(-normalize(in.in_var_COLOR3.xyz / float3(in.in_var_COLOR3.w)), _50)), 60.0))) * in.in_var_COLOR1.w, 1.0);
-    _77.w = _76;
-    out.out_var_SV_Target = _77;
-    out.gl_FragDepth = _76;
+    float3 _51 = (in.in_var_COLOR0 * float3(2.0)) - float3(1.0);
+    float _77 = log2(in.in_var_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _80 = 1.0 - in.in_var_COLOR0.z;
+    out.out_var_SV_Target0 = float4(((in.in_var_COLOR1.xyz * (0.5 + (dot(in.in_var_COLOR2, _51) * (-0.5)))) + (float3(1.0, 1.0, 0.89999997615814208984375) * pow(fast::max(0.0, -dot(-normalize(in.in_var_COLOR3.xyz / float3(in.in_var_COLOR3.w)), _51)), 60.0))) * in.in_var_COLOR1.w, 1.0);
+    out.out_var_SV_Target1 = float4(in.in_var_COLOR0.x / _80, in.in_var_COLOR0.y / _80, 0.0, _77);
+    out.gl_FragDepth = _77;
     return out;
 }
 

--- a/src/gl/metal/shaders/mobile/depthOnlyFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/depthOnlyFragmentShader.metal
@@ -13,7 +13,7 @@ struct type_u_cameraPlaneParams
 
 struct main0_out
 {
-    float4 out_var_SV_Target [[color(0)]];
+    float4 out_var_SV_Target0 [[color(0)]];
     float gl_FragDepth [[depth(any)]];
 };
 
@@ -25,11 +25,8 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]])
 {
     main0_out out = {};
-    float _39 = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
-    float4 _40 = float4(0.0);
-    _40.w = _39;
-    out.out_var_SV_Target = _40;
-    out.gl_FragDepth = _39;
+    out.out_var_SV_Target0 = float4(0.0);
+    out.gl_FragDepth = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
     return out;
 }
 

--- a/src/gl/metal/shaders/mobile/fenceFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/fenceFragmentShader.metal
@@ -13,7 +13,8 @@ struct type_u_cameraPlaneParams
 
 struct main0_out
 {
-    float4 out_var_SV_Target [[color(0)]];
+    float4 out_var_SV_Target0 [[color(0)]];
+    float4 out_var_SV_Target1 [[color(1)]];
     float gl_FragDepth [[depth(any)]];
 };
 
@@ -27,9 +28,11 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], texture2d<float> colourTexture [[texture(0)]], sampler colourSampler [[sampler(0)]])
 {
     main0_out out = {};
-    float4 _40 = colourTexture.sample(colourSampler, in.in_var_TEXCOORD0);
-    out.out_var_SV_Target = float4(_40.xyz * in.in_var_COLOR0.xyz, _40.w * in.in_var_COLOR0.w);
-    out.gl_FragDepth = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float4 _42 = colourTexture.sample(colourSampler, in.in_var_TEXCOORD0);
+    float _60 = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    out.out_var_SV_Target0 = float4(_42.xyz * in.in_var_COLOR0.xyz, _42.w * in.in_var_COLOR0.w);
+    out.out_var_SV_Target1 = float4(0.0, 0.0, 0.0, _60);
+    out.gl_FragDepth = _60;
     return out;
 }
 

--- a/src/gl/metal/shaders/mobile/flatColourFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/flatColourFragmentShader.metal
@@ -3,34 +3,20 @@
 
 using namespace metal;
 
-struct type_u_cameraPlaneParams
-{
-    float s_CameraNearPlane;
-    float s_CameraFarPlane;
-    float u_clipZNear;
-    float u_clipZFar;
-};
-
 struct main0_out
 {
-    float4 out_var_SV_Target [[color(0)]];
-    float gl_FragDepth [[depth(any)]];
+    float4 out_var_SV_Target0 [[color(0)]];
 };
 
 struct main0_in
 {
     float4 in_var_COLOR0 [[user(locn2)]];
-    float2 in_var_TEXCOORD1 [[user(locn3)]];
 };
 
-fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]])
+fragment main0_out main0(main0_in in [[stage_in]])
 {
     main0_out out = {};
-    float _38 = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
-    float4 _39 = in.in_var_COLOR0;
-    _39.w = _38;
-    out.out_var_SV_Target = _39;
-    out.gl_FragDepth = _38;
+    out.out_var_SV_Target0 = in.in_var_COLOR0;
     return out;
 }
 

--- a/src/gl/metal/shaders/mobile/imageRendererFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/imageRendererFragmentShader.metal
@@ -13,7 +13,8 @@ struct type_u_cameraPlaneParams
 
 struct main0_out
 {
-    float4 out_var_SV_Target [[color(0)]];
+    float4 out_var_SV_Target0 [[color(0)]];
+    float4 out_var_SV_Target1 [[color(1)]];
     float gl_FragDepth [[depth(any)]];
 };
 
@@ -27,8 +28,10 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], texture2d<float> albedoTexture [[texture(0)]], sampler albedoSampler [[sampler(0)]])
 {
     main0_out out = {};
-    out.out_var_SV_Target = albedoTexture.sample(albedoSampler, in.in_var_TEXCOORD0) * in.in_var_COLOR0;
-    out.gl_FragDepth = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _50 = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    out.out_var_SV_Target0 = albedoTexture.sample(albedoSampler, in.in_var_TEXCOORD0) * in.in_var_COLOR0;
+    out.out_var_SV_Target1 = float4(0.0, 0.0, 0.0, _50);
+    out.gl_FragDepth = _50;
     return out;
 }
 

--- a/src/gl/metal/shaders/mobile/lineFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/lineFragmentShader.metal
@@ -13,7 +13,8 @@ struct type_u_cameraPlaneParams
 
 struct main0_out
 {
-    float4 out_var_SV_Target [[color(0)]];
+    float4 out_var_SV_Target0 [[color(0)]];
+    float4 out_var_SV_Target1 [[color(1)]];
     float gl_FragDepth [[depth(any)]];
 };
 
@@ -26,8 +27,10 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]])
 {
     main0_out out = {};
-    out.out_var_SV_Target = in.in_var_COLOR0;
-    out.gl_FragDepth = log2(in.in_var_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _36 = log2(in.in_var_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    out.out_var_SV_Target0 = in.in_var_COLOR0;
+    out.out_var_SV_Target1 = float4(0.0, 0.0, 0.0, _36);
+    out.gl_FragDepth = _36;
     return out;
 }
 

--- a/src/gl/metal/shaders/mobile/polygonImageFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/polygonImageFragmentShader.metal
@@ -13,7 +13,8 @@ struct type_u_cameraPlaneParams
 
 struct main0_out
 {
-    float4 out_var_SV_Target [[color(0)]];
+    float4 out_var_SV_Target0 [[color(0)]];
+    float4 out_var_SV_Target1 [[color(1)]];
     float gl_FragDepth [[depth(any)]];
 };
 
@@ -22,16 +23,16 @@ struct main0_in
     float2 in_var_TEXCOORD0 [[user(locn0)]];
     float4 in_var_COLOR0 [[user(locn2)]];
     float2 in_var_TEXCOORD1 [[user(locn3)]];
+    float2 in_var_TEXCOORD2 [[user(locn4)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], texture2d<float> albedoTexture [[texture(0)]], sampler albedoSampler [[sampler(0)]])
 {
     main0_out out = {};
-    float _51 = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
-    float4 _52 = albedoTexture.sample(albedoSampler, in.in_var_TEXCOORD0) * in.in_var_COLOR0;
-    _52.w = _51;
-    out.out_var_SV_Target = _52;
-    out.gl_FragDepth = _51;
+    float _55 = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    out.out_var_SV_Target0 = albedoTexture.sample(albedoSampler, in.in_var_TEXCOORD0) * in.in_var_COLOR0;
+    out.out_var_SV_Target1 = float4(0.0, 0.0, in.in_var_TEXCOORD2.x, _55);
+    out.gl_FragDepth = _55;
     return out;
 }
 

--- a/src/gl/metal/shaders/mobile/polygonP3N3UV2FragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/polygonP3N3UV2FragmentShader.metal
@@ -11,11 +11,10 @@ struct type_u_cameraPlaneParams
     float u_clipZFar;
 };
 
-constant float _39 = {};
-
 struct main0_out
 {
-    float4 out_var_SV_Target [[color(0)]];
+    float4 out_var_SV_Target0 [[color(0)]];
+    float4 out_var_SV_Target1 [[color(1)]];
     float gl_FragDepth [[depth(any)]];
 };
 
@@ -25,16 +24,18 @@ struct main0_in
     float3 in_var_NORMAL [[user(locn1)]];
     float4 in_var_COLOR0 [[user(locn2)]];
     float2 in_var_TEXCOORD1 [[user(locn3)]];
+    float2 in_var_TEXCOORD2 [[user(locn4)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], texture2d<float> albedoTexture [[texture(0)]], sampler albedoSampler [[sampler(0)]])
 {
     main0_out out = {};
-    float _67 = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
-    float4 _68 = float4((albedoTexture.sample(albedoSampler, in.in_var_TEXCOORD0) * in.in_var_COLOR0).xyz * ((dot(in.in_var_NORMAL, normalize(float3(0.85000002384185791015625, 0.1500000059604644775390625, 0.5))) * 0.5) + 0.5), _39);
-    _68.w = _67;
-    out.out_var_SV_Target = _68;
-    out.gl_FragDepth = _67;
+    float4 _51 = albedoTexture.sample(albedoSampler, in.in_var_TEXCOORD0) * in.in_var_COLOR0;
+    float _70 = log2(in.in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _74 = 1.0 - in.in_var_NORMAL.z;
+    out.out_var_SV_Target0 = float4(_51.xyz * ((dot(in.in_var_NORMAL, normalize(float3(0.85000002384185791015625, 0.1500000059604644775390625, 0.5))) * 0.5) + 0.5), _51.w);
+    out.out_var_SV_Target1 = float4(in.in_var_NORMAL.x / _74, in.in_var_NORMAL.y / _74, in.in_var_TEXCOORD2.x, _70);
+    out.gl_FragDepth = _70;
     return out;
 }
 

--- a/src/gl/metal/shaders/mobile/polygonP3N3UV2VertexShader.metal
+++ b/src/gl/metal/shaders/mobile/polygonP3N3UV2VertexShader.metal
@@ -8,9 +8,10 @@ struct type_u_EveryObject
     float4x4 u_worldViewProjectionMatrix;
     float4x4 u_worldMatrix;
     float4 u_colour;
+    float4 u_objectInfo;
 };
 
-constant float2 _34 = {};
+constant float2 _37 = {};
 
 struct main0_out
 {
@@ -18,6 +19,7 @@ struct main0_out
     float3 out_var_NORMAL [[user(locn1)]];
     float4 out_var_COLOR0 [[user(locn2)]];
     float2 out_var_TEXCOORD1 [[user(locn3)]];
+    float2 out_var_TEXCOORD2 [[user(locn4)]];
     float4 gl_Position [[position]];
 };
 
@@ -31,14 +33,17 @@ struct main0_in
 vertex main0_out main0(main0_in in [[stage_in]], constant type_u_EveryObject& u_EveryObject [[buffer(0)]])
 {
     main0_out out = {};
-    float4 _54 = u_EveryObject.u_worldViewProjectionMatrix * float4(in.in_var_POSITION, 1.0);
-    float2 _59 = _34;
-    _59.x = 1.0 + _54.w;
-    out.gl_Position = _54;
+    float4 _57 = u_EveryObject.u_worldViewProjectionMatrix * float4(in.in_var_POSITION, 1.0);
+    float2 _62 = _37;
+    _62.x = 1.0 + _57.w;
+    float2 _65 = _37;
+    _65.x = u_EveryObject.u_objectInfo.x;
+    out.gl_Position = _57;
     out.out_var_TEXCOORD0 = in.in_var_TEXCOORD0;
     out.out_var_NORMAL = normalize((u_EveryObject.u_worldMatrix * float4(in.in_var_NORMAL, 0.0)).xyz);
     out.out_var_COLOR0 = u_EveryObject.u_colour;
-    out.out_var_TEXCOORD1 = _59;
+    out.out_var_TEXCOORD1 = _62;
+    out.out_var_TEXCOORD2 = _65;
     return out;
 }
 

--- a/src/gl/metal/shaders/mobile/tileFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/tileFragmentShader.metal
@@ -11,11 +11,10 @@ struct type_u_cameraPlaneParams
     float u_clipZFar;
 };
 
-constant float _32 = {};
-
 struct main0_out
 {
-    float4 out_var_SV_Target [[color(0)]];
+    float4 out_var_SV_Target0 [[color(0)]];
+    float4 out_var_SV_Target1 [[color(1)]];
 };
 
 struct main0_in
@@ -23,14 +22,14 @@ struct main0_in
     float4 in_var_COLOR0 [[user(locn0)]];
     float2 in_var_TEXCOORD0 [[user(locn1)]];
     float2 in_var_TEXCOORD1 [[user(locn2)]];
+    float2 in_var_TEXCOORD2 [[user(locn3)]];
 };
 
 fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], texture2d<float> colourTexture [[texture(0)]], sampler colourSampler [[sampler(0)]])
 {
     main0_out out = {};
-    float4 _60 = float4(colourTexture.sample(colourSampler, in.in_var_TEXCOORD0).xyz * in.in_var_COLOR0.xyz, _32);
-    _60.w = ((in.in_var_TEXCOORD1.x / in.in_var_TEXCOORD1.y) * (1.0 / (u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear))) + (u_cameraPlaneParams.u_clipZNear * (-0.5));
-    out.out_var_SV_Target = _60;
+    out.out_var_SV_Target0 = float4(colourTexture.sample(colourSampler, in.in_var_TEXCOORD0).xyz * in.in_var_COLOR0.xyz, in.in_var_COLOR0.w);
+    out.out_var_SV_Target1 = float4(0.0, 0.0, in.in_var_TEXCOORD2.x, ((in.in_var_TEXCOORD1.x / in.in_var_TEXCOORD1.y) * (1.0 / (u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear))) + (u_cameraPlaneParams.u_clipZNear * (-0.5)));
     return out;
 }
 

--- a/src/gl/metal/shaders/mobile/tileVertexShader.metal
+++ b/src/gl/metal/shaders/mobile/tileVertexShader.metal
@@ -17,16 +17,20 @@ struct type_u_EveryObject
     float4x4 u_view;
     float4 u_eyePositions[9];
     float4 u_colour;
+    float4 u_objectInfo;
     float4 u_uvOffsetScale;
     float4 u_demUVOffsetScale;
     float4 u_tileNormal;
 };
+
+constant float2 _55 = {};
 
 struct main0_out
 {
     float4 out_var_COLOR0 [[user(locn0)]];
     float2 out_var_TEXCOORD0 [[user(locn1)]];
     float2 out_var_TEXCOORD1 [[user(locn2)]];
+    float2 out_var_TEXCOORD2 [[user(locn3)]];
     float4 gl_Position [[position]];
 };
 
@@ -38,28 +42,31 @@ struct main0_in
 vertex main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], constant type_u_EveryObject& u_EveryObject [[buffer(1)]], texture2d<float> demTexture [[texture(0)]], sampler demSampler [[sampler(0)]])
 {
     main0_out out = {};
-    float2 _57 = in.in_var_POSITION.xy * 2.0;
-    float _58 = _57.x;
-    float _59 = floor(_58);
-    float _60 = _57.y;
-    float _61 = floor(_60);
-    float _63 = fast::min(2.0, _59 + 1.0);
-    float _66 = _58 - _59;
-    float _68 = _61 * 3.0;
-    int _70 = int(_68 + _59);
-    float _77 = fast::min(2.0, _61 + 1.0) * 3.0;
-    int _79 = int(_77 + _59);
-    float4 _88 = u_EveryObject.u_eyePositions[_70] + ((u_EveryObject.u_eyePositions[int(_68 + _63)] - u_EveryObject.u_eyePositions[_70]) * _66);
-    float4 _104 = demTexture.sample(demSampler, (u_EveryObject.u_demUVOffsetScale.xy + (u_EveryObject.u_demUVOffsetScale.zw * in.in_var_POSITION.xy)), level(0.0));
-    float4 _127 = u_EveryObject.u_projection * ((_88 + (((u_EveryObject.u_eyePositions[_79] + ((u_EveryObject.u_eyePositions[int(_77 + _63)] - u_EveryObject.u_eyePositions[_79]) * _66)) - _88) * (_60 - _61))) + ((u_EveryObject.u_view * float4(u_EveryObject.u_tileNormal.xyz * (((_104.x * 255.0) + (_104.y * 65280.0)) - 32768.0), 1.0)) - (u_EveryObject.u_view * float4(0.0, 0.0, 0.0, 1.0))));
-    float _138 = _127.w;
-    float _144 = ((log2(fast::max(9.9999999747524270787835121154785e-07, 1.0 + _138)) * ((u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear) / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0))) + u_cameraPlaneParams.u_clipZNear) * _138;
-    float4 _145 = _127;
-    _145.z = _144;
-    out.gl_Position = _145;
+    float2 _60 = in.in_var_POSITION.xy * 2.0;
+    float _61 = _60.x;
+    float _62 = floor(_61);
+    float _63 = _60.y;
+    float _64 = floor(_63);
+    float _66 = fast::min(2.0, _62 + 1.0);
+    float _69 = _61 - _62;
+    float _71 = _64 * 3.0;
+    int _73 = int(_71 + _62);
+    float _80 = fast::min(2.0, _64 + 1.0) * 3.0;
+    int _82 = int(_80 + _62);
+    float4 _91 = u_EveryObject.u_eyePositions[_73] + ((u_EveryObject.u_eyePositions[int(_71 + _66)] - u_EveryObject.u_eyePositions[_73]) * _69);
+    float4 _107 = demTexture.sample(demSampler, (u_EveryObject.u_demUVOffsetScale.xy + (u_EveryObject.u_demUVOffsetScale.zw * in.in_var_POSITION.xy)), level(0.0));
+    float4 _130 = u_EveryObject.u_projection * ((_91 + (((u_EveryObject.u_eyePositions[_82] + ((u_EveryObject.u_eyePositions[int(_80 + _66)] - u_EveryObject.u_eyePositions[_82]) * _69)) - _91) * (_63 - _64))) + ((u_EveryObject.u_view * float4(u_EveryObject.u_tileNormal.xyz * (((_107.x * 255.0) + (_107.y * 65280.0)) - 32768.0), 1.0)) - (u_EveryObject.u_view * float4(0.0, 0.0, 0.0, 1.0))));
+    float _141 = _130.w;
+    float _147 = ((log2(fast::max(9.9999999747524270787835121154785e-07, 1.0 + _141)) * ((u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear) / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0))) + u_cameraPlaneParams.u_clipZNear) * _141;
+    float4 _148 = _130;
+    _148.z = _147;
+    float2 _160 = _55;
+    _160.x = u_EveryObject.u_objectInfo.x;
+    out.gl_Position = _148;
     out.out_var_COLOR0 = u_EveryObject.u_colour;
     out.out_var_TEXCOORD0 = u_EveryObject.u_uvOffsetScale.xy + (u_EveryObject.u_uvOffsetScale.zw * in.in_var_POSITION.xy);
-    out.out_var_TEXCOORD1 = float2(_144, _138);
+    out.out_var_TEXCOORD1 = float2(_147, _141);
+    out.out_var_TEXCOORD2 = _160;
     return out;
 }
 

--- a/src/gl/metal/shaders/mobile/udFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/udFragmentShader.metal
@@ -5,7 +5,8 @@ using namespace metal;
 
 struct main0_out
 {
-    float4 out_var_SV_Target [[color(0)]];
+    float4 out_var_SV_Target0 [[color(0)]];
+    float4 out_var_SV_Target1 [[color(1)]];
     float gl_FragDepth [[depth(any)]];
 };
 
@@ -17,12 +18,11 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> sceneColourTexture [[texture(0)]], texture2d<float> sceneDepthTexture [[texture(1)]], sampler sceneColourSampler [[sampler(0)]], sampler sceneDepthSampler [[sampler(1)]])
 {
     main0_out out = {};
-    float4 _34 = sceneDepthTexture.sample(sceneDepthSampler, in.in_var_TEXCOORD0);
-    float _35 = _34.x;
-    float4 _40 = float4(sceneColourTexture.sample(sceneColourSampler, in.in_var_TEXCOORD0).zyx, 1.0);
-    _40.w = _35;
-    out.out_var_SV_Target = _40;
-    out.gl_FragDepth = _35;
+    float4 _36 = sceneDepthTexture.sample(sceneDepthSampler, in.in_var_TEXCOORD0);
+    float _37 = _36.x;
+    out.out_var_SV_Target0 = float4(sceneColourTexture.sample(sceneColourSampler, in.in_var_TEXCOORD0).zyx, 1.0);
+    out.out_var_SV_Target1 = float4(0.0, 0.0, 0.0, _37);
+    out.gl_FragDepth = _37;
     return out;
 }
 

--- a/src/gl/metal/shaders/mobile/viewShedFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/viewShedFragmentShader.metal
@@ -22,7 +22,7 @@ struct type_u_params
 
 struct main0_out
 {
-    float4 out_var_SV_Target [[color(0)]];
+    float4 out_var_SV_Target0 [[color(0)]];
 };
 
 struct main0_in
@@ -67,7 +67,7 @@ fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlanePa
     {
         _225 = float4(0.0);
     }
-    out.out_var_SV_Target = float4(_225.xyz * _225.w, 1.0);
+    out.out_var_SV_Target0 = float4(_225.xyz * _225.w, 1.0);
     return out;
 }
 

--- a/src/gl/metal/shaders/mobile/visualizationFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/visualizationFragmentShader.metal
@@ -32,7 +32,8 @@ struct type_u_fragParams
 
 struct main0_out
 {
-    float4 out_var_SV_Target [[color(0)]];
+    float4 out_var_SV_Target0 [[color(0)]];
+    float4 out_var_SV_Target1 [[color(1)]];
     float gl_FragDepth [[depth(any)]];
 };
 
@@ -53,55 +54,55 @@ inline Tx mod(Tx x, Ty y)
     return x - y * floor(x / y);
 }
 
-fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], constant type_u_fragParams& u_fragParams [[buffer(1)]], texture2d<float> sceneColourTexture [[texture(0)]], texture2d<float> sceneDepthTexture [[texture(1)]], sampler sceneColourSampler [[sampler(0)]], sampler sceneDepthSampler [[sampler(1)]])
+fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], constant type_u_fragParams& u_fragParams [[buffer(1)]], texture2d<float> sceneColourTexture [[texture(0)]], texture2d<float> sceneNormalTexture [[texture(1)]], texture2d<float> sceneDepthTexture [[texture(2)]], sampler sceneColourSampler [[sampler(0)]], sampler sceneNormalSampler [[sampler(1)]], sampler sceneDepthSampler [[sampler(2)]])
 {
     main0_out out = {};
-    float4 _78 = sceneColourTexture.sample(sceneColourSampler, in.in_var_TEXCOORD1);
-    float4 _82 = sceneDepthTexture.sample(sceneDepthSampler, in.in_var_TEXCOORD1);
-    float _83 = _82.x;
-    float _89 = u_cameraPlaneParams.s_CameraFarPlane / (u_cameraPlaneParams.s_CameraFarPlane - u_cameraPlaneParams.s_CameraNearPlane);
-    float _92 = (u_cameraPlaneParams.s_CameraFarPlane * u_cameraPlaneParams.s_CameraNearPlane) / (u_cameraPlaneParams.s_CameraNearPlane - u_cameraPlaneParams.s_CameraFarPlane);
-    float _94 = log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0);
-    float _104 = u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear;
-    float _106 = ((_89 + (_92 / (pow(2.0, _83 * _94) - 1.0))) * _104) + u_cameraPlaneParams.u_clipZNear;
-    float4 _112 = u_fragParams.u_inverseProjection * float4(in.in_var_TEXCOORD0.xy, _106, 1.0);
-    float3 _116 = _78.xyz;
-    float3 _117 = (_112 / float4(_112.w)).xyz;
-    float _124 = dot(u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz, u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz);
-    float3 _126 = u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz * (dot(_117, u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz) / _124);
-    float _132 = mix(length(u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz - _126), 0.0, float(dot(_126, _126) > _124));
-    float3 _207 = mix(mix(mix(mix(mix(_116, u_fragParams.u_colourizeHeightColourMin.xyz, float3(u_fragParams.u_colourizeHeightColourMin.w)), mix(_116, u_fragParams.u_colourizeHeightColourMax.xyz, float3(u_fragParams.u_colourizeHeightColourMax.w)), float3(fast::clamp((_132 - u_fragParams.u_colourizeHeightParams.x) / (u_fragParams.u_colourizeHeightParams.y - u_fragParams.u_colourizeHeightParams.x), 0.0, 1.0))).xyz, u_fragParams.u_colourizeDepthColour.xyz, float3(fast::clamp((length(_117) - u_fragParams.u_colourizeDepthParams.x) / (u_fragParams.u_colourizeDepthParams.y - u_fragParams.u_colourizeDepthParams.x), 0.0, 1.0) * u_fragParams.u_colourizeDepthColour.w)).xyz, fast::clamp(abs((fract(float3(_132 * (1.0 / u_fragParams.u_contourParams.z), 1.0, 1.0).xxx + float3(1.0, 0.666666686534881591796875, 0.3333333432674407958984375)) * 6.0) - float3(3.0)) - float3(1.0), float3(0.0), float3(1.0)) * 1.0, float3(u_fragParams.u_contourParams.w)), u_fragParams.u_contourColour.xyz, float3((1.0 - step(u_fragParams.u_contourParams.y, mod(abs(_132), u_fragParams.u_contourParams.x))) * u_fragParams.u_contourColour.w));
-    float _357;
-    float4 _358;
+    float4 _81 = sceneColourTexture.sample(sceneColourSampler, in.in_var_TEXCOORD1);
+    float4 _85 = sceneNormalTexture.sample(sceneNormalSampler, in.in_var_TEXCOORD1);
+    float4 _89 = sceneDepthTexture.sample(sceneDepthSampler, in.in_var_TEXCOORD1);
+    float _90 = _89.x;
+    float _96 = u_cameraPlaneParams.s_CameraFarPlane / (u_cameraPlaneParams.s_CameraFarPlane - u_cameraPlaneParams.s_CameraNearPlane);
+    float _99 = (u_cameraPlaneParams.s_CameraFarPlane * u_cameraPlaneParams.s_CameraNearPlane) / (u_cameraPlaneParams.s_CameraNearPlane - u_cameraPlaneParams.s_CameraFarPlane);
+    float _101 = log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0);
+    float _111 = u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear;
+    float _113 = ((_96 + (_99 / (pow(2.0, _90 * _101) - 1.0))) * _111) + u_cameraPlaneParams.u_clipZNear;
+    float4 _119 = u_fragParams.u_inverseProjection * float4(in.in_var_TEXCOORD0.xy, _113, 1.0);
+    float3 _123 = _81.xyz;
+    float3 _124 = (_119 / float4(_119.w)).xyz;
+    float _131 = dot(u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz, u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz);
+    float3 _133 = u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz * (dot(_124, u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz) / _131);
+    float _139 = mix(length(u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz - _133), 0.0, float(dot(_133, _133) > _131));
+    float3 _214 = mix(mix(mix(mix(mix(_123, u_fragParams.u_colourizeHeightColourMin.xyz, float3(u_fragParams.u_colourizeHeightColourMin.w)), mix(_123, u_fragParams.u_colourizeHeightColourMax.xyz, float3(u_fragParams.u_colourizeHeightColourMax.w)), float3(fast::clamp((_139 - u_fragParams.u_colourizeHeightParams.x) / (u_fragParams.u_colourizeHeightParams.y - u_fragParams.u_colourizeHeightParams.x), 0.0, 1.0))).xyz, u_fragParams.u_colourizeDepthColour.xyz, float3(fast::clamp((length(_124) - u_fragParams.u_colourizeDepthParams.x) / (u_fragParams.u_colourizeDepthParams.y - u_fragParams.u_colourizeDepthParams.x), 0.0, 1.0) * u_fragParams.u_colourizeDepthColour.w)).xyz, fast::clamp(abs((fract(float3(_139 * (1.0 / u_fragParams.u_contourParams.z), 1.0, 1.0).xxx + float3(1.0, 0.666666686534881591796875, 0.3333333432674407958984375)) * 6.0) - float3(3.0)) - float3(1.0), float3(0.0), float3(1.0)) * 1.0, float3(u_fragParams.u_contourParams.w)), u_fragParams.u_contourColour.xyz, float3((1.0 - step(u_fragParams.u_contourParams.y, mod(abs(_139), u_fragParams.u_contourParams.x))) * u_fragParams.u_contourColour.w));
+    float _364;
+    float4 _365;
     if ((u_fragParams.u_outlineParams.x > 0.0) && (u_fragParams.u_outlineColour.w > 0.0))
     {
-        float4 _229 = u_fragParams.u_inverseProjection * float4((in.in_var_TEXCOORD1.x * 2.0) - 1.0, (in.in_var_TEXCOORD1.y * 2.0) - 1.0, _106, 1.0);
-        float4 _234 = sceneDepthTexture.sample(sceneDepthSampler, in.in_var_TEXCOORD2);
-        float _235 = _234.x;
-        float4 _237 = sceneDepthTexture.sample(sceneDepthSampler, in.in_var_TEXCOORD3);
-        float _238 = _237.x;
-        float4 _240 = sceneDepthTexture.sample(sceneDepthSampler, in.in_var_TEXCOORD4);
-        float _241 = _240.x;
-        float4 _243 = sceneDepthTexture.sample(sceneDepthSampler, in.in_var_TEXCOORD5);
-        float _244 = _243.x;
-        float4 _259 = u_fragParams.u_inverseProjection * float4((in.in_var_TEXCOORD2.x * 2.0) - 1.0, (in.in_var_TEXCOORD2.y * 2.0) - 1.0, ((_89 + (_92 / (pow(2.0, _235 * _94) - 1.0))) * _104) + u_cameraPlaneParams.u_clipZNear, 1.0);
-        float4 _274 = u_fragParams.u_inverseProjection * float4((in.in_var_TEXCOORD3.x * 2.0) - 1.0, (in.in_var_TEXCOORD3.y * 2.0) - 1.0, ((_89 + (_92 / (pow(2.0, _238 * _94) - 1.0))) * _104) + u_cameraPlaneParams.u_clipZNear, 1.0);
-        float4 _289 = u_fragParams.u_inverseProjection * float4((in.in_var_TEXCOORD4.x * 2.0) - 1.0, (in.in_var_TEXCOORD4.y * 2.0) - 1.0, ((_89 + (_92 / (pow(2.0, _241 * _94) - 1.0))) * _104) + u_cameraPlaneParams.u_clipZNear, 1.0);
-        float4 _304 = u_fragParams.u_inverseProjection * float4((in.in_var_TEXCOORD5.x * 2.0) - 1.0, (in.in_var_TEXCOORD5.y * 2.0) - 1.0, ((_89 + (_92 / (pow(2.0, _244 * _94) - 1.0))) * _104) + u_cameraPlaneParams.u_clipZNear, 1.0);
-        float3 _317 = (_229 / float4(_229.w)).xyz;
-        float4 _354 = mix(float4(_207, _83), float4(mix(_207.xyz, u_fragParams.u_outlineColour.xyz, float3(u_fragParams.u_outlineColour.w)), fast::min(fast::min(fast::min(_235, _238), _241), _244)), float4(1.0 - (((step(length(_317 - (_259 / float4(_259.w)).xyz), u_fragParams.u_outlineParams.y) * step(length(_317 - (_274 / float4(_274.w)).xyz), u_fragParams.u_outlineParams.y)) * step(length(_317 - (_289 / float4(_289.w)).xyz), u_fragParams.u_outlineParams.y)) * step(length(_317 - (_304 / float4(_304.w)).xyz), u_fragParams.u_outlineParams.y))));
-        _357 = _354.w;
-        _358 = float4(_354.x, _354.y, _354.z, _78.w);
+        float4 _236 = u_fragParams.u_inverseProjection * float4((in.in_var_TEXCOORD1.x * 2.0) - 1.0, (in.in_var_TEXCOORD1.y * 2.0) - 1.0, _113, 1.0);
+        float4 _241 = sceneDepthTexture.sample(sceneDepthSampler, in.in_var_TEXCOORD2);
+        float _242 = _241.x;
+        float4 _244 = sceneDepthTexture.sample(sceneDepthSampler, in.in_var_TEXCOORD3);
+        float _245 = _244.x;
+        float4 _247 = sceneDepthTexture.sample(sceneDepthSampler, in.in_var_TEXCOORD4);
+        float _248 = _247.x;
+        float4 _250 = sceneDepthTexture.sample(sceneDepthSampler, in.in_var_TEXCOORD5);
+        float _251 = _250.x;
+        float4 _266 = u_fragParams.u_inverseProjection * float4((in.in_var_TEXCOORD2.x * 2.0) - 1.0, (in.in_var_TEXCOORD2.y * 2.0) - 1.0, ((_96 + (_99 / (pow(2.0, _242 * _101) - 1.0))) * _111) + u_cameraPlaneParams.u_clipZNear, 1.0);
+        float4 _281 = u_fragParams.u_inverseProjection * float4((in.in_var_TEXCOORD3.x * 2.0) - 1.0, (in.in_var_TEXCOORD3.y * 2.0) - 1.0, ((_96 + (_99 / (pow(2.0, _245 * _101) - 1.0))) * _111) + u_cameraPlaneParams.u_clipZNear, 1.0);
+        float4 _296 = u_fragParams.u_inverseProjection * float4((in.in_var_TEXCOORD4.x * 2.0) - 1.0, (in.in_var_TEXCOORD4.y * 2.0) - 1.0, ((_96 + (_99 / (pow(2.0, _248 * _101) - 1.0))) * _111) + u_cameraPlaneParams.u_clipZNear, 1.0);
+        float4 _311 = u_fragParams.u_inverseProjection * float4((in.in_var_TEXCOORD5.x * 2.0) - 1.0, (in.in_var_TEXCOORD5.y * 2.0) - 1.0, ((_96 + (_99 / (pow(2.0, _251 * _101) - 1.0))) * _111) + u_cameraPlaneParams.u_clipZNear, 1.0);
+        float3 _324 = (_236 / float4(_236.w)).xyz;
+        float4 _361 = mix(float4(_214, _90), float4(mix(_214.xyz, u_fragParams.u_outlineColour.xyz, float3(u_fragParams.u_outlineColour.w)), fast::min(fast::min(fast::min(_242, _245), _248), _251)), float4(1.0 - (((step(length(_324 - (_266 / float4(_266.w)).xyz), u_fragParams.u_outlineParams.y) * step(length(_324 - (_281 / float4(_281.w)).xyz), u_fragParams.u_outlineParams.y)) * step(length(_324 - (_296 / float4(_296.w)).xyz), u_fragParams.u_outlineParams.y)) * step(length(_324 - (_311 / float4(_311.w)).xyz), u_fragParams.u_outlineParams.y))));
+        _364 = _361.w;
+        _365 = float4(_361.x, _361.y, _361.z, _81.w);
     }
     else
     {
-        _357 = _83;
-        _358 = float4(_207.x, _207.y, _207.z, _78.w);
+        _364 = _90;
+        _365 = float4(_214.x, _214.y, _214.z, _81.w);
     }
-    float4 _363 = float4(_358.xyz, 1.0);
-    _363.w = _357;
-    out.out_var_SV_Target = _363;
-    out.gl_FragDepth = _357;
+    out.out_var_SV_Target0 = float4(_365.xyz, 1.0);
+    out.out_var_SV_Target1 = _85;
+    out.gl_FragDepth = _364;
     return out;
 }
 

--- a/src/gl/metal/shaders/mobile/waterFragmentShader.metal
+++ b/src/gl/metal/shaders/mobile/waterFragmentShader.metal
@@ -20,7 +20,8 @@ struct type_u_EveryFrameFrag
 
 struct main0_out
 {
-    float4 out_var_SV_Target [[color(0)]];
+    float4 out_var_SV_Target0 [[color(0)]];
+    float4 out_var_SV_Target1 [[color(1)]];
     float gl_FragDepth [[depth(any)]];
 };
 
@@ -36,16 +37,15 @@ struct main0_in
 fragment main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], constant type_u_EveryFrameFrag& u_EveryFrameFrag [[buffer(1)]], texture2d<float> normalMapTexture [[texture(0)]], texture2d<float> skyboxTexture [[texture(1)]], sampler normalMapSampler [[sampler(0)]], sampler skyboxSampler [[sampler(1)]])
 {
     main0_out out = {};
-    float3 _90 = normalize(((normalMapTexture.sample(normalMapSampler, in.in_var_TEXCOORD0).xyz * float3(2.0)) - float3(1.0)) + ((normalMapTexture.sample(normalMapSampler, in.in_var_TEXCOORD1).xyz * float3(2.0)) - float3(1.0)));
-    float3 _92 = normalize(in.in_var_COLOR0.xyz);
-    float3 _108 = normalize((u_EveryFrameFrag.u_eyeNormalMatrix * float4(_90, 0.0)).xyz);
-    float3 _110 = normalize(reflect(_92, _108));
-    float3 _134 = normalize((u_EveryFrameFrag.u_inverseViewMatrix * float4(_110, 0.0)).xyz);
-    float _162 = log2(in.in_var_TEXCOORD2.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
-    float4 _165 = (float4(mix(skyboxTexture.sample(skyboxSampler, (float2(atan2(_134.x, _134.y) + 3.1415927410125732421875, acos(_134.z)) * float2(0.15915493667125701904296875, 0.3183098733425140380859375))).xyz, in.in_var_COLOR1.xyz * mix(float3(1.0, 1.0, 0.60000002384185791015625), float3(0.3499999940395355224609375), float3(pow(fast::max(0.0, _90.z), 5.0))), float3(((dot(_108, _92) * (-0.5)) + 0.5) * 0.75)) + float3(pow(abs(dot(_110, normalize((u_EveryFrameFrag.u_eyeNormalMatrix * float4(normalize(u_EveryFrameFrag.u_specularDir.xyz), 0.0)).xyz))), 50.0) * 0.5), 1.0) * 0.300000011920928955078125) + float4(0.20000000298023223876953125, 0.4000000059604644775390625, 0.699999988079071044921875, 1.0);
-    _165.w = _162;
-    out.out_var_SV_Target = _165;
-    out.gl_FragDepth = _162;
+    float3 _91 = normalize(((normalMapTexture.sample(normalMapSampler, in.in_var_TEXCOORD0).xyz * float3(2.0)) - float3(1.0)) + ((normalMapTexture.sample(normalMapSampler, in.in_var_TEXCOORD1).xyz * float3(2.0)) - float3(1.0)));
+    float3 _93 = normalize(in.in_var_COLOR0.xyz);
+    float3 _109 = normalize((u_EveryFrameFrag.u_eyeNormalMatrix * float4(_91, 0.0)).xyz);
+    float3 _111 = normalize(reflect(_93, _109));
+    float3 _135 = normalize((u_EveryFrameFrag.u_inverseViewMatrix * float4(_111, 0.0)).xyz);
+    float _163 = log2(in.in_var_TEXCOORD2.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    out.out_var_SV_Target0 = (float4(mix(skyboxTexture.sample(skyboxSampler, (float2(atan2(_135.x, _135.y) + 3.1415927410125732421875, acos(_135.z)) * float2(0.15915493667125701904296875, 0.3183098733425140380859375))).xyz, in.in_var_COLOR1.xyz * mix(float3(1.0, 1.0, 0.60000002384185791015625), float3(0.3499999940395355224609375), float3(pow(fast::max(0.0, _91.z), 5.0))), float3(((dot(_109, _93) * (-0.5)) + 0.5) * 0.75)) + float3(pow(abs(dot(_111, normalize((u_EveryFrameFrag.u_eyeNormalMatrix * float4(normalize(u_EveryFrameFrag.u_specularDir.xyz), 0.0)).xyz))), 50.0) * 0.5), 1.0) * 0.300000011920928955078125) + float4(0.20000000298023223876953125, 0.4000000059604644775390625, 0.699999988079071044921875, 1.0);
+    out.out_var_SV_Target1 = float4(0.0, 0.0, 0.0, _163);
+    out.gl_FragDepth = _163;
     return out;
 }
 

--- a/src/gl/opengl/shaders/desktop/atmosphereFragmentShader.frag
+++ b/src/gl/opengl/shaders/desktop/atmosphereFragmentShader.frag
@@ -20,540 +20,544 @@ layout(std140) uniform type_u_fragParams
     layout(row_major) mat4 u_inverseProjection;
 } u_fragParams;
 
-uniform sampler2D SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler;
 uniform sampler2D SPIRV_Cross_CombinedsceneColourTexturesceneColourSampler;
+uniform sampler2D SPIRV_Cross_CombinedsceneNormalTexturesceneNormalSampler;
+uniform sampler2D SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler;
 uniform sampler2D SPIRV_Cross_CombinedirradianceTextureirradianceSampler;
 uniform sampler2D SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler;
 uniform sampler3D SPIRV_Cross_CombinedscatteringTexturescatteringSampler;
 
 layout(location = 0) in vec2 in_var_TEXCOORD0;
 layout(location = 1) in vec3 in_var_TEXCOORD1;
-layout(location = 0) out vec4 out_var_SV_Target;
+layout(location = 0) out vec4 out_var_SV_Target0;
+layout(location = 1) out vec4 out_var_SV_Target1;
 
-vec4 _105;
+vec4 _108;
 
 void main()
 {
-    float _113 = u_fragParams.u_earthCenter.w + 60000.0;
-    vec3 _126 = normalize(in_var_TEXCOORD1);
-    vec4 _130 = texture(SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler, in_var_TEXCOORD0);
-    float _131 = _130.x;
-    float _136 = u_cameraPlaneParams.s_CameraFarPlane - u_cameraPlaneParams.s_CameraNearPlane;
-    vec4 _151 = texture(SPIRV_Cross_CombinedsceneColourTexturesceneColourSampler, in_var_TEXCOORD0);
-    vec3 _154 = pow(abs(_151.xyz), vec3(2.2000000476837158203125));
-    float _160 = ((2.0 * u_cameraPlaneParams.s_CameraNearPlane) / ((u_cameraPlaneParams.s_CameraFarPlane + u_cameraPlaneParams.s_CameraNearPlane) - (((u_cameraPlaneParams.s_CameraFarPlane / _136) + (((u_cameraPlaneParams.s_CameraFarPlane * u_cameraPlaneParams.s_CameraNearPlane) / (u_cameraPlaneParams.s_CameraNearPlane - u_cameraPlaneParams.s_CameraFarPlane)) / (pow(2.0, _131 * log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0)) - 1.0))) * _136))) * u_cameraPlaneParams.s_CameraFarPlane;
-    bool _163 = _131 < 0.64999997615814208984375;
-    vec3 _754;
-    if (_163)
+    float _116 = u_fragParams.u_earthCenter.w + 60000.0;
+    vec3 _129 = normalize(in_var_TEXCOORD1);
+    vec4 _133 = texture(SPIRV_Cross_CombinedsceneColourTexturesceneColourSampler, in_var_TEXCOORD0);
+    vec4 _137 = texture(SPIRV_Cross_CombinedsceneNormalTexturesceneNormalSampler, in_var_TEXCOORD0);
+    vec4 _141 = texture(SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler, in_var_TEXCOORD0);
+    float _142 = _141.x;
+    float _147 = u_cameraPlaneParams.s_CameraFarPlane - u_cameraPlaneParams.s_CameraNearPlane;
+    vec3 _161 = pow(abs(_133.xyz), vec3(2.2000000476837158203125));
+    float _167 = ((2.0 * u_cameraPlaneParams.s_CameraNearPlane) / ((u_cameraPlaneParams.s_CameraFarPlane + u_cameraPlaneParams.s_CameraNearPlane) - (((u_cameraPlaneParams.s_CameraFarPlane / _147) + (((u_cameraPlaneParams.s_CameraFarPlane * u_cameraPlaneParams.s_CameraNearPlane) / (u_cameraPlaneParams.s_CameraNearPlane - u_cameraPlaneParams.s_CameraFarPlane)) / (pow(2.0, _142 * log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0)) - 1.0))) * _147))) * u_cameraPlaneParams.s_CameraFarPlane;
+    bool _170 = _142 < 0.64999997615814208984375;
+    vec3 _761;
+    if (_170)
     {
-        vec3 _166 = (u_fragParams.u_camera.xyz + (_126 * _160)) - u_fragParams.u_earthCenter.xyz;
-        vec3 _167 = normalize(_166);
-        float _170 = length(_166);
-        float _172 = dot(_166, u_fragParams.u_sunDirection.xyz) / _170;
-        float _174 = _113 - u_fragParams.u_earthCenter.w;
-        vec4 _185 = texture(SPIRV_Cross_CombinedirradianceTextureirradianceSampler, vec2(0.0078125 + (((_172 * 0.5) + 0.5) * 0.984375), 0.03125 + (((_170 - u_fragParams.u_earthCenter.w) / _174) * 0.9375)));
-        float _192 = u_fragParams.u_earthCenter.w / _170;
-        float _198 = _113 * _113;
-        float _199 = u_fragParams.u_earthCenter.w * u_fragParams.u_earthCenter.w;
-        float _201 = sqrt(_198 - _199);
-        float _202 = _170 * _170;
-        float _205 = sqrt(max(_202 - _199, 0.0));
-        float _216 = _113 - _170;
-        vec4 _229 = texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_170) * _172) + sqrt(max((_202 * ((_172 * _172) - 1.0)) + _198, 0.0)), 0.0) - _216) / ((_205 + _201) - _216)) * 0.99609375), 0.0078125 + ((_205 / _201) * 0.984375)));
-        float _248 = mix(_160 * 0.64999997615814208984375, 0.0, pow(_131 * 1.53846156597137451171875, 8.0));
-        vec3 _249 = u_fragParams.u_camera.xyz - u_fragParams.u_earthCenter.xyz;
-        vec3 _252 = normalize(_166 - _249);
-        float _253 = length(_249);
-        float _254 = dot(_249, _252);
-        float _261 = (-_254) - sqrt(((_254 * _254) - (_253 * _253)) + _198);
-        bool _262 = _261 > 0.0;
-        vec3 _268;
-        float _269;
-        if (_262)
+        vec3 _173 = (u_fragParams.u_camera.xyz + (_129 * _167)) - u_fragParams.u_earthCenter.xyz;
+        vec3 _174 = normalize(_173);
+        float _177 = length(_173);
+        float _179 = dot(_173, u_fragParams.u_sunDirection.xyz) / _177;
+        float _181 = _116 - u_fragParams.u_earthCenter.w;
+        vec4 _192 = texture(SPIRV_Cross_CombinedirradianceTextureirradianceSampler, vec2(0.0078125 + (((_179 * 0.5) + 0.5) * 0.984375), 0.03125 + (((_177 - u_fragParams.u_earthCenter.w) / _181) * 0.9375)));
+        float _199 = u_fragParams.u_earthCenter.w / _177;
+        float _205 = _116 * _116;
+        float _206 = u_fragParams.u_earthCenter.w * u_fragParams.u_earthCenter.w;
+        float _208 = sqrt(_205 - _206);
+        float _209 = _177 * _177;
+        float _212 = sqrt(max(_209 - _206, 0.0));
+        float _223 = _116 - _177;
+        vec4 _236 = texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_177) * _179) + sqrt(max((_209 * ((_179 * _179) - 1.0)) + _205, 0.0)), 0.0) - _223) / ((_212 + _208) - _223)) * 0.99609375), 0.0078125 + ((_212 / _208) * 0.984375)));
+        float _255 = mix(_167 * 0.64999997615814208984375, 0.0, pow(_142 * 1.53846156597137451171875, 8.0));
+        vec3 _256 = u_fragParams.u_camera.xyz - u_fragParams.u_earthCenter.xyz;
+        vec3 _259 = normalize(_173 - _256);
+        float _260 = length(_256);
+        float _261 = dot(_256, _259);
+        float _268 = (-_261) - sqrt(((_261 * _261) - (_260 * _260)) + _205);
+        bool _269 = _268 > 0.0;
+        vec3 _275;
+        float _276;
+        if (_269)
         {
-            _268 = _249 + (_252 * _261);
-            _269 = _254 + _261;
+            _275 = _256 + (_259 * _268);
+            _276 = _261 + _268;
         }
         else
         {
-            _268 = _249;
-            _269 = _254;
+            _275 = _256;
+            _276 = _261;
         }
-        float _288;
-        float _270 = _262 ? _113 : _253;
-        float _271 = _269 / _270;
-        float _272 = dot(_268, u_fragParams.u_sunDirection.xyz);
-        float _273 = _272 / _270;
-        float _274 = dot(_252, u_fragParams.u_sunDirection.xyz);
-        float _276 = length(_166 - _268);
-        float _278 = _270 * _270;
-        float _281 = _278 * ((_271 * _271) - 1.0);
-        bool _284 = (_271 < 0.0) && ((_281 + _199) >= 0.0);
-        vec3 _413;
+        float _295;
+        float _277 = _269 ? _116 : _260;
+        float _278 = _276 / _277;
+        float _279 = dot(_275, u_fragParams.u_sunDirection.xyz);
+        float _280 = _279 / _277;
+        float _281 = dot(_259, u_fragParams.u_sunDirection.xyz);
+        float _283 = length(_173 - _275);
+        float _285 = _277 * _277;
+        float _288 = _285 * ((_278 * _278) - 1.0);
+        bool _291 = (_278 < 0.0) && ((_288 + _206) >= 0.0);
+        vec3 _420;
         switch (0u)
         {
             default:
             {
-                _288 = (2.0 * _270) * _271;
-                float _293 = clamp(sqrt((_276 * (_276 + _288)) + _278), u_fragParams.u_earthCenter.w, _113);
-                float _296 = clamp((_269 + _276) / _293, -1.0, 1.0);
-                if (_284)
+                _295 = (2.0 * _277) * _278;
+                float _300 = clamp(sqrt((_283 * (_283 + _295)) + _285), u_fragParams.u_earthCenter.w, _116);
+                float _303 = clamp((_276 + _283) / _300, -1.0, 1.0);
+                if (_291)
                 {
-                    float _354 = -_296;
-                    float _355 = _293 * _293;
-                    float _358 = sqrt(max(_355 - _199, 0.0));
-                    float _369 = _113 - _293;
-                    float _383 = -_271;
-                    float _386 = sqrt(max(_278 - _199, 0.0));
-                    float _397 = _113 - _270;
-                    _413 = min(texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_293) * _354) + sqrt(max((_355 * ((_354 * _354) - 1.0)) + _198, 0.0)), 0.0) - _369) / ((_358 + _201) - _369)) * 0.99609375), 0.0078125 + ((_358 / _201) * 0.984375))).xyz / texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_270) * _383) + sqrt(max((_278 * ((_383 * _383) - 1.0)) + _198, 0.0)), 0.0) - _397) / ((_386 + _201) - _397)) * 0.99609375), 0.0078125 + ((_386 / _201) * 0.984375))).xyz, vec3(1.0));
+                    float _361 = -_303;
+                    float _362 = _300 * _300;
+                    float _365 = sqrt(max(_362 - _206, 0.0));
+                    float _376 = _116 - _300;
+                    float _390 = -_278;
+                    float _393 = sqrt(max(_285 - _206, 0.0));
+                    float _404 = _116 - _277;
+                    _420 = min(texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_300) * _361) + sqrt(max((_362 * ((_361 * _361) - 1.0)) + _205, 0.0)), 0.0) - _376) / ((_365 + _208) - _376)) * 0.99609375), 0.0078125 + ((_365 / _208) * 0.984375))).xyz / texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_277) * _390) + sqrt(max((_285 * ((_390 * _390) - 1.0)) + _205, 0.0)), 0.0) - _404) / ((_393 + _208) - _404)) * 0.99609375), 0.0078125 + ((_393 / _208) * 0.984375))).xyz, vec3(1.0));
                     break;
                 }
                 else
                 {
-                    float _302 = sqrt(max(_278 - _199, 0.0));
-                    float _310 = _113 - _270;
-                    float _324 = _293 * _293;
-                    float _327 = sqrt(max(_324 - _199, 0.0));
-                    float _338 = _113 - _293;
-                    _413 = min(texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_270) * _271) + sqrt(max(_281 + _198, 0.0)), 0.0) - _310) / ((_302 + _201) - _310)) * 0.99609375), 0.0078125 + ((_302 / _201) * 0.984375))).xyz / texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_293) * _296) + sqrt(max((_324 * ((_296 * _296) - 1.0)) + _198, 0.0)), 0.0) - _338) / ((_327 + _201) - _338)) * 0.99609375), 0.0078125 + ((_327 / _201) * 0.984375))).xyz, vec3(1.0));
+                    float _309 = sqrt(max(_285 - _206, 0.0));
+                    float _317 = _116 - _277;
+                    float _331 = _300 * _300;
+                    float _334 = sqrt(max(_331 - _206, 0.0));
+                    float _345 = _116 - _300;
+                    _420 = min(texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_277) * _278) + sqrt(max(_288 + _205, 0.0)), 0.0) - _317) / ((_309 + _208) - _317)) * 0.99609375), 0.0078125 + ((_309 / _208) * 0.984375))).xyz / texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_300) * _303) + sqrt(max((_331 * ((_303 * _303) - 1.0)) + _205, 0.0)), 0.0) - _345) / ((_334 + _208) - _345)) * 0.99609375), 0.0078125 + ((_334 / _208) * 0.984375))).xyz, vec3(1.0));
                     break;
                 }
             }
         }
-        float _416 = sqrt(max(_278 - _199, 0.0));
-        float _417 = _416 / _201;
-        float _419 = 0.015625 + (_417 * 0.96875);
-        float _422 = ((_269 * _269) - _278) + _199;
-        float _455;
-        if (_284)
+        float _423 = sqrt(max(_285 - _206, 0.0));
+        float _424 = _423 / _208;
+        float _426 = 0.015625 + (_424 * 0.96875);
+        float _429 = ((_276 * _276) - _285) + _206;
+        float _462;
+        if (_291)
         {
-            float _445 = _270 - u_fragParams.u_earthCenter.w;
-            _455 = 0.5 - (0.5 * (0.0078125 + (((_416 == _445) ? 0.0 : ((((-_269) - sqrt(max(_422, 0.0))) - _445) / (_416 - _445))) * 0.984375)));
+            float _452 = _277 - u_fragParams.u_earthCenter.w;
+            _462 = 0.5 - (0.5 * (0.0078125 + (((_423 == _452) ? 0.0 : ((((-_276) - sqrt(max(_429, 0.0))) - _452) / (_423 - _452))) * 0.984375)));
         }
         else
         {
-            float _432 = _113 - _270;
-            _455 = 0.5 + (0.5 * (0.0078125 + (((((-_269) + sqrt(max(_422 + (_201 * _201), 0.0))) - _432) / ((_416 + _201) - _432)) * 0.984375)));
+            float _439 = _116 - _277;
+            _462 = 0.5 + (0.5 * (0.0078125 + (((((-_276) + sqrt(max(_429 + (_208 * _208), 0.0))) - _439) / ((_423 + _208) - _439)) * 0.984375)));
         }
-        float _460 = -u_fragParams.u_earthCenter.w;
-        float _467 = _201 - _174;
-        float _468 = (max((_460 * _273) + sqrt(max((_199 * ((_273 * _273) - 1.0)) + _198, 0.0)), 0.0) - _174) / _467;
-        float _470 = (0.415823996067047119140625 * u_fragParams.u_earthCenter.w) / _467;
-        float _477 = 0.015625 + ((max(1.0 - (_468 / _470), 0.0) / (1.0 + _468)) * 0.96875);
-        float _479 = (_274 + 1.0) * 3.5;
-        float _480 = floor(_479);
-        float _481 = _479 - _480;
-        float _485 = _480 + 1.0;
-        vec4 _491 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_480 + _477) * 0.125, _455, _419));
-        float _492 = 1.0 - _481;
-        vec4 _495 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_485 + _477) * 0.125, _455, _419));
-        vec4 _497 = (_491 * _492) + (_495 * _481);
-        vec3 _498 = _497.xyz;
-        vec3 _511;
+        float _467 = -u_fragParams.u_earthCenter.w;
+        float _474 = _208 - _181;
+        float _475 = (max((_467 * _280) + sqrt(max((_206 * ((_280 * _280) - 1.0)) + _205, 0.0)), 0.0) - _181) / _474;
+        float _477 = (0.415823996067047119140625 * u_fragParams.u_earthCenter.w) / _474;
+        float _484 = 0.015625 + ((max(1.0 - (_475 / _477), 0.0) / (1.0 + _475)) * 0.96875);
+        float _486 = (_281 + 1.0) * 3.5;
+        float _487 = floor(_486);
+        float _488 = _486 - _487;
+        float _492 = _487 + 1.0;
+        vec4 _498 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_487 + _484) * 0.125, _462, _426));
+        float _499 = 1.0 - _488;
+        vec4 _502 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_492 + _484) * 0.125, _462, _426));
+        vec4 _504 = (_498 * _499) + (_502 * _488);
+        vec3 _505 = _504.xyz;
+        vec3 _518;
         switch (0u)
         {
             default:
             {
-                float _501 = _497.x;
-                if (_501 == 0.0)
+                float _508 = _504.x;
+                if (_508 == 0.0)
                 {
-                    _511 = vec3(0.0);
+                    _518 = vec3(0.0);
                     break;
                 }
-                _511 = (((_498 * _497.w) / vec3(_501)) * 1.5) * vec3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
+                _518 = (((_505 * _504.w) / vec3(_508)) * 1.5) * vec3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
                 break;
             }
         }
-        float _513 = max(_276 - _248, 0.0);
-        float _518 = clamp(sqrt((_513 * (_513 + _288)) + _278), u_fragParams.u_earthCenter.w, _113);
-        float _519 = _269 + _513;
-        float _522 = (_272 + (_513 * _274)) / _518;
-        float _523 = _518 * _518;
-        float _526 = sqrt(max(_523 - _199, 0.0));
-        float _527 = _526 / _201;
-        float _529 = 0.015625 + (_527 * 0.96875);
-        float _532 = ((_519 * _519) - _523) + _199;
-        float _565;
-        if (_284)
+        float _520 = max(_283 - _255, 0.0);
+        float _525 = clamp(sqrt((_520 * (_520 + _295)) + _285), u_fragParams.u_earthCenter.w, _116);
+        float _526 = _276 + _520;
+        float _529 = (_279 + (_520 * _281)) / _525;
+        float _530 = _525 * _525;
+        float _533 = sqrt(max(_530 - _206, 0.0));
+        float _534 = _533 / _208;
+        float _536 = 0.015625 + (_534 * 0.96875);
+        float _539 = ((_526 * _526) - _530) + _206;
+        float _572;
+        if (_291)
         {
-            float _555 = _518 - u_fragParams.u_earthCenter.w;
-            _565 = 0.5 - (0.5 * (0.0078125 + (((_526 == _555) ? 0.0 : ((((-_519) - sqrt(max(_532, 0.0))) - _555) / (_526 - _555))) * 0.984375)));
+            float _562 = _525 - u_fragParams.u_earthCenter.w;
+            _572 = 0.5 - (0.5 * (0.0078125 + (((_533 == _562) ? 0.0 : ((((-_526) - sqrt(max(_539, 0.0))) - _562) / (_533 - _562))) * 0.984375)));
         }
         else
         {
-            float _542 = _113 - _518;
-            _565 = 0.5 + (0.5 * (0.0078125 + (((((-_519) + sqrt(max(_532 + (_201 * _201), 0.0))) - _542) / ((_526 + _201) - _542)) * 0.984375)));
+            float _549 = _116 - _525;
+            _572 = 0.5 + (0.5 * (0.0078125 + (((((-_526) + sqrt(max(_539 + (_208 * _208), 0.0))) - _549) / ((_533 + _208) - _549)) * 0.984375)));
         }
-        float _576 = (max((_460 * _522) + sqrt(max((_199 * ((_522 * _522) - 1.0)) + _198, 0.0)), 0.0) - _174) / _467;
-        float _583 = 0.015625 + ((max(1.0 - (_576 / _470), 0.0) / (1.0 + _576)) * 0.96875);
-        vec4 _591 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_480 + _583) * 0.125, _565, _529));
-        vec4 _594 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_485 + _583) * 0.125, _565, _529));
-        vec4 _596 = (_591 * _492) + (_594 * _481);
-        vec3 _597 = _596.xyz;
-        vec3 _610;
+        float _583 = (max((_467 * _529) + sqrt(max((_206 * ((_529 * _529) - 1.0)) + _205, 0.0)), 0.0) - _181) / _474;
+        float _590 = 0.015625 + ((max(1.0 - (_583 / _477), 0.0) / (1.0 + _583)) * 0.96875);
+        vec4 _598 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_487 + _590) * 0.125, _572, _536));
+        vec4 _601 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_492 + _590) * 0.125, _572, _536));
+        vec4 _603 = (_598 * _499) + (_601 * _488);
+        vec3 _604 = _603.xyz;
+        vec3 _617;
         switch (0u)
         {
             default:
             {
-                float _600 = _596.x;
-                if (_600 == 0.0)
+                float _607 = _603.x;
+                if (_607 == 0.0)
                 {
-                    _610 = vec3(0.0);
+                    _617 = vec3(0.0);
                     break;
                 }
-                _610 = (((_597 * _596.w) / vec3(_600)) * 1.5) * vec3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
+                _617 = (((_604 * _603.w) / vec3(_607)) * 1.5) * vec3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
                 break;
             }
         }
-        vec3 _717;
-        if (_248 > 0.0)
+        vec3 _724;
+        if (_255 > 0.0)
         {
-            vec3 _716;
+            vec3 _723;
             switch (0u)
             {
                 default:
                 {
-                    float _617 = clamp(_519 / _518, -1.0, 1.0);
-                    if (_284)
+                    float _624 = clamp(_526 / _525, -1.0, 1.0);
+                    if (_291)
                     {
-                        float _666 = -_617;
-                        float _677 = _113 - _518;
-                        float _690 = -_271;
-                        float _701 = _113 - _270;
-                        _716 = min(texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_518) * _666) + sqrt(max((_523 * ((_666 * _666) - 1.0)) + _198, 0.0)), 0.0) - _677) / ((_526 + _201) - _677)) * 0.99609375), 0.0078125 + (_527 * 0.984375))).xyz / texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_270) * _690) + sqrt(max((_278 * ((_690 * _690) - 1.0)) + _198, 0.0)), 0.0) - _701) / ((_416 + _201) - _701)) * 0.99609375), 0.0078125 + (_417 * 0.984375))).xyz, vec3(1.0));
+                        float _673 = -_624;
+                        float _684 = _116 - _525;
+                        float _697 = -_278;
+                        float _708 = _116 - _277;
+                        _723 = min(texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_525) * _673) + sqrt(max((_530 * ((_673 * _673) - 1.0)) + _205, 0.0)), 0.0) - _684) / ((_533 + _208) - _684)) * 0.99609375), 0.0078125 + (_534 * 0.984375))).xyz / texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_277) * _697) + sqrt(max((_285 * ((_697 * _697) - 1.0)) + _205, 0.0)), 0.0) - _708) / ((_423 + _208) - _708)) * 0.99609375), 0.0078125 + (_424 * 0.984375))).xyz, vec3(1.0));
                         break;
                     }
                     else
                     {
-                        float _628 = _113 - _270;
-                        float _651 = _113 - _518;
-                        _716 = min(texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_270) * _271) + sqrt(max(_281 + _198, 0.0)), 0.0) - _628) / ((_416 + _201) - _628)) * 0.99609375), 0.0078125 + (_417 * 0.984375))).xyz / texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_518) * _617) + sqrt(max((_523 * ((_617 * _617) - 1.0)) + _198, 0.0)), 0.0) - _651) / ((_526 + _201) - _651)) * 0.99609375), 0.0078125 + (_527 * 0.984375))).xyz, vec3(1.0));
+                        float _635 = _116 - _277;
+                        float _658 = _116 - _525;
+                        _723 = min(texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_277) * _278) + sqrt(max(_288 + _205, 0.0)), 0.0) - _635) / ((_423 + _208) - _635)) * 0.99609375), 0.0078125 + (_424 * 0.984375))).xyz / texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_525) * _624) + sqrt(max((_530 * ((_624 * _624) - 1.0)) + _205, 0.0)), 0.0) - _658) / ((_533 + _208) - _658)) * 0.99609375), 0.0078125 + (_534 * 0.984375))).xyz, vec3(1.0));
                         break;
                     }
                 }
             }
-            _717 = _716;
+            _724 = _723;
         }
         else
         {
-            _717 = _413;
+            _724 = _420;
         }
-        vec3 _719 = _498 - (_717 * _597);
-        vec3 _721 = _511 - (_717 * _610);
-        float _722 = _721.x;
-        float _723 = _719.x;
-        vec3 _738;
+        vec3 _726 = _505 - (_724 * _604);
+        vec3 _728 = _518 - (_724 * _617);
+        float _729 = _728.x;
+        float _730 = _726.x;
+        vec3 _745;
         switch (0u)
         {
             default:
             {
-                if (_723 == 0.0)
+                if (_730 == 0.0)
                 {
-                    _738 = vec3(0.0);
+                    _745 = vec3(0.0);
                     break;
                 }
-                _738 = (((vec4(_723, _719.yz, _722).xyz * _722) / vec3(_723)) * 1.5) * vec3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
+                _745 = (((vec4(_730, _726.yz, _729).xyz * _729) / vec3(_730)) * 1.5) * vec3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
                 break;
             }
         }
-        float _742 = 1.0 + (_274 * _274);
-        _754 = (((_154.xyz * 0.3183098733425140380859375) * ((vec3(1.47399997711181640625, 1.85039997100830078125, 1.91198003292083740234375) * max((_229.xyz * smoothstep(_192 * (-0.004674999974668025970458984375), _192 * 0.004674999974668025970458984375, _172 - (-sqrt(max(1.0 - (_192 * _192), 0.0))))) * max(dot(_167, u_fragParams.u_sunDirection.xyz), 0.0), vec3(0.001000000047497451305389404296875))) + ((_185.xyz * (1.0 + (dot(_167, _166) / _170))) * 0.5))) * _413) + ((_719 * (0.0596831031143665313720703125 * _742)) + ((_738 * smoothstep(0.0, 0.00999999977648258209228515625, _273)) * ((0.01627720706164836883544921875 * _742) / pow(1.6400001049041748046875 - (1.60000002384185791015625 * _274), 1.5))));
+        float _749 = 1.0 + (_281 * _281);
+        _761 = (((_161.xyz * 0.3183098733425140380859375) * ((vec3(1.47399997711181640625, 1.85039997100830078125, 1.91198003292083740234375) * max((_236.xyz * smoothstep(_199 * (-0.004674999974668025970458984375), _199 * 0.004674999974668025970458984375, _179 - (-sqrt(max(1.0 - (_199 * _199), 0.0))))) * max(dot(_174, u_fragParams.u_sunDirection.xyz), 0.0), vec3(0.001000000047497451305389404296875))) + ((_192.xyz * (1.0 + (dot(_174, _173) / _177))) * 0.5))) * _420) + ((_726 * (0.0596831031143665313720703125 * _749)) + ((_745 * smoothstep(0.0, 0.00999999977648258209228515625, _280)) * ((0.01627720706164836883544921875 * _749) / pow(1.6400001049041748046875 - (1.60000002384185791015625 * _281), 1.5))));
     }
     else
     {
-        _754 = vec3(0.0);
+        _761 = vec3(0.0);
     }
-    vec3 _756 = u_fragParams.u_camera.xyz - u_fragParams.u_earthCenter.xyz;
-    float _757 = dot(_756, _126);
-    float _759 = _757 * _757;
-    float _761 = -_757;
-    float _762 = u_fragParams.u_earthCenter.w * u_fragParams.u_earthCenter.w;
-    float _765 = _761 - sqrt(_762 - (dot(_756, _756) - _759));
-    bool _766 = _765 > 0.0;
-    vec3 _1245;
-    if (_766)
+    vec3 _763 = u_fragParams.u_camera.xyz - u_fragParams.u_earthCenter.xyz;
+    float _764 = dot(_763, _129);
+    float _766 = _764 * _764;
+    float _768 = -_764;
+    float _769 = u_fragParams.u_earthCenter.w * u_fragParams.u_earthCenter.w;
+    float _772 = _768 - sqrt(_769 - (dot(_763, _763) - _766));
+    bool _773 = _772 > 0.0;
+    vec3 _1252;
+    if (_773)
     {
-        vec3 _771 = (u_fragParams.u_camera.xyz + (_126 * _765)) - u_fragParams.u_earthCenter.xyz;
-        vec3 _772 = normalize(_771);
-        float _775 = length(_771);
-        float _777 = dot(_771, u_fragParams.u_sunDirection.xyz) / _775;
-        float _779 = _113 - u_fragParams.u_earthCenter.w;
-        vec4 _790 = texture(SPIRV_Cross_CombinedirradianceTextureirradianceSampler, vec2(0.0078125 + (((_777 * 0.5) + 0.5) * 0.984375), 0.03125 + (((_775 - u_fragParams.u_earthCenter.w) / _779) * 0.9375)));
-        float _797 = u_fragParams.u_earthCenter.w / _775;
-        float _803 = _113 * _113;
-        float _805 = sqrt(_803 - _762);
-        float _806 = _775 * _775;
-        float _809 = sqrt(max(_806 - _762, 0.0));
-        float _820 = _113 - _775;
-        vec4 _833 = texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_775) * _777) + sqrt(max((_806 * ((_777 * _777) - 1.0)) + _803, 0.0)), 0.0) - _820) / ((_809 + _805) - _820)) * 0.99609375), 0.0078125 + ((_809 / _805) * 0.984375)));
-        vec3 _851 = normalize(_771 - _756);
-        float _852 = length(_756);
-        float _853 = dot(_756, _851);
-        float _860 = (-_853) - sqrt(((_853 * _853) - (_852 * _852)) + _803);
-        bool _861 = _860 > 0.0;
-        vec3 _867;
-        float _868;
-        if (_861)
+        vec3 _778 = (u_fragParams.u_camera.xyz + (_129 * _772)) - u_fragParams.u_earthCenter.xyz;
+        vec3 _779 = normalize(_778);
+        float _782 = length(_778);
+        float _784 = dot(_778, u_fragParams.u_sunDirection.xyz) / _782;
+        float _786 = _116 - u_fragParams.u_earthCenter.w;
+        vec4 _797 = texture(SPIRV_Cross_CombinedirradianceTextureirradianceSampler, vec2(0.0078125 + (((_784 * 0.5) + 0.5) * 0.984375), 0.03125 + (((_782 - u_fragParams.u_earthCenter.w) / _786) * 0.9375)));
+        float _804 = u_fragParams.u_earthCenter.w / _782;
+        float _810 = _116 * _116;
+        float _812 = sqrt(_810 - _769);
+        float _813 = _782 * _782;
+        float _816 = sqrt(max(_813 - _769, 0.0));
+        float _827 = _116 - _782;
+        vec4 _840 = texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_782) * _784) + sqrt(max((_813 * ((_784 * _784) - 1.0)) + _810, 0.0)), 0.0) - _827) / ((_816 + _812) - _827)) * 0.99609375), 0.0078125 + ((_816 / _812) * 0.984375)));
+        vec3 _858 = normalize(_778 - _763);
+        float _859 = length(_763);
+        float _860 = dot(_763, _858);
+        float _867 = (-_860) - sqrt(((_860 * _860) - (_859 * _859)) + _810);
+        bool _868 = _867 > 0.0;
+        vec3 _874;
+        float _875;
+        if (_868)
         {
-            _867 = _756 + (_851 * _860);
-            _868 = _853 + _860;
+            _874 = _763 + (_858 * _867);
+            _875 = _860 + _867;
         }
         else
         {
-            _867 = _756;
-            _868 = _853;
+            _874 = _763;
+            _875 = _860;
         }
-        float _887;
-        float _869 = _861 ? _113 : _852;
-        float _870 = _868 / _869;
-        float _871 = dot(_867, u_fragParams.u_sunDirection.xyz);
-        float _872 = _871 / _869;
-        float _873 = dot(_851, u_fragParams.u_sunDirection.xyz);
-        float _875 = length(_771 - _867);
-        float _877 = _869 * _869;
-        float _880 = _877 * ((_870 * _870) - 1.0);
-        bool _883 = (_870 < 0.0) && ((_880 + _762) >= 0.0);
-        vec3 _1012;
+        float _894;
+        float _876 = _868 ? _116 : _859;
+        float _877 = _875 / _876;
+        float _878 = dot(_874, u_fragParams.u_sunDirection.xyz);
+        float _879 = _878 / _876;
+        float _880 = dot(_858, u_fragParams.u_sunDirection.xyz);
+        float _882 = length(_778 - _874);
+        float _884 = _876 * _876;
+        float _887 = _884 * ((_877 * _877) - 1.0);
+        bool _890 = (_877 < 0.0) && ((_887 + _769) >= 0.0);
+        vec3 _1019;
         switch (0u)
         {
             default:
             {
-                _887 = (2.0 * _869) * _870;
-                float _892 = clamp(sqrt((_875 * (_875 + _887)) + _877), u_fragParams.u_earthCenter.w, _113);
-                float _895 = clamp((_868 + _875) / _892, -1.0, 1.0);
-                if (_883)
+                _894 = (2.0 * _876) * _877;
+                float _899 = clamp(sqrt((_882 * (_882 + _894)) + _884), u_fragParams.u_earthCenter.w, _116);
+                float _902 = clamp((_875 + _882) / _899, -1.0, 1.0);
+                if (_890)
                 {
-                    float _953 = -_895;
-                    float _954 = _892 * _892;
-                    float _957 = sqrt(max(_954 - _762, 0.0));
-                    float _968 = _113 - _892;
-                    float _982 = -_870;
-                    float _985 = sqrt(max(_877 - _762, 0.0));
-                    float _996 = _113 - _869;
-                    _1012 = min(texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_892) * _953) + sqrt(max((_954 * ((_953 * _953) - 1.0)) + _803, 0.0)), 0.0) - _968) / ((_957 + _805) - _968)) * 0.99609375), 0.0078125 + ((_957 / _805) * 0.984375))).xyz / texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_869) * _982) + sqrt(max((_877 * ((_982 * _982) - 1.0)) + _803, 0.0)), 0.0) - _996) / ((_985 + _805) - _996)) * 0.99609375), 0.0078125 + ((_985 / _805) * 0.984375))).xyz, vec3(1.0));
+                    float _960 = -_902;
+                    float _961 = _899 * _899;
+                    float _964 = sqrt(max(_961 - _769, 0.0));
+                    float _975 = _116 - _899;
+                    float _989 = -_877;
+                    float _992 = sqrt(max(_884 - _769, 0.0));
+                    float _1003 = _116 - _876;
+                    _1019 = min(texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_899) * _960) + sqrt(max((_961 * ((_960 * _960) - 1.0)) + _810, 0.0)), 0.0) - _975) / ((_964 + _812) - _975)) * 0.99609375), 0.0078125 + ((_964 / _812) * 0.984375))).xyz / texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_876) * _989) + sqrt(max((_884 * ((_989 * _989) - 1.0)) + _810, 0.0)), 0.0) - _1003) / ((_992 + _812) - _1003)) * 0.99609375), 0.0078125 + ((_992 / _812) * 0.984375))).xyz, vec3(1.0));
                     break;
                 }
                 else
                 {
-                    float _901 = sqrt(max(_877 - _762, 0.0));
-                    float _909 = _113 - _869;
-                    float _923 = _892 * _892;
-                    float _926 = sqrt(max(_923 - _762, 0.0));
-                    float _937 = _113 - _892;
-                    _1012 = min(texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_869) * _870) + sqrt(max(_880 + _803, 0.0)), 0.0) - _909) / ((_901 + _805) - _909)) * 0.99609375), 0.0078125 + ((_901 / _805) * 0.984375))).xyz / texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_892) * _895) + sqrt(max((_923 * ((_895 * _895) - 1.0)) + _803, 0.0)), 0.0) - _937) / ((_926 + _805) - _937)) * 0.99609375), 0.0078125 + ((_926 / _805) * 0.984375))).xyz, vec3(1.0));
+                    float _908 = sqrt(max(_884 - _769, 0.0));
+                    float _916 = _116 - _876;
+                    float _930 = _899 * _899;
+                    float _933 = sqrt(max(_930 - _769, 0.0));
+                    float _944 = _116 - _899;
+                    _1019 = min(texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_876) * _877) + sqrt(max(_887 + _810, 0.0)), 0.0) - _916) / ((_908 + _812) - _916)) * 0.99609375), 0.0078125 + ((_908 / _812) * 0.984375))).xyz / texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_899) * _902) + sqrt(max((_930 * ((_902 * _902) - 1.0)) + _810, 0.0)), 0.0) - _944) / ((_933 + _812) - _944)) * 0.99609375), 0.0078125 + ((_933 / _812) * 0.984375))).xyz, vec3(1.0));
                     break;
                 }
             }
         }
-        float _1015 = sqrt(max(_877 - _762, 0.0));
-        float _1018 = 0.015625 + ((_1015 / _805) * 0.96875);
-        float _1021 = ((_868 * _868) - _877) + _762;
-        float _1054;
-        if (_883)
+        float _1022 = sqrt(max(_884 - _769, 0.0));
+        float _1025 = 0.015625 + ((_1022 / _812) * 0.96875);
+        float _1028 = ((_875 * _875) - _884) + _769;
+        float _1061;
+        if (_890)
         {
-            float _1044 = _869 - u_fragParams.u_earthCenter.w;
-            _1054 = 0.5 - (0.5 * (0.0078125 + (((_1015 == _1044) ? 0.0 : ((((-_868) - sqrt(max(_1021, 0.0))) - _1044) / (_1015 - _1044))) * 0.984375)));
+            float _1051 = _876 - u_fragParams.u_earthCenter.w;
+            _1061 = 0.5 - (0.5 * (0.0078125 + (((_1022 == _1051) ? 0.0 : ((((-_875) - sqrt(max(_1028, 0.0))) - _1051) / (_1022 - _1051))) * 0.984375)));
         }
         else
         {
-            float _1031 = _113 - _869;
-            _1054 = 0.5 + (0.5 * (0.0078125 + (((((-_868) + sqrt(max(_1021 + (_805 * _805), 0.0))) - _1031) / ((_1015 + _805) - _1031)) * 0.984375)));
+            float _1038 = _116 - _876;
+            _1061 = 0.5 + (0.5 * (0.0078125 + (((((-_875) + sqrt(max(_1028 + (_812 * _812), 0.0))) - _1038) / ((_1022 + _812) - _1038)) * 0.984375)));
         }
-        float _1059 = -u_fragParams.u_earthCenter.w;
-        float _1066 = _805 - _779;
-        float _1067 = (max((_1059 * _872) + sqrt(max((_762 * ((_872 * _872) - 1.0)) + _803, 0.0)), 0.0) - _779) / _1066;
-        float _1069 = (0.415823996067047119140625 * u_fragParams.u_earthCenter.w) / _1066;
-        float _1076 = 0.015625 + ((max(1.0 - (_1067 / _1069), 0.0) / (1.0 + _1067)) * 0.96875);
-        float _1078 = (_873 + 1.0) * 3.5;
-        float _1079 = floor(_1078);
-        float _1080 = _1078 - _1079;
-        float _1084 = _1079 + 1.0;
-        vec4 _1090 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_1079 + _1076) * 0.125, _1054, _1018));
-        float _1091 = 1.0 - _1080;
-        vec4 _1094 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_1084 + _1076) * 0.125, _1054, _1018));
-        vec4 _1096 = (_1090 * _1091) + (_1094 * _1080);
-        vec3 _1097 = _1096.xyz;
-        vec3 _1110;
+        float _1066 = -u_fragParams.u_earthCenter.w;
+        float _1073 = _812 - _786;
+        float _1074 = (max((_1066 * _879) + sqrt(max((_769 * ((_879 * _879) - 1.0)) + _810, 0.0)), 0.0) - _786) / _1073;
+        float _1076 = (0.415823996067047119140625 * u_fragParams.u_earthCenter.w) / _1073;
+        float _1083 = 0.015625 + ((max(1.0 - (_1074 / _1076), 0.0) / (1.0 + _1074)) * 0.96875);
+        float _1085 = (_880 + 1.0) * 3.5;
+        float _1086 = floor(_1085);
+        float _1087 = _1085 - _1086;
+        float _1091 = _1086 + 1.0;
+        vec4 _1097 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_1086 + _1083) * 0.125, _1061, _1025));
+        float _1098 = 1.0 - _1087;
+        vec4 _1101 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_1091 + _1083) * 0.125, _1061, _1025));
+        vec4 _1103 = (_1097 * _1098) + (_1101 * _1087);
+        vec3 _1104 = _1103.xyz;
+        vec3 _1117;
         switch (0u)
         {
             default:
             {
-                float _1100 = _1096.x;
-                if (_1100 == 0.0)
+                float _1107 = _1103.x;
+                if (_1107 == 0.0)
                 {
-                    _1110 = vec3(0.0);
+                    _1117 = vec3(0.0);
                     break;
                 }
-                _1110 = (((_1097 * _1096.w) / vec3(_1100)) * 1.5) * vec3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
+                _1117 = (((_1104 * _1103.w) / vec3(_1107)) * 1.5) * vec3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
                 break;
             }
         }
-        float _1111 = max(_875, 0.0);
-        float _1116 = clamp(sqrt((_1111 * (_1111 + _887)) + _877), u_fragParams.u_earthCenter.w, _113);
-        float _1117 = _868 + _1111;
-        float _1120 = (_871 + (_1111 * _873)) / _1116;
-        float _1121 = _1116 * _1116;
-        float _1124 = sqrt(max(_1121 - _762, 0.0));
-        float _1127 = 0.015625 + ((_1124 / _805) * 0.96875);
-        float _1130 = ((_1117 * _1117) - _1121) + _762;
-        float _1163;
-        if (_883)
+        float _1118 = max(_882, 0.0);
+        float _1123 = clamp(sqrt((_1118 * (_1118 + _894)) + _884), u_fragParams.u_earthCenter.w, _116);
+        float _1124 = _875 + _1118;
+        float _1127 = (_878 + (_1118 * _880)) / _1123;
+        float _1128 = _1123 * _1123;
+        float _1131 = sqrt(max(_1128 - _769, 0.0));
+        float _1134 = 0.015625 + ((_1131 / _812) * 0.96875);
+        float _1137 = ((_1124 * _1124) - _1128) + _769;
+        float _1170;
+        if (_890)
         {
-            float _1153 = _1116 - u_fragParams.u_earthCenter.w;
-            _1163 = 0.5 - (0.5 * (0.0078125 + (((_1124 == _1153) ? 0.0 : ((((-_1117) - sqrt(max(_1130, 0.0))) - _1153) / (_1124 - _1153))) * 0.984375)));
+            float _1160 = _1123 - u_fragParams.u_earthCenter.w;
+            _1170 = 0.5 - (0.5 * (0.0078125 + (((_1131 == _1160) ? 0.0 : ((((-_1124) - sqrt(max(_1137, 0.0))) - _1160) / (_1131 - _1160))) * 0.984375)));
         }
         else
         {
-            float _1140 = _113 - _1116;
-            _1163 = 0.5 + (0.5 * (0.0078125 + (((((-_1117) + sqrt(max(_1130 + (_805 * _805), 0.0))) - _1140) / ((_1124 + _805) - _1140)) * 0.984375)));
+            float _1147 = _116 - _1123;
+            _1170 = 0.5 + (0.5 * (0.0078125 + (((((-_1124) + sqrt(max(_1137 + (_812 * _812), 0.0))) - _1147) / ((_1131 + _812) - _1147)) * 0.984375)));
         }
-        float _1174 = (max((_1059 * _1120) + sqrt(max((_762 * ((_1120 * _1120) - 1.0)) + _803, 0.0)), 0.0) - _779) / _1066;
-        float _1181 = 0.015625 + ((max(1.0 - (_1174 / _1069), 0.0) / (1.0 + _1174)) * 0.96875);
-        vec4 _1189 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_1079 + _1181) * 0.125, _1163, _1127));
-        vec4 _1192 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_1084 + _1181) * 0.125, _1163, _1127));
-        vec4 _1194 = (_1189 * _1091) + (_1192 * _1080);
-        vec3 _1195 = _1194.xyz;
-        vec3 _1208;
+        float _1181 = (max((_1066 * _1127) + sqrt(max((_769 * ((_1127 * _1127) - 1.0)) + _810, 0.0)), 0.0) - _786) / _1073;
+        float _1188 = 0.015625 + ((max(1.0 - (_1181 / _1076), 0.0) / (1.0 + _1181)) * 0.96875);
+        vec4 _1196 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_1086 + _1188) * 0.125, _1170, _1134));
+        vec4 _1199 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_1091 + _1188) * 0.125, _1170, _1134));
+        vec4 _1201 = (_1196 * _1098) + (_1199 * _1087);
+        vec3 _1202 = _1201.xyz;
+        vec3 _1215;
         switch (0u)
         {
             default:
             {
-                float _1198 = _1194.x;
-                if (_1198 == 0.0)
+                float _1205 = _1201.x;
+                if (_1205 == 0.0)
                 {
-                    _1208 = vec3(0.0);
+                    _1215 = vec3(0.0);
                     break;
                 }
-                _1208 = (((_1195 * _1194.w) / vec3(_1198)) * 1.5) * vec3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
+                _1215 = (((_1202 * _1201.w) / vec3(_1205)) * 1.5) * vec3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
                 break;
             }
         }
-        vec3 _1210 = _1097 - (_1012 * _1195);
-        vec3 _1212 = _1110 - (_1012 * _1208);
-        float _1213 = _1212.x;
-        float _1214 = _1210.x;
-        vec3 _1229;
+        vec3 _1217 = _1104 - (_1019 * _1202);
+        vec3 _1219 = _1117 - (_1019 * _1215);
+        float _1220 = _1219.x;
+        float _1221 = _1217.x;
+        vec3 _1236;
         switch (0u)
         {
             default:
             {
-                if (_1214 == 0.0)
+                if (_1221 == 0.0)
                 {
-                    _1229 = vec3(0.0);
+                    _1236 = vec3(0.0);
                     break;
                 }
-                _1229 = (((vec4(_1214, _1210.yz, _1213).xyz * _1213) / vec3(_1214)) * 1.5) * vec3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
+                _1236 = (((vec4(_1221, _1217.yz, _1220).xyz * _1220) / vec3(_1221)) * 1.5) * vec3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
                 break;
             }
         }
-        float _1233 = 1.0 + (_873 * _873);
-        _1245 = (((_154.xyz * 0.3183098733425140380859375) * ((vec3(1.47399997711181640625, 1.85039997100830078125, 1.91198003292083740234375) * max((_833.xyz * smoothstep(_797 * (-0.004674999974668025970458984375), _797 * 0.004674999974668025970458984375, _777 - (-sqrt(max(1.0 - (_797 * _797), 0.0))))) * max(dot(_772, u_fragParams.u_sunDirection.xyz), 0.0), vec3(0.001000000047497451305389404296875))) + ((_790.xyz * (1.0 + (dot(_772, _771) / _775))) * 0.5))) * _1012) + ((_1210 * (0.0596831031143665313720703125 * _1233)) + ((_1229 * smoothstep(0.0, 0.00999999977648258209228515625, _872)) * ((0.01627720706164836883544921875 * _1233) / pow(1.6400001049041748046875 - (1.60000002384185791015625 * _873), 1.5))));
+        float _1240 = 1.0 + (_880 * _880);
+        _1252 = (((_161.xyz * 0.3183098733425140380859375) * ((vec3(1.47399997711181640625, 1.85039997100830078125, 1.91198003292083740234375) * max((_840.xyz * smoothstep(_804 * (-0.004674999974668025970458984375), _804 * 0.004674999974668025970458984375, _784 - (-sqrt(max(1.0 - (_804 * _804), 0.0))))) * max(dot(_779, u_fragParams.u_sunDirection.xyz), 0.0), vec3(0.001000000047497451305389404296875))) + ((_797.xyz * (1.0 + (dot(_779, _778) / _782))) * 0.5))) * _1019) + ((_1217 * (0.0596831031143665313720703125 * _1240)) + ((_1236 * smoothstep(0.0, 0.00999999977648258209228515625, _879)) * ((0.01627720706164836883544921875 * _1240) / pow(1.6400001049041748046875 - (1.60000002384185791015625 * _880), 1.5))));
     }
     else
     {
-        _1245 = vec3(0.0);
+        _1252 = vec3(0.0);
     }
-    vec3 _1415;
-    vec3 _1416;
+    vec3 _1422;
+    vec3 _1423;
     switch (0u)
     {
         default:
         {
-            float _1251 = length(_756);
-            float _1254 = _113 * _113;
-            float _1257 = _761 - sqrt((_759 - (_1251 * _1251)) + _1254);
-            bool _1258 = _1257 > 0.0;
-            vec3 _1268;
-            float _1269;
-            if (_1258)
+            float _1258 = length(_763);
+            float _1261 = _116 * _116;
+            float _1264 = _768 - sqrt((_766 - (_1258 * _1258)) + _1261);
+            bool _1265 = _1264 > 0.0;
+            vec3 _1275;
+            float _1276;
+            if (_1265)
             {
-                _1268 = _756 + (_126 * _1257);
-                _1269 = _757 + _1257;
+                _1275 = _763 + (_129 * _1264);
+                _1276 = _764 + _1264;
             }
             else
             {
-                if (_1251 > _113)
+                if (_1258 > _116)
                 {
-                    _1415 = vec3(1.0);
-                    _1416 = vec3(0.0);
+                    _1422 = vec3(1.0);
+                    _1423 = vec3(0.0);
                     break;
                 }
-                _1268 = _756;
-                _1269 = _757;
+                _1275 = _763;
+                _1276 = _764;
             }
-            float _1270 = _1258 ? _113 : _1251;
-            float _1271 = _1269 / _1270;
-            float _1273 = dot(_1268, u_fragParams.u_sunDirection.xyz) / _1270;
-            float _1274 = dot(_126, u_fragParams.u_sunDirection.xyz);
-            float _1276 = _1270 * _1270;
-            float _1279 = _1276 * ((_1271 * _1271) - 1.0);
-            bool _1282 = (_1271 < 0.0) && ((_1279 + _762) >= 0.0);
-            float _1284 = sqrt(_1254 - _762);
-            float _1287 = sqrt(max(_1276 - _762, 0.0));
-            float _1295 = _113 - _1270;
-            float _1298 = (_1287 + _1284) - _1295;
-            float _1300 = _1287 / _1284;
-            vec4 _1308 = texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_1270) * _1271) + sqrt(max(_1279 + _1254, 0.0)), 0.0) - _1295) / _1298) * 0.99609375), 0.0078125 + (_1300 * 0.984375)));
-            vec3 _1309 = _1308.xyz;
-            bvec3 _1310 = bvec3(_1282);
-            float _1313 = 0.015625 + (_1300 * 0.96875);
-            float _1316 = ((_1269 * _1269) - _1276) + _762;
-            float _1346;
-            if (_1282)
+            float _1277 = _1265 ? _116 : _1258;
+            float _1278 = _1276 / _1277;
+            float _1280 = dot(_1275, u_fragParams.u_sunDirection.xyz) / _1277;
+            float _1281 = dot(_129, u_fragParams.u_sunDirection.xyz);
+            float _1283 = _1277 * _1277;
+            float _1286 = _1283 * ((_1278 * _1278) - 1.0);
+            bool _1289 = (_1278 < 0.0) && ((_1286 + _769) >= 0.0);
+            float _1291 = sqrt(_1261 - _769);
+            float _1294 = sqrt(max(_1283 - _769, 0.0));
+            float _1302 = _116 - _1277;
+            float _1305 = (_1294 + _1291) - _1302;
+            float _1307 = _1294 / _1291;
+            vec4 _1315 = texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_1277) * _1278) + sqrt(max(_1286 + _1261, 0.0)), 0.0) - _1302) / _1305) * 0.99609375), 0.0078125 + (_1307 * 0.984375)));
+            vec3 _1316 = _1315.xyz;
+            bvec3 _1317 = bvec3(_1289);
+            float _1320 = 0.015625 + (_1307 * 0.96875);
+            float _1323 = ((_1276 * _1276) - _1283) + _769;
+            float _1353;
+            if (_1289)
             {
-                float _1336 = _1270 - u_fragParams.u_earthCenter.w;
-                _1346 = 0.5 - (0.5 * (0.0078125 + (((_1287 == _1336) ? 0.0 : ((((-_1269) - sqrt(max(_1316, 0.0))) - _1336) / (_1287 - _1336))) * 0.984375)));
+                float _1343 = _1277 - u_fragParams.u_earthCenter.w;
+                _1353 = 0.5 - (0.5 * (0.0078125 + (((_1294 == _1343) ? 0.0 : ((((-_1276) - sqrt(max(_1323, 0.0))) - _1343) / (_1294 - _1343))) * 0.984375)));
             }
             else
             {
-                _1346 = 0.5 + (0.5 * (0.0078125 + (((((-_1269) + sqrt(max(_1316 + (_1284 * _1284), 0.0))) - _1295) / _1298) * 0.984375)));
+                _1353 = 0.5 + (0.5 * (0.0078125 + (((((-_1276) + sqrt(max(_1323 + (_1291 * _1291), 0.0))) - _1302) / _1305) * 0.984375)));
             }
-            float _1357 = _113 - u_fragParams.u_earthCenter.w;
-            float _1359 = _1284 - _1357;
-            float _1360 = (max(((-u_fragParams.u_earthCenter.w) * _1273) + sqrt(max((_762 * ((_1273 * _1273) - 1.0)) + _1254, 0.0)), 0.0) - _1357) / _1359;
-            float _1369 = 0.015625 + ((max(1.0 - (_1360 / ((0.415823996067047119140625 * u_fragParams.u_earthCenter.w) / _1359)), 0.0) / (1.0 + _1360)) * 0.96875);
-            float _1371 = (_1274 + 1.0) * 3.5;
-            float _1372 = floor(_1371);
-            float _1373 = _1371 - _1372;
-            vec4 _1383 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_1372 + _1369) * 0.125, _1346, _1313));
-            vec4 _1387 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3(((_1372 + 1.0) + _1369) * 0.125, _1346, _1313));
-            vec4 _1389 = (_1383 * (1.0 - _1373)) + (_1387 * _1373);
-            vec3 _1390 = _1389.xyz;
-            vec3 _1403;
+            float _1364 = _116 - u_fragParams.u_earthCenter.w;
+            float _1366 = _1291 - _1364;
+            float _1367 = (max(((-u_fragParams.u_earthCenter.w) * _1280) + sqrt(max((_769 * ((_1280 * _1280) - 1.0)) + _1261, 0.0)), 0.0) - _1364) / _1366;
+            float _1376 = 0.015625 + ((max(1.0 - (_1367 / ((0.415823996067047119140625 * u_fragParams.u_earthCenter.w) / _1366)), 0.0) / (1.0 + _1367)) * 0.96875);
+            float _1378 = (_1281 + 1.0) * 3.5;
+            float _1379 = floor(_1378);
+            float _1380 = _1378 - _1379;
+            vec4 _1390 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_1379 + _1376) * 0.125, _1353, _1320));
+            vec4 _1394 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3(((_1379 + 1.0) + _1376) * 0.125, _1353, _1320));
+            vec4 _1396 = (_1390 * (1.0 - _1380)) + (_1394 * _1380);
+            vec3 _1397 = _1396.xyz;
+            vec3 _1410;
             switch (0u)
             {
                 default:
                 {
-                    float _1393 = _1389.x;
-                    if (_1393 == 0.0)
+                    float _1400 = _1396.x;
+                    if (_1400 == 0.0)
                     {
-                        _1403 = vec3(0.0);
+                        _1410 = vec3(0.0);
                         break;
                     }
-                    _1403 = (((_1390 * _1389.w) / vec3(_1393)) * 1.5) * vec3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
+                    _1410 = (((_1397 * _1396.w) / vec3(_1400)) * 1.5) * vec3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
                     break;
                 }
             }
-            float _1405 = 1.0 + (_1274 * _1274);
-            _1415 = vec3(_1310.x ? vec3(0.0).x : _1309.x, _1310.y ? vec3(0.0).y : _1309.y, _1310.z ? vec3(0.0).z : _1309.z);
-            _1416 = (_1390 * (0.0596831031143665313720703125 * _1405)) + (_1403 * ((0.01627720706164836883544921875 * _1405) / pow(1.6400001049041748046875 - (1.60000002384185791015625 * _1274), 1.5)));
+            float _1412 = 1.0 + (_1281 * _1281);
+            _1422 = vec3(_1317.x ? vec3(0.0).x : _1316.x, _1317.y ? vec3(0.0).y : _1316.y, _1317.z ? vec3(0.0).z : _1316.z);
+            _1423 = (_1397 * (0.0596831031143665313720703125 * _1412)) + (_1410 * ((0.01627720706164836883544921875 * _1412) / pow(1.6400001049041748046875 - (1.60000002384185791015625 * _1281), 1.5)));
             break;
         }
     }
-    vec3 _1424;
-    if (dot(_126, u_fragParams.u_sunDirection.xyz) > u_fragParams.u_sunSize.y)
+    vec3 _1431;
+    if (dot(_129, u_fragParams.u_sunDirection.xyz) > u_fragParams.u_sunSize.y)
     {
-        _1424 = _1416 + (_1415 * vec3(21467.642578125, 26949.611328125, 27846.474609375));
+        _1431 = _1423 + (_1422 * vec3(21467.642578125, 26949.611328125, 27846.474609375));
     }
     else
     {
-        _1424 = _1416;
+        _1431 = _1423;
     }
-    vec3 _1438 = pow(abs(vec3(1.0) - exp(((-mix(mix(_1424, _1245, vec3(float(_766))), _754, vec3(float(_163)))) / u_fragParams.u_whitePoint.xyz) * u_fragParams.u_camera.w)), vec3(0.4545454680919647216796875));
-    vec4 _1440 = vec4(_1438.x, _1438.y, _1438.z, _105.w);
-    _1440.w = 1.0;
-    out_var_SV_Target = _1440;
-    gl_FragDepth = _131;
+    vec3 _1445 = pow(abs(vec3(1.0) - exp(((-mix(mix(_1431, _1252, vec3(float(_773))), _761, vec3(float(_170)))) / u_fragParams.u_whitePoint.xyz) * u_fragParams.u_camera.w)), vec3(0.4545454680919647216796875));
+    vec4 _1447 = vec4(_1445.x, _1445.y, _1445.z, _108.w);
+    _1447.w = 1.0;
+    out_var_SV_Target0 = _1447;
+    out_var_SV_Target1 = _137;
+    gl_FragDepth = _142;
 }
 

--- a/src/gl/opengl/shaders/desktop/compassFragmentShader.frag
+++ b/src/gl/opengl/shaders/desktop/compassFragmentShader.frag
@@ -14,15 +14,16 @@ layout(location = 1) in vec4 in_var_COLOR1;
 layout(location = 2) in vec3 in_var_COLOR2;
 layout(location = 3) in vec4 in_var_COLOR3;
 layout(location = 4) in vec2 in_var_TEXCOORD0;
-layout(location = 0) out vec4 out_var_SV_Target;
+layout(location = 0) out vec4 out_var_SV_Target0;
+layout(location = 1) out vec4 out_var_SV_Target1;
 
 void main()
 {
-    vec3 _50 = (in_var_COLOR0 * vec3(2.0)) - vec3(1.0);
-    float _76 = log2(in_var_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
-    vec4 _77 = vec4(((in_var_COLOR1.xyz * (0.5 + (dot(in_var_COLOR2, _50) * (-0.5)))) + (vec3(1.0, 1.0, 0.89999997615814208984375) * pow(max(0.0, -dot(-normalize(in_var_COLOR3.xyz / vec3(in_var_COLOR3.w)), _50)), 60.0))) * in_var_COLOR1.w, 1.0);
-    _77.w = _76;
-    out_var_SV_Target = _77;
-    gl_FragDepth = _76;
+    vec3 _51 = (in_var_COLOR0 * vec3(2.0)) - vec3(1.0);
+    float _77 = log2(in_var_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _80 = 1.0 - in_var_COLOR0.z;
+    out_var_SV_Target0 = vec4(((in_var_COLOR1.xyz * (0.5 + (dot(in_var_COLOR2, _51) * (-0.5)))) + (vec3(1.0, 1.0, 0.89999997615814208984375) * pow(max(0.0, -dot(-normalize(in_var_COLOR3.xyz / vec3(in_var_COLOR3.w)), _51)), 60.0))) * in_var_COLOR1.w, 1.0);
+    out_var_SV_Target1 = vec4(in_var_COLOR0.x / _80, in_var_COLOR0.y / _80, 0.0, _77);
+    gl_FragDepth = _77;
 }
 

--- a/src/gl/opengl/shaders/desktop/depthOnlyFragmentShader.frag
+++ b/src/gl/opengl/shaders/desktop/depthOnlyFragmentShader.frag
@@ -13,14 +13,12 @@ layout(location = 0) in vec2 in_var_TEXCOORD0;
 layout(location = 1) in vec3 in_var_NORMAL;
 layout(location = 2) in vec4 in_var_COLOR0;
 layout(location = 3) in vec2 in_var_TEXCOORD1;
-layout(location = 0) out vec4 out_var_SV_Target;
+layout(location = 4) in vec2 in_var_TEXCOORD2;
+layout(location = 0) out vec4 out_var_SV_Target0;
 
 void main()
 {
-    float _39 = log2(in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
-    vec4 _40 = vec4(0.0);
-    _40.w = _39;
-    out_var_SV_Target = _40;
-    gl_FragDepth = _39;
+    out_var_SV_Target0 = vec4(0.0);
+    gl_FragDepth = log2(in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
 }
 

--- a/src/gl/opengl/shaders/desktop/fenceFragmentShader.frag
+++ b/src/gl/opengl/shaders/desktop/fenceFragmentShader.frag
@@ -14,12 +14,15 @@ uniform sampler2D SPIRV_Cross_CombinedcolourTexturecolourSampler;
 layout(location = 0) in vec4 in_var_COLOR0;
 layout(location = 1) in vec2 in_var_TEXCOORD0;
 layout(location = 2) in vec2 in_var_TEXCOORD1;
-layout(location = 0) out vec4 out_var_SV_Target;
+layout(location = 0) out vec4 out_var_SV_Target0;
+layout(location = 1) out vec4 out_var_SV_Target1;
 
 void main()
 {
-    vec4 _40 = texture(SPIRV_Cross_CombinedcolourTexturecolourSampler, in_var_TEXCOORD0);
-    out_var_SV_Target = vec4(_40.xyz * in_var_COLOR0.xyz, _40.w * in_var_COLOR0.w);
-    gl_FragDepth = log2(in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    vec4 _42 = texture(SPIRV_Cross_CombinedcolourTexturecolourSampler, in_var_TEXCOORD0);
+    float _60 = log2(in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    out_var_SV_Target0 = vec4(_42.xyz * in_var_COLOR0.xyz, _42.w * in_var_COLOR0.w);
+    out_var_SV_Target1 = vec4(0.0, 0.0, 0.0, _60);
+    gl_FragDepth = _60;
 }
 

--- a/src/gl/opengl/shaders/desktop/flatColourFragmentShader.frag
+++ b/src/gl/opengl/shaders/desktop/flatColourFragmentShader.frag
@@ -1,26 +1,15 @@
 #version 330
 #extension GL_ARB_separate_shader_objects : require
 
-layout(std140) uniform type_u_cameraPlaneParams
-{
-    float s_CameraNearPlane;
-    float s_CameraFarPlane;
-    float u_clipZNear;
-    float u_clipZFar;
-} u_cameraPlaneParams;
-
 layout(location = 0) in vec2 in_var_TEXCOORD0;
 layout(location = 1) in vec3 in_var_NORMAL;
 layout(location = 2) in vec4 in_var_COLOR0;
 layout(location = 3) in vec2 in_var_TEXCOORD1;
-layout(location = 0) out vec4 out_var_SV_Target;
+layout(location = 4) in vec2 in_var_TEXCOORD2;
+layout(location = 0) out vec4 out_var_SV_Target0;
 
 void main()
 {
-    float _38 = log2(in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
-    vec4 _39 = in_var_COLOR0;
-    _39.w = _38;
-    out_var_SV_Target = _39;
-    gl_FragDepth = _38;
+    out_var_SV_Target0 = in_var_COLOR0;
 }
 

--- a/src/gl/opengl/shaders/desktop/imageRendererFragmentShader.frag
+++ b/src/gl/opengl/shaders/desktop/imageRendererFragmentShader.frag
@@ -14,11 +14,14 @@ uniform sampler2D SPIRV_Cross_CombinedalbedoTexturealbedoSampler;
 layout(location = 0) in vec2 in_var_TEXCOORD0;
 layout(location = 1) in vec4 in_var_COLOR0;
 layout(location = 2) in vec2 in_var_TEXCOORD1;
-layout(location = 0) out vec4 out_var_SV_Target;
+layout(location = 0) out vec4 out_var_SV_Target0;
+layout(location = 1) out vec4 out_var_SV_Target1;
 
 void main()
 {
-    out_var_SV_Target = texture(SPIRV_Cross_CombinedalbedoTexturealbedoSampler, in_var_TEXCOORD0) * in_var_COLOR0;
-    gl_FragDepth = log2(in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _50 = log2(in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    out_var_SV_Target0 = texture(SPIRV_Cross_CombinedalbedoTexturealbedoSampler, in_var_TEXCOORD0) * in_var_COLOR0;
+    out_var_SV_Target1 = vec4(0.0, 0.0, 0.0, _50);
+    gl_FragDepth = _50;
 }
 

--- a/src/gl/opengl/shaders/desktop/lineFragmentShader.frag
+++ b/src/gl/opengl/shaders/desktop/lineFragmentShader.frag
@@ -11,11 +11,14 @@ layout(std140) uniform type_u_cameraPlaneParams
 
 layout(location = 0) in vec4 in_var_COLOR0;
 layout(location = 1) in vec2 in_var_TEXCOORD0;
-layout(location = 0) out vec4 out_var_SV_Target;
+layout(location = 0) out vec4 out_var_SV_Target0;
+layout(location = 1) out vec4 out_var_SV_Target1;
 
 void main()
 {
-    out_var_SV_Target = in_var_COLOR0;
-    gl_FragDepth = log2(in_var_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _36 = log2(in_var_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    out_var_SV_Target0 = in_var_COLOR0;
+    out_var_SV_Target1 = vec4(0.0, 0.0, 0.0, _36);
+    gl_FragDepth = _36;
 }
 

--- a/src/gl/opengl/shaders/desktop/polygonImageFragmentShader.frag
+++ b/src/gl/opengl/shaders/desktop/polygonImageFragmentShader.frag
@@ -15,14 +15,15 @@ layout(location = 0) in vec2 in_var_TEXCOORD0;
 layout(location = 1) in vec3 in_var_NORMAL;
 layout(location = 2) in vec4 in_var_COLOR0;
 layout(location = 3) in vec2 in_var_TEXCOORD1;
-layout(location = 0) out vec4 out_var_SV_Target;
+layout(location = 4) in vec2 in_var_TEXCOORD2;
+layout(location = 0) out vec4 out_var_SV_Target0;
+layout(location = 1) out vec4 out_var_SV_Target1;
 
 void main()
 {
-    float _51 = log2(in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
-    vec4 _52 = texture(SPIRV_Cross_CombinedalbedoTexturealbedoSampler, in_var_TEXCOORD0) * in_var_COLOR0;
-    _52.w = _51;
-    out_var_SV_Target = _52;
-    gl_FragDepth = _51;
+    float _55 = log2(in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    out_var_SV_Target0 = texture(SPIRV_Cross_CombinedalbedoTexturealbedoSampler, in_var_TEXCOORD0) * in_var_COLOR0;
+    out_var_SV_Target1 = vec4(0.0, 0.0, in_var_TEXCOORD2.x, _55);
+    gl_FragDepth = _55;
 }
 

--- a/src/gl/opengl/shaders/desktop/polygonP3N3UV2FragmentShader.frag
+++ b/src/gl/opengl/shaders/desktop/polygonP3N3UV2FragmentShader.frag
@@ -15,16 +15,17 @@ layout(location = 0) in vec2 in_var_TEXCOORD0;
 layout(location = 1) in vec3 in_var_NORMAL;
 layout(location = 2) in vec4 in_var_COLOR0;
 layout(location = 3) in vec2 in_var_TEXCOORD1;
-layout(location = 0) out vec4 out_var_SV_Target;
-
-float _39;
+layout(location = 4) in vec2 in_var_TEXCOORD2;
+layout(location = 0) out vec4 out_var_SV_Target0;
+layout(location = 1) out vec4 out_var_SV_Target1;
 
 void main()
 {
-    float _67 = log2(in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
-    vec4 _68 = vec4((texture(SPIRV_Cross_CombinedalbedoTexturealbedoSampler, in_var_TEXCOORD0) * in_var_COLOR0).xyz * ((dot(in_var_NORMAL, normalize(vec3(0.85000002384185791015625, 0.1500000059604644775390625, 0.5))) * 0.5) + 0.5), _39);
-    _68.w = _67;
-    out_var_SV_Target = _68;
-    gl_FragDepth = _67;
+    vec4 _51 = texture(SPIRV_Cross_CombinedalbedoTexturealbedoSampler, in_var_TEXCOORD0) * in_var_COLOR0;
+    float _70 = log2(in_var_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    float _74 = 1.0 - in_var_NORMAL.z;
+    out_var_SV_Target0 = vec4(_51.xyz * ((dot(in_var_NORMAL, normalize(vec3(0.85000002384185791015625, 0.1500000059604644775390625, 0.5))) * 0.5) + 0.5), _51.w);
+    out_var_SV_Target1 = vec4(in_var_NORMAL.x / _74, in_var_NORMAL.y / _74, in_var_TEXCOORD2.x, _70);
+    gl_FragDepth = _70;
 }
 

--- a/src/gl/opengl/shaders/desktop/polygonP3N3UV2VertexShader.vert
+++ b/src/gl/opengl/shaders/desktop/polygonP3N3UV2VertexShader.vert
@@ -11,6 +11,7 @@ layout(std140) uniform type_u_EveryObject
     layout(row_major) mat4 u_worldViewProjectionMatrix;
     layout(row_major) mat4 u_worldMatrix;
     vec4 u_colour;
+    vec4 u_objectInfo;
 } u_EveryObject;
 
 layout(location = 0) in vec3 in_var_POSITION;
@@ -20,18 +21,22 @@ layout(location = 0) out vec2 out_var_TEXCOORD0;
 layout(location = 1) out vec3 out_var_NORMAL;
 layout(location = 2) out vec4 out_var_COLOR0;
 layout(location = 3) out vec2 out_var_TEXCOORD1;
+layout(location = 4) out vec2 out_var_TEXCOORD2;
 
-vec2 _34;
+vec2 _37;
 
 void main()
 {
-    vec4 _54 = vec4(in_var_POSITION, 1.0) * u_EveryObject.u_worldViewProjectionMatrix;
-    vec2 _59 = _34;
-    _59.x = 1.0 + _54.w;
-    gl_Position = _54;
+    vec4 _57 = vec4(in_var_POSITION, 1.0) * u_EveryObject.u_worldViewProjectionMatrix;
+    vec2 _62 = _37;
+    _62.x = 1.0 + _57.w;
+    vec2 _65 = _37;
+    _65.x = u_EveryObject.u_objectInfo.x;
+    gl_Position = _57;
     out_var_TEXCOORD0 = in_var_TEXCOORD0;
     out_var_NORMAL = normalize((vec4(in_var_NORMAL, 0.0) * u_EveryObject.u_worldMatrix).xyz);
     out_var_COLOR0 = u_EveryObject.u_colour;
-    out_var_TEXCOORD1 = _59;
+    out_var_TEXCOORD1 = _62;
+    out_var_TEXCOORD2 = _65;
 }
 

--- a/src/gl/opengl/shaders/desktop/tileFragmentShader.frag
+++ b/src/gl/opengl/shaders/desktop/tileFragmentShader.frag
@@ -14,14 +14,13 @@ uniform sampler2D SPIRV_Cross_CombinedcolourTexturecolourSampler;
 layout(location = 0) in vec4 in_var_COLOR0;
 layout(location = 1) in vec2 in_var_TEXCOORD0;
 layout(location = 2) in vec2 in_var_TEXCOORD1;
-layout(location = 0) out vec4 out_var_SV_Target;
-
-float _32;
+layout(location = 3) in vec2 in_var_TEXCOORD2;
+layout(location = 0) out vec4 out_var_SV_Target0;
+layout(location = 1) out vec4 out_var_SV_Target1;
 
 void main()
 {
-    vec4 _60 = vec4(texture(SPIRV_Cross_CombinedcolourTexturecolourSampler, in_var_TEXCOORD0).xyz * in_var_COLOR0.xyz, _32);
-    _60.w = ((in_var_TEXCOORD1.x / in_var_TEXCOORD1.y) * (1.0 / (u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear))) + (u_cameraPlaneParams.u_clipZNear * (-0.5));
-    out_var_SV_Target = _60;
+    out_var_SV_Target0 = vec4(texture(SPIRV_Cross_CombinedcolourTexturecolourSampler, in_var_TEXCOORD0).xyz * in_var_COLOR0.xyz, in_var_COLOR0.w);
+    out_var_SV_Target1 = vec4(0.0, 0.0, in_var_TEXCOORD2.x, ((in_var_TEXCOORD1.x / in_var_TEXCOORD1.y) * (1.0 / (u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear))) + (u_cameraPlaneParams.u_clipZNear * (-0.5)));
 }
 

--- a/src/gl/opengl/shaders/desktop/tileVertexShader.vert
+++ b/src/gl/opengl/shaders/desktop/tileVertexShader.vert
@@ -20,6 +20,7 @@ layout(std140) uniform type_u_EveryObject
     layout(row_major) mat4 u_view;
     vec4 u_eyePositions[9];
     vec4 u_colour;
+    vec4 u_objectInfo;
     vec4 u_uvOffsetScale;
     vec4 u_demUVOffsetScale;
     vec4 u_tileNormal;
@@ -31,30 +32,36 @@ layout(location = 0) in vec3 in_var_POSITION;
 layout(location = 0) out vec4 out_var_COLOR0;
 layout(location = 1) out vec2 out_var_TEXCOORD0;
 layout(location = 2) out vec2 out_var_TEXCOORD1;
+layout(location = 3) out vec2 out_var_TEXCOORD2;
+
+vec2 _55;
 
 void main()
 {
-    vec2 _57 = in_var_POSITION.xy * 2.0;
-    float _58 = _57.x;
-    float _59 = floor(_58);
-    float _60 = _57.y;
-    float _61 = floor(_60);
-    float _63 = min(2.0, _59 + 1.0);
-    float _66 = _58 - _59;
-    float _68 = _61 * 3.0;
-    int _70 = int(_68 + _59);
-    float _77 = min(2.0, _61 + 1.0) * 3.0;
-    int _79 = int(_77 + _59);
-    vec4 _88 = u_EveryObject.u_eyePositions[_70] + ((u_EveryObject.u_eyePositions[int(_68 + _63)] - u_EveryObject.u_eyePositions[_70]) * _66);
-    vec4 _104 = textureLod(SPIRV_Cross_CombineddemTexturedemSampler, u_EveryObject.u_demUVOffsetScale.xy + (u_EveryObject.u_demUVOffsetScale.zw * in_var_POSITION.xy), 0.0);
-    vec4 _127 = ((_88 + (((u_EveryObject.u_eyePositions[_79] + ((u_EveryObject.u_eyePositions[int(_77 + _63)] - u_EveryObject.u_eyePositions[_79]) * _66)) - _88) * (_60 - _61))) + ((vec4(u_EveryObject.u_tileNormal.xyz * (((_104.x * 255.0) + (_104.y * 65280.0)) - 32768.0), 1.0) * u_EveryObject.u_view) - (vec4(0.0, 0.0, 0.0, 1.0) * u_EveryObject.u_view))) * u_EveryObject.u_projection;
-    float _138 = _127.w;
-    float _144 = ((log2(max(9.9999999747524270787835121154785e-07, 1.0 + _138)) * ((u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear) / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0))) + u_cameraPlaneParams.u_clipZNear) * _138;
-    vec4 _145 = _127;
-    _145.z = _144;
-    gl_Position = _145;
+    vec2 _60 = in_var_POSITION.xy * 2.0;
+    float _61 = _60.x;
+    float _62 = floor(_61);
+    float _63 = _60.y;
+    float _64 = floor(_63);
+    float _66 = min(2.0, _62 + 1.0);
+    float _69 = _61 - _62;
+    float _71 = _64 * 3.0;
+    int _73 = int(_71 + _62);
+    float _80 = min(2.0, _64 + 1.0) * 3.0;
+    int _82 = int(_80 + _62);
+    vec4 _91 = u_EveryObject.u_eyePositions[_73] + ((u_EveryObject.u_eyePositions[int(_71 + _66)] - u_EveryObject.u_eyePositions[_73]) * _69);
+    vec4 _107 = textureLod(SPIRV_Cross_CombineddemTexturedemSampler, u_EveryObject.u_demUVOffsetScale.xy + (u_EveryObject.u_demUVOffsetScale.zw * in_var_POSITION.xy), 0.0);
+    vec4 _130 = ((_91 + (((u_EveryObject.u_eyePositions[_82] + ((u_EveryObject.u_eyePositions[int(_80 + _66)] - u_EveryObject.u_eyePositions[_82]) * _69)) - _91) * (_63 - _64))) + ((vec4(u_EveryObject.u_tileNormal.xyz * (((_107.x * 255.0) + (_107.y * 65280.0)) - 32768.0), 1.0) * u_EveryObject.u_view) - (vec4(0.0, 0.0, 0.0, 1.0) * u_EveryObject.u_view))) * u_EveryObject.u_projection;
+    float _141 = _130.w;
+    float _147 = ((log2(max(9.9999999747524270787835121154785e-07, 1.0 + _141)) * ((u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear) / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0))) + u_cameraPlaneParams.u_clipZNear) * _141;
+    vec4 _148 = _130;
+    _148.z = _147;
+    vec2 _160 = _55;
+    _160.x = u_EveryObject.u_objectInfo.x;
+    gl_Position = _148;
     out_var_COLOR0 = u_EveryObject.u_colour;
     out_var_TEXCOORD0 = u_EveryObject.u_uvOffsetScale.xy + (u_EveryObject.u_uvOffsetScale.zw * in_var_POSITION.xy);
-    out_var_TEXCOORD1 = vec2(_144, _138);
+    out_var_TEXCOORD1 = vec2(_147, _141);
+    out_var_TEXCOORD2 = _160;
 }
 

--- a/src/gl/opengl/shaders/desktop/udFragmentShader.frag
+++ b/src/gl/opengl/shaders/desktop/udFragmentShader.frag
@@ -5,15 +5,15 @@ uniform sampler2D SPIRV_Cross_CombinedsceneColourTexturesceneColourSampler;
 uniform sampler2D SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler;
 
 layout(location = 0) in vec2 in_var_TEXCOORD0;
-layout(location = 0) out vec4 out_var_SV_Target;
+layout(location = 0) out vec4 out_var_SV_Target0;
+layout(location = 1) out vec4 out_var_SV_Target1;
 
 void main()
 {
-    vec4 _34 = texture(SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler, in_var_TEXCOORD0);
-    float _35 = _34.x;
-    vec4 _40 = vec4(texture(SPIRV_Cross_CombinedsceneColourTexturesceneColourSampler, in_var_TEXCOORD0).zyx, 1.0);
-    _40.w = _35;
-    out_var_SV_Target = _40;
-    gl_FragDepth = _35;
+    vec4 _36 = texture(SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler, in_var_TEXCOORD0);
+    float _37 = _36.x;
+    out_var_SV_Target0 = vec4(texture(SPIRV_Cross_CombinedsceneColourTexturesceneColourSampler, in_var_TEXCOORD0).zyx, 1.0);
+    out_var_SV_Target1 = vec4(0.0, 0.0, 0.0, _37);
+    gl_FragDepth = _37;
 }
 

--- a/src/gl/opengl/shaders/desktop/viewShedFragmentShader.frag
+++ b/src/gl/opengl/shaders/desktop/viewShedFragmentShader.frag
@@ -23,7 +23,7 @@ uniform sampler2D SPIRV_Cross_CombinedshadowMapAtlasTextureshadowMapAtlasSampler
 
 layout(location = 0) in vec4 in_var_TEXCOORD0;
 layout(location = 1) in vec2 in_var_TEXCOORD1;
-layout(location = 0) out vec4 out_var_SV_Target;
+layout(location = 0) out vec4 out_var_SV_Target0;
 
 void main()
 {
@@ -60,6 +60,6 @@ void main()
     {
         _225 = vec4(0.0);
     }
-    out_var_SV_Target = vec4(_225.xyz * _225.w, 1.0);
+    out_var_SV_Target0 = vec4(_225.xyz * _225.w, 1.0);
 }
 

--- a/src/gl/opengl/shaders/desktop/visualizationFragmentShader.frag
+++ b/src/gl/opengl/shaders/desktop/visualizationFragmentShader.frag
@@ -27,6 +27,7 @@ layout(std140) uniform type_u_fragParams
 } u_fragParams;
 
 uniform sampler2D SPIRV_Cross_CombinedsceneColourTexturesceneColourSampler;
+uniform sampler2D SPIRV_Cross_CombinedsceneNormalTexturesceneNormalSampler;
 uniform sampler2D SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler;
 
 layout(location = 0) in vec4 in_var_TEXCOORD0;
@@ -35,55 +36,56 @@ layout(location = 2) in vec2 in_var_TEXCOORD2;
 layout(location = 3) in vec2 in_var_TEXCOORD3;
 layout(location = 4) in vec2 in_var_TEXCOORD4;
 layout(location = 5) in vec2 in_var_TEXCOORD5;
-layout(location = 0) out vec4 out_var_SV_Target;
+layout(location = 0) out vec4 out_var_SV_Target0;
+layout(location = 1) out vec4 out_var_SV_Target1;
 
 void main()
 {
-    vec4 _78 = texture(SPIRV_Cross_CombinedsceneColourTexturesceneColourSampler, in_var_TEXCOORD1);
-    vec4 _82 = texture(SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler, in_var_TEXCOORD1);
-    float _83 = _82.x;
-    float _89 = u_cameraPlaneParams.s_CameraFarPlane / (u_cameraPlaneParams.s_CameraFarPlane - u_cameraPlaneParams.s_CameraNearPlane);
-    float _92 = (u_cameraPlaneParams.s_CameraFarPlane * u_cameraPlaneParams.s_CameraNearPlane) / (u_cameraPlaneParams.s_CameraNearPlane - u_cameraPlaneParams.s_CameraFarPlane);
-    float _94 = log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0);
-    float _104 = u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear;
-    float _106 = ((_89 + (_92 / (pow(2.0, _83 * _94) - 1.0))) * _104) + u_cameraPlaneParams.u_clipZNear;
-    vec4 _112 = vec4(in_var_TEXCOORD0.xy, _106, 1.0) * u_fragParams.u_inverseProjection;
-    vec3 _116 = _78.xyz;
-    vec3 _117 = (_112 / vec4(_112.w)).xyz;
-    float _124 = dot(u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz, u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz);
-    vec3 _126 = u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz * (dot(_117, u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz) / _124);
-    float _132 = mix(length(u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz - _126), 0.0, float(dot(_126, _126) > _124));
-    vec3 _207 = mix(mix(mix(mix(mix(_116, u_fragParams.u_colourizeHeightColourMin.xyz, vec3(u_fragParams.u_colourizeHeightColourMin.w)), mix(_116, u_fragParams.u_colourizeHeightColourMax.xyz, vec3(u_fragParams.u_colourizeHeightColourMax.w)), vec3(clamp((_132 - u_fragParams.u_colourizeHeightParams.x) / (u_fragParams.u_colourizeHeightParams.y - u_fragParams.u_colourizeHeightParams.x), 0.0, 1.0))).xyz, u_fragParams.u_colourizeDepthColour.xyz, vec3(clamp((length(_117) - u_fragParams.u_colourizeDepthParams.x) / (u_fragParams.u_colourizeDepthParams.y - u_fragParams.u_colourizeDepthParams.x), 0.0, 1.0) * u_fragParams.u_colourizeDepthColour.w)).xyz, clamp(abs((fract(vec3(_132 * (1.0 / u_fragParams.u_contourParams.z), 1.0, 1.0).xxx + vec3(1.0, 0.666666686534881591796875, 0.3333333432674407958984375)) * 6.0) - vec3(3.0)) - vec3(1.0), vec3(0.0), vec3(1.0)) * 1.0, vec3(u_fragParams.u_contourParams.w)), u_fragParams.u_contourColour.xyz, vec3((1.0 - step(u_fragParams.u_contourParams.y, mod(abs(_132), u_fragParams.u_contourParams.x))) * u_fragParams.u_contourColour.w));
-    float _357;
-    vec4 _358;
+    vec4 _81 = texture(SPIRV_Cross_CombinedsceneColourTexturesceneColourSampler, in_var_TEXCOORD1);
+    vec4 _85 = texture(SPIRV_Cross_CombinedsceneNormalTexturesceneNormalSampler, in_var_TEXCOORD1);
+    vec4 _89 = texture(SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler, in_var_TEXCOORD1);
+    float _90 = _89.x;
+    float _96 = u_cameraPlaneParams.s_CameraFarPlane / (u_cameraPlaneParams.s_CameraFarPlane - u_cameraPlaneParams.s_CameraNearPlane);
+    float _99 = (u_cameraPlaneParams.s_CameraFarPlane * u_cameraPlaneParams.s_CameraNearPlane) / (u_cameraPlaneParams.s_CameraNearPlane - u_cameraPlaneParams.s_CameraFarPlane);
+    float _101 = log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0);
+    float _111 = u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear;
+    float _113 = ((_96 + (_99 / (pow(2.0, _90 * _101) - 1.0))) * _111) + u_cameraPlaneParams.u_clipZNear;
+    vec4 _119 = vec4(in_var_TEXCOORD0.xy, _113, 1.0) * u_fragParams.u_inverseProjection;
+    vec3 _123 = _81.xyz;
+    vec3 _124 = (_119 / vec4(_119.w)).xyz;
+    float _131 = dot(u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz, u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz);
+    vec3 _133 = u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz * (dot(_124, u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz) / _131);
+    float _139 = mix(length(u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz - _133), 0.0, float(dot(_133, _133) > _131));
+    vec3 _214 = mix(mix(mix(mix(mix(_123, u_fragParams.u_colourizeHeightColourMin.xyz, vec3(u_fragParams.u_colourizeHeightColourMin.w)), mix(_123, u_fragParams.u_colourizeHeightColourMax.xyz, vec3(u_fragParams.u_colourizeHeightColourMax.w)), vec3(clamp((_139 - u_fragParams.u_colourizeHeightParams.x) / (u_fragParams.u_colourizeHeightParams.y - u_fragParams.u_colourizeHeightParams.x), 0.0, 1.0))).xyz, u_fragParams.u_colourizeDepthColour.xyz, vec3(clamp((length(_124) - u_fragParams.u_colourizeDepthParams.x) / (u_fragParams.u_colourizeDepthParams.y - u_fragParams.u_colourizeDepthParams.x), 0.0, 1.0) * u_fragParams.u_colourizeDepthColour.w)).xyz, clamp(abs((fract(vec3(_139 * (1.0 / u_fragParams.u_contourParams.z), 1.0, 1.0).xxx + vec3(1.0, 0.666666686534881591796875, 0.3333333432674407958984375)) * 6.0) - vec3(3.0)) - vec3(1.0), vec3(0.0), vec3(1.0)) * 1.0, vec3(u_fragParams.u_contourParams.w)), u_fragParams.u_contourColour.xyz, vec3((1.0 - step(u_fragParams.u_contourParams.y, mod(abs(_139), u_fragParams.u_contourParams.x))) * u_fragParams.u_contourColour.w));
+    float _364;
+    vec4 _365;
     if ((u_fragParams.u_outlineParams.x > 0.0) && (u_fragParams.u_outlineColour.w > 0.0))
     {
-        vec4 _229 = vec4((in_var_TEXCOORD1.x * 2.0) - 1.0, (in_var_TEXCOORD1.y * 2.0) - 1.0, _106, 1.0) * u_fragParams.u_inverseProjection;
-        vec4 _234 = texture(SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler, in_var_TEXCOORD2);
-        float _235 = _234.x;
-        vec4 _237 = texture(SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler, in_var_TEXCOORD3);
-        float _238 = _237.x;
-        vec4 _240 = texture(SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler, in_var_TEXCOORD4);
-        float _241 = _240.x;
-        vec4 _243 = texture(SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler, in_var_TEXCOORD5);
-        float _244 = _243.x;
-        vec4 _259 = vec4((in_var_TEXCOORD2.x * 2.0) - 1.0, (in_var_TEXCOORD2.y * 2.0) - 1.0, ((_89 + (_92 / (pow(2.0, _235 * _94) - 1.0))) * _104) + u_cameraPlaneParams.u_clipZNear, 1.0) * u_fragParams.u_inverseProjection;
-        vec4 _274 = vec4((in_var_TEXCOORD3.x * 2.0) - 1.0, (in_var_TEXCOORD3.y * 2.0) - 1.0, ((_89 + (_92 / (pow(2.0, _238 * _94) - 1.0))) * _104) + u_cameraPlaneParams.u_clipZNear, 1.0) * u_fragParams.u_inverseProjection;
-        vec4 _289 = vec4((in_var_TEXCOORD4.x * 2.0) - 1.0, (in_var_TEXCOORD4.y * 2.0) - 1.0, ((_89 + (_92 / (pow(2.0, _241 * _94) - 1.0))) * _104) + u_cameraPlaneParams.u_clipZNear, 1.0) * u_fragParams.u_inverseProjection;
-        vec4 _304 = vec4((in_var_TEXCOORD5.x * 2.0) - 1.0, (in_var_TEXCOORD5.y * 2.0) - 1.0, ((_89 + (_92 / (pow(2.0, _244 * _94) - 1.0))) * _104) + u_cameraPlaneParams.u_clipZNear, 1.0) * u_fragParams.u_inverseProjection;
-        vec3 _317 = (_229 / vec4(_229.w)).xyz;
-        vec4 _354 = mix(vec4(_207, _83), vec4(mix(_207.xyz, u_fragParams.u_outlineColour.xyz, vec3(u_fragParams.u_outlineColour.w)), min(min(min(_235, _238), _241), _244)), vec4(1.0 - (((step(length(_317 - (_259 / vec4(_259.w)).xyz), u_fragParams.u_outlineParams.y) * step(length(_317 - (_274 / vec4(_274.w)).xyz), u_fragParams.u_outlineParams.y)) * step(length(_317 - (_289 / vec4(_289.w)).xyz), u_fragParams.u_outlineParams.y)) * step(length(_317 - (_304 / vec4(_304.w)).xyz), u_fragParams.u_outlineParams.y))));
-        _357 = _354.w;
-        _358 = vec4(_354.x, _354.y, _354.z, _78.w);
+        vec4 _236 = vec4((in_var_TEXCOORD1.x * 2.0) - 1.0, (in_var_TEXCOORD1.y * 2.0) - 1.0, _113, 1.0) * u_fragParams.u_inverseProjection;
+        vec4 _241 = texture(SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler, in_var_TEXCOORD2);
+        float _242 = _241.x;
+        vec4 _244 = texture(SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler, in_var_TEXCOORD3);
+        float _245 = _244.x;
+        vec4 _247 = texture(SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler, in_var_TEXCOORD4);
+        float _248 = _247.x;
+        vec4 _250 = texture(SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler, in_var_TEXCOORD5);
+        float _251 = _250.x;
+        vec4 _266 = vec4((in_var_TEXCOORD2.x * 2.0) - 1.0, (in_var_TEXCOORD2.y * 2.0) - 1.0, ((_96 + (_99 / (pow(2.0, _242 * _101) - 1.0))) * _111) + u_cameraPlaneParams.u_clipZNear, 1.0) * u_fragParams.u_inverseProjection;
+        vec4 _281 = vec4((in_var_TEXCOORD3.x * 2.0) - 1.0, (in_var_TEXCOORD3.y * 2.0) - 1.0, ((_96 + (_99 / (pow(2.0, _245 * _101) - 1.0))) * _111) + u_cameraPlaneParams.u_clipZNear, 1.0) * u_fragParams.u_inverseProjection;
+        vec4 _296 = vec4((in_var_TEXCOORD4.x * 2.0) - 1.0, (in_var_TEXCOORD4.y * 2.0) - 1.0, ((_96 + (_99 / (pow(2.0, _248 * _101) - 1.0))) * _111) + u_cameraPlaneParams.u_clipZNear, 1.0) * u_fragParams.u_inverseProjection;
+        vec4 _311 = vec4((in_var_TEXCOORD5.x * 2.0) - 1.0, (in_var_TEXCOORD5.y * 2.0) - 1.0, ((_96 + (_99 / (pow(2.0, _251 * _101) - 1.0))) * _111) + u_cameraPlaneParams.u_clipZNear, 1.0) * u_fragParams.u_inverseProjection;
+        vec3 _324 = (_236 / vec4(_236.w)).xyz;
+        vec4 _361 = mix(vec4(_214, _90), vec4(mix(_214.xyz, u_fragParams.u_outlineColour.xyz, vec3(u_fragParams.u_outlineColour.w)), min(min(min(_242, _245), _248), _251)), vec4(1.0 - (((step(length(_324 - (_266 / vec4(_266.w)).xyz), u_fragParams.u_outlineParams.y) * step(length(_324 - (_281 / vec4(_281.w)).xyz), u_fragParams.u_outlineParams.y)) * step(length(_324 - (_296 / vec4(_296.w)).xyz), u_fragParams.u_outlineParams.y)) * step(length(_324 - (_311 / vec4(_311.w)).xyz), u_fragParams.u_outlineParams.y))));
+        _364 = _361.w;
+        _365 = vec4(_361.x, _361.y, _361.z, _81.w);
     }
     else
     {
-        _357 = _83;
-        _358 = vec4(_207.x, _207.y, _207.z, _78.w);
+        _364 = _90;
+        _365 = vec4(_214.x, _214.y, _214.z, _81.w);
     }
-    vec4 _363 = vec4(_358.xyz, 1.0);
-    _363.w = _357;
-    out_var_SV_Target = _363;
-    gl_FragDepth = _357;
+    out_var_SV_Target0 = vec4(_365.xyz, 1.0);
+    out_var_SV_Target1 = _85;
+    gl_FragDepth = _364;
 }
 

--- a/src/gl/opengl/shaders/desktop/waterFragmentShader.frag
+++ b/src/gl/opengl/shaders/desktop/waterFragmentShader.frag
@@ -24,19 +24,19 @@ layout(location = 1) in vec2 in_var_TEXCOORD1;
 layout(location = 2) in vec4 in_var_COLOR0;
 layout(location = 3) in vec4 in_var_COLOR1;
 layout(location = 4) in vec2 in_var_TEXCOORD2;
-layout(location = 0) out vec4 out_var_SV_Target;
+layout(location = 0) out vec4 out_var_SV_Target0;
+layout(location = 1) out vec4 out_var_SV_Target1;
 
 void main()
 {
-    vec3 _90 = normalize(((texture(SPIRV_Cross_CombinednormalMapTexturenormalMapSampler, in_var_TEXCOORD0).xyz * vec3(2.0)) - vec3(1.0)) + ((texture(SPIRV_Cross_CombinednormalMapTexturenormalMapSampler, in_var_TEXCOORD1).xyz * vec3(2.0)) - vec3(1.0)));
-    vec3 _92 = normalize(in_var_COLOR0.xyz);
-    vec3 _108 = normalize((vec4(_90, 0.0) * u_EveryFrameFrag.u_eyeNormalMatrix).xyz);
-    vec3 _110 = normalize(reflect(_92, _108));
-    vec3 _134 = normalize((vec4(_110, 0.0) * u_EveryFrameFrag.u_inverseViewMatrix).xyz);
-    float _162 = log2(in_var_TEXCOORD2.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
-    vec4 _165 = (vec4(mix(texture(SPIRV_Cross_CombinedskyboxTextureskyboxSampler, vec2(atan(_134.x, _134.y) + 3.1415927410125732421875, acos(_134.z)) * vec2(0.15915493667125701904296875, 0.3183098733425140380859375)).xyz, in_var_COLOR1.xyz * mix(vec3(1.0, 1.0, 0.60000002384185791015625), vec3(0.3499999940395355224609375), vec3(pow(max(0.0, _90.z), 5.0))), vec3(((dot(_108, _92) * (-0.5)) + 0.5) * 0.75)) + vec3(pow(abs(dot(_110, normalize((vec4(normalize(u_EveryFrameFrag.u_specularDir.xyz), 0.0) * u_EveryFrameFrag.u_eyeNormalMatrix).xyz))), 50.0) * 0.5), 1.0) * 0.300000011920928955078125) + vec4(0.20000000298023223876953125, 0.4000000059604644775390625, 0.699999988079071044921875, 1.0);
-    _165.w = _162;
-    out_var_SV_Target = _165;
-    gl_FragDepth = _162;
+    vec3 _91 = normalize(((texture(SPIRV_Cross_CombinednormalMapTexturenormalMapSampler, in_var_TEXCOORD0).xyz * vec3(2.0)) - vec3(1.0)) + ((texture(SPIRV_Cross_CombinednormalMapTexturenormalMapSampler, in_var_TEXCOORD1).xyz * vec3(2.0)) - vec3(1.0)));
+    vec3 _93 = normalize(in_var_COLOR0.xyz);
+    vec3 _109 = normalize((vec4(_91, 0.0) * u_EveryFrameFrag.u_eyeNormalMatrix).xyz);
+    vec3 _111 = normalize(reflect(_93, _109));
+    vec3 _135 = normalize((vec4(_111, 0.0) * u_EveryFrameFrag.u_inverseViewMatrix).xyz);
+    float _163 = log2(in_var_TEXCOORD2.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    out_var_SV_Target0 = (vec4(mix(texture(SPIRV_Cross_CombinedskyboxTextureskyboxSampler, vec2(atan(_135.x, _135.y) + 3.1415927410125732421875, acos(_135.z)) * vec2(0.15915493667125701904296875, 0.3183098733425140380859375)).xyz, in_var_COLOR1.xyz * mix(vec3(1.0, 1.0, 0.60000002384185791015625), vec3(0.3499999940395355224609375), vec3(pow(max(0.0, _91.z), 5.0))), vec3(((dot(_109, _93) * (-0.5)) + 0.5) * 0.75)) + vec3(pow(abs(dot(_111, normalize((vec4(normalize(u_EveryFrameFrag.u_specularDir.xyz), 0.0) * u_EveryFrameFrag.u_eyeNormalMatrix).xyz))), 50.0) * 0.5), 1.0) * 0.300000011920928955078125) + vec4(0.20000000298023223876953125, 0.4000000059604644775390625, 0.699999988079071044921875, 1.0);
+    out_var_SV_Target1 = vec4(0.0, 0.0, 0.0, _163);
+    gl_FragDepth = _163;
 }
 

--- a/src/gl/opengl/shaders/mobile/atmosphereFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/atmosphereFragmentShader.frag
@@ -21,540 +21,544 @@ layout(std140) uniform type_u_fragParams
     layout(row_major) highp mat4 u_inverseProjection;
 } u_fragParams;
 
-uniform highp sampler2D SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler;
 uniform highp sampler2D SPIRV_Cross_CombinedsceneColourTexturesceneColourSampler;
+uniform highp sampler2D SPIRV_Cross_CombinedsceneNormalTexturesceneNormalSampler;
+uniform highp sampler2D SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler;
 uniform highp sampler2D SPIRV_Cross_CombinedirradianceTextureirradianceSampler;
 uniform highp sampler2D SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler;
 uniform highp sampler3D SPIRV_Cross_CombinedscatteringTexturescatteringSampler;
 
 in highp vec2 varying_TEXCOORD0;
 in highp vec3 varying_TEXCOORD1;
-layout(location = 0) out highp vec4 out_var_SV_Target;
+layout(location = 0) out highp vec4 out_var_SV_Target0;
+layout(location = 1) out highp vec4 out_var_SV_Target1;
 
-vec4 _105;
+vec4 _108;
 
 void main()
 {
-    highp float _113 = u_fragParams.u_earthCenter.w + 60000.0;
-    highp vec3 _126 = normalize(varying_TEXCOORD1);
-    highp vec4 _130 = texture(SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler, varying_TEXCOORD0);
-    highp float _131 = _130.x;
-    highp float _136 = u_cameraPlaneParams.s_CameraFarPlane - u_cameraPlaneParams.s_CameraNearPlane;
-    highp vec4 _151 = texture(SPIRV_Cross_CombinedsceneColourTexturesceneColourSampler, varying_TEXCOORD0);
-    highp vec3 _154 = pow(abs(_151.xyz), vec3(2.2000000476837158203125));
-    highp float _160 = ((2.0 * u_cameraPlaneParams.s_CameraNearPlane) / ((u_cameraPlaneParams.s_CameraFarPlane + u_cameraPlaneParams.s_CameraNearPlane) - (((u_cameraPlaneParams.s_CameraFarPlane / _136) + (((u_cameraPlaneParams.s_CameraFarPlane * u_cameraPlaneParams.s_CameraNearPlane) / (u_cameraPlaneParams.s_CameraNearPlane - u_cameraPlaneParams.s_CameraFarPlane)) / (pow(2.0, _131 * log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0)) - 1.0))) * _136))) * u_cameraPlaneParams.s_CameraFarPlane;
-    bool _163 = _131 < 0.64999997615814208984375;
-    highp vec3 _754;
-    if (_163)
+    highp float _116 = u_fragParams.u_earthCenter.w + 60000.0;
+    highp vec3 _129 = normalize(varying_TEXCOORD1);
+    highp vec4 _133 = texture(SPIRV_Cross_CombinedsceneColourTexturesceneColourSampler, varying_TEXCOORD0);
+    highp vec4 _137 = texture(SPIRV_Cross_CombinedsceneNormalTexturesceneNormalSampler, varying_TEXCOORD0);
+    highp vec4 _141 = texture(SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler, varying_TEXCOORD0);
+    highp float _142 = _141.x;
+    highp float _147 = u_cameraPlaneParams.s_CameraFarPlane - u_cameraPlaneParams.s_CameraNearPlane;
+    highp vec3 _161 = pow(abs(_133.xyz), vec3(2.2000000476837158203125));
+    highp float _167 = ((2.0 * u_cameraPlaneParams.s_CameraNearPlane) / ((u_cameraPlaneParams.s_CameraFarPlane + u_cameraPlaneParams.s_CameraNearPlane) - (((u_cameraPlaneParams.s_CameraFarPlane / _147) + (((u_cameraPlaneParams.s_CameraFarPlane * u_cameraPlaneParams.s_CameraNearPlane) / (u_cameraPlaneParams.s_CameraNearPlane - u_cameraPlaneParams.s_CameraFarPlane)) / (pow(2.0, _142 * log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0)) - 1.0))) * _147))) * u_cameraPlaneParams.s_CameraFarPlane;
+    bool _170 = _142 < 0.64999997615814208984375;
+    highp vec3 _761;
+    if (_170)
     {
-        highp vec3 _166 = (u_fragParams.u_camera.xyz + (_126 * _160)) - u_fragParams.u_earthCenter.xyz;
-        highp vec3 _167 = normalize(_166);
-        highp float _170 = length(_166);
-        highp float _172 = dot(_166, u_fragParams.u_sunDirection.xyz) / _170;
-        highp float _174 = _113 - u_fragParams.u_earthCenter.w;
-        highp vec4 _185 = texture(SPIRV_Cross_CombinedirradianceTextureirradianceSampler, vec2(0.0078125 + (((_172 * 0.5) + 0.5) * 0.984375), 0.03125 + (((_170 - u_fragParams.u_earthCenter.w) / _174) * 0.9375)));
-        highp float _192 = u_fragParams.u_earthCenter.w / _170;
-        highp float _198 = _113 * _113;
-        highp float _199 = u_fragParams.u_earthCenter.w * u_fragParams.u_earthCenter.w;
-        highp float _201 = sqrt(_198 - _199);
-        highp float _202 = _170 * _170;
-        highp float _205 = sqrt(max(_202 - _199, 0.0));
-        highp float _216 = _113 - _170;
-        highp vec4 _229 = texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_170) * _172) + sqrt(max((_202 * ((_172 * _172) - 1.0)) + _198, 0.0)), 0.0) - _216) / ((_205 + _201) - _216)) * 0.99609375), 0.0078125 + ((_205 / _201) * 0.984375)));
-        highp float _248 = mix(_160 * 0.64999997615814208984375, 0.0, pow(_131 * 1.53846156597137451171875, 8.0));
-        highp vec3 _249 = u_fragParams.u_camera.xyz - u_fragParams.u_earthCenter.xyz;
-        highp vec3 _252 = normalize(_166 - _249);
-        highp float _253 = length(_249);
-        highp float _254 = dot(_249, _252);
-        highp float _261 = (-_254) - sqrt(((_254 * _254) - (_253 * _253)) + _198);
-        bool _262 = _261 > 0.0;
-        highp vec3 _268;
-        highp float _269;
-        if (_262)
+        highp vec3 _173 = (u_fragParams.u_camera.xyz + (_129 * _167)) - u_fragParams.u_earthCenter.xyz;
+        highp vec3 _174 = normalize(_173);
+        highp float _177 = length(_173);
+        highp float _179 = dot(_173, u_fragParams.u_sunDirection.xyz) / _177;
+        highp float _181 = _116 - u_fragParams.u_earthCenter.w;
+        highp vec4 _192 = texture(SPIRV_Cross_CombinedirradianceTextureirradianceSampler, vec2(0.0078125 + (((_179 * 0.5) + 0.5) * 0.984375), 0.03125 + (((_177 - u_fragParams.u_earthCenter.w) / _181) * 0.9375)));
+        highp float _199 = u_fragParams.u_earthCenter.w / _177;
+        highp float _205 = _116 * _116;
+        highp float _206 = u_fragParams.u_earthCenter.w * u_fragParams.u_earthCenter.w;
+        highp float _208 = sqrt(_205 - _206);
+        highp float _209 = _177 * _177;
+        highp float _212 = sqrt(max(_209 - _206, 0.0));
+        highp float _223 = _116 - _177;
+        highp vec4 _236 = texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_177) * _179) + sqrt(max((_209 * ((_179 * _179) - 1.0)) + _205, 0.0)), 0.0) - _223) / ((_212 + _208) - _223)) * 0.99609375), 0.0078125 + ((_212 / _208) * 0.984375)));
+        highp float _255 = mix(_167 * 0.64999997615814208984375, 0.0, pow(_142 * 1.53846156597137451171875, 8.0));
+        highp vec3 _256 = u_fragParams.u_camera.xyz - u_fragParams.u_earthCenter.xyz;
+        highp vec3 _259 = normalize(_173 - _256);
+        highp float _260 = length(_256);
+        highp float _261 = dot(_256, _259);
+        highp float _268 = (-_261) - sqrt(((_261 * _261) - (_260 * _260)) + _205);
+        bool _269 = _268 > 0.0;
+        highp vec3 _275;
+        highp float _276;
+        if (_269)
         {
-            _268 = _249 + (_252 * _261);
-            _269 = _254 + _261;
+            _275 = _256 + (_259 * _268);
+            _276 = _261 + _268;
         }
         else
         {
-            _268 = _249;
-            _269 = _254;
+            _275 = _256;
+            _276 = _261;
         }
-        highp float _288;
-        highp float _270 = _262 ? _113 : _253;
-        highp float _271 = _269 / _270;
-        highp float _272 = dot(_268, u_fragParams.u_sunDirection.xyz);
-        highp float _273 = _272 / _270;
-        highp float _274 = dot(_252, u_fragParams.u_sunDirection.xyz);
-        highp float _276 = length(_166 - _268);
-        highp float _278 = _270 * _270;
-        highp float _281 = _278 * ((_271 * _271) - 1.0);
-        bool _284 = (_271 < 0.0) && ((_281 + _199) >= 0.0);
-        highp vec3 _413;
+        highp float _295;
+        highp float _277 = _269 ? _116 : _260;
+        highp float _278 = _276 / _277;
+        highp float _279 = dot(_275, u_fragParams.u_sunDirection.xyz);
+        highp float _280 = _279 / _277;
+        highp float _281 = dot(_259, u_fragParams.u_sunDirection.xyz);
+        highp float _283 = length(_173 - _275);
+        highp float _285 = _277 * _277;
+        highp float _288 = _285 * ((_278 * _278) - 1.0);
+        bool _291 = (_278 < 0.0) && ((_288 + _206) >= 0.0);
+        highp vec3 _420;
         switch (0u)
         {
             case 0u:
             {
-                _288 = (2.0 * _270) * _271;
-                highp float _293 = clamp(sqrt((_276 * (_276 + _288)) + _278), u_fragParams.u_earthCenter.w, _113);
-                highp float _296 = clamp((_269 + _276) / _293, -1.0, 1.0);
-                if (_284)
+                _295 = (2.0 * _277) * _278;
+                highp float _300 = clamp(sqrt((_283 * (_283 + _295)) + _285), u_fragParams.u_earthCenter.w, _116);
+                highp float _303 = clamp((_276 + _283) / _300, -1.0, 1.0);
+                if (_291)
                 {
-                    highp float _354 = -_296;
-                    highp float _355 = _293 * _293;
-                    highp float _358 = sqrt(max(_355 - _199, 0.0));
-                    highp float _369 = _113 - _293;
-                    highp float _383 = -_271;
-                    highp float _386 = sqrt(max(_278 - _199, 0.0));
-                    highp float _397 = _113 - _270;
-                    _413 = min(texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_293) * _354) + sqrt(max((_355 * ((_354 * _354) - 1.0)) + _198, 0.0)), 0.0) - _369) / ((_358 + _201) - _369)) * 0.99609375), 0.0078125 + ((_358 / _201) * 0.984375))).xyz / texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_270) * _383) + sqrt(max((_278 * ((_383 * _383) - 1.0)) + _198, 0.0)), 0.0) - _397) / ((_386 + _201) - _397)) * 0.99609375), 0.0078125 + ((_386 / _201) * 0.984375))).xyz, vec3(1.0));
+                    highp float _361 = -_303;
+                    highp float _362 = _300 * _300;
+                    highp float _365 = sqrt(max(_362 - _206, 0.0));
+                    highp float _376 = _116 - _300;
+                    highp float _390 = -_278;
+                    highp float _393 = sqrt(max(_285 - _206, 0.0));
+                    highp float _404 = _116 - _277;
+                    _420 = min(texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_300) * _361) + sqrt(max((_362 * ((_361 * _361) - 1.0)) + _205, 0.0)), 0.0) - _376) / ((_365 + _208) - _376)) * 0.99609375), 0.0078125 + ((_365 / _208) * 0.984375))).xyz / texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_277) * _390) + sqrt(max((_285 * ((_390 * _390) - 1.0)) + _205, 0.0)), 0.0) - _404) / ((_393 + _208) - _404)) * 0.99609375), 0.0078125 + ((_393 / _208) * 0.984375))).xyz, vec3(1.0));
                     break;
                 }
                 else
                 {
-                    highp float _302 = sqrt(max(_278 - _199, 0.0));
-                    highp float _310 = _113 - _270;
-                    highp float _324 = _293 * _293;
-                    highp float _327 = sqrt(max(_324 - _199, 0.0));
-                    highp float _338 = _113 - _293;
-                    _413 = min(texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_270) * _271) + sqrt(max(_281 + _198, 0.0)), 0.0) - _310) / ((_302 + _201) - _310)) * 0.99609375), 0.0078125 + ((_302 / _201) * 0.984375))).xyz / texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_293) * _296) + sqrt(max((_324 * ((_296 * _296) - 1.0)) + _198, 0.0)), 0.0) - _338) / ((_327 + _201) - _338)) * 0.99609375), 0.0078125 + ((_327 / _201) * 0.984375))).xyz, vec3(1.0));
+                    highp float _309 = sqrt(max(_285 - _206, 0.0));
+                    highp float _317 = _116 - _277;
+                    highp float _331 = _300 * _300;
+                    highp float _334 = sqrt(max(_331 - _206, 0.0));
+                    highp float _345 = _116 - _300;
+                    _420 = min(texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_277) * _278) + sqrt(max(_288 + _205, 0.0)), 0.0) - _317) / ((_309 + _208) - _317)) * 0.99609375), 0.0078125 + ((_309 / _208) * 0.984375))).xyz / texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_300) * _303) + sqrt(max((_331 * ((_303 * _303) - 1.0)) + _205, 0.0)), 0.0) - _345) / ((_334 + _208) - _345)) * 0.99609375), 0.0078125 + ((_334 / _208) * 0.984375))).xyz, vec3(1.0));
                     break;
                 }
             }
         }
-        highp float _416 = sqrt(max(_278 - _199, 0.0));
-        highp float _417 = _416 / _201;
-        highp float _419 = 0.015625 + (_417 * 0.96875);
-        highp float _422 = ((_269 * _269) - _278) + _199;
-        highp float _455;
-        if (_284)
+        highp float _423 = sqrt(max(_285 - _206, 0.0));
+        highp float _424 = _423 / _208;
+        highp float _426 = 0.015625 + (_424 * 0.96875);
+        highp float _429 = ((_276 * _276) - _285) + _206;
+        highp float _462;
+        if (_291)
         {
-            highp float _445 = _270 - u_fragParams.u_earthCenter.w;
-            _455 = 0.5 - (0.5 * (0.0078125 + (((_416 == _445) ? 0.0 : ((((-_269) - sqrt(max(_422, 0.0))) - _445) / (_416 - _445))) * 0.984375)));
+            highp float _452 = _277 - u_fragParams.u_earthCenter.w;
+            _462 = 0.5 - (0.5 * (0.0078125 + (((_423 == _452) ? 0.0 : ((((-_276) - sqrt(max(_429, 0.0))) - _452) / (_423 - _452))) * 0.984375)));
         }
         else
         {
-            highp float _432 = _113 - _270;
-            _455 = 0.5 + (0.5 * (0.0078125 + (((((-_269) + sqrt(max(_422 + (_201 * _201), 0.0))) - _432) / ((_416 + _201) - _432)) * 0.984375)));
+            highp float _439 = _116 - _277;
+            _462 = 0.5 + (0.5 * (0.0078125 + (((((-_276) + sqrt(max(_429 + (_208 * _208), 0.0))) - _439) / ((_423 + _208) - _439)) * 0.984375)));
         }
-        highp float _460 = -u_fragParams.u_earthCenter.w;
-        highp float _467 = _201 - _174;
-        highp float _468 = (max((_460 * _273) + sqrt(max((_199 * ((_273 * _273) - 1.0)) + _198, 0.0)), 0.0) - _174) / _467;
-        highp float _470 = (0.415823996067047119140625 * u_fragParams.u_earthCenter.w) / _467;
-        highp float _477 = 0.015625 + ((max(1.0 - (_468 / _470), 0.0) / (1.0 + _468)) * 0.96875);
-        highp float _479 = (_274 + 1.0) * 3.5;
-        highp float _480 = floor(_479);
-        highp float _481 = _479 - _480;
-        highp float _485 = _480 + 1.0;
-        highp vec4 _491 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_480 + _477) * 0.125, _455, _419));
-        highp float _492 = 1.0 - _481;
-        highp vec4 _495 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_485 + _477) * 0.125, _455, _419));
-        highp vec4 _497 = (_491 * _492) + (_495 * _481);
-        highp vec3 _498 = _497.xyz;
-        highp vec3 _511;
+        highp float _467 = -u_fragParams.u_earthCenter.w;
+        highp float _474 = _208 - _181;
+        highp float _475 = (max((_467 * _280) + sqrt(max((_206 * ((_280 * _280) - 1.0)) + _205, 0.0)), 0.0) - _181) / _474;
+        highp float _477 = (0.415823996067047119140625 * u_fragParams.u_earthCenter.w) / _474;
+        highp float _484 = 0.015625 + ((max(1.0 - (_475 / _477), 0.0) / (1.0 + _475)) * 0.96875);
+        highp float _486 = (_281 + 1.0) * 3.5;
+        highp float _487 = floor(_486);
+        highp float _488 = _486 - _487;
+        highp float _492 = _487 + 1.0;
+        highp vec4 _498 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_487 + _484) * 0.125, _462, _426));
+        highp float _499 = 1.0 - _488;
+        highp vec4 _502 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_492 + _484) * 0.125, _462, _426));
+        highp vec4 _504 = (_498 * _499) + (_502 * _488);
+        highp vec3 _505 = _504.xyz;
+        highp vec3 _518;
         switch (0u)
         {
             case 0u:
             {
-                highp float _501 = _497.x;
-                if (_501 == 0.0)
+                highp float _508 = _504.x;
+                if (_508 == 0.0)
                 {
-                    _511 = vec3(0.0);
+                    _518 = vec3(0.0);
                     break;
                 }
-                _511 = (((_498 * _497.w) / vec3(_501)) * 1.5) * vec3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
+                _518 = (((_505 * _504.w) / vec3(_508)) * 1.5) * vec3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
                 break;
             }
         }
-        highp float _513 = max(_276 - _248, 0.0);
-        highp float _518 = clamp(sqrt((_513 * (_513 + _288)) + _278), u_fragParams.u_earthCenter.w, _113);
-        highp float _519 = _269 + _513;
-        highp float _522 = (_272 + (_513 * _274)) / _518;
-        highp float _523 = _518 * _518;
-        highp float _526 = sqrt(max(_523 - _199, 0.0));
-        highp float _527 = _526 / _201;
-        highp float _529 = 0.015625 + (_527 * 0.96875);
-        highp float _532 = ((_519 * _519) - _523) + _199;
-        highp float _565;
-        if (_284)
+        highp float _520 = max(_283 - _255, 0.0);
+        highp float _525 = clamp(sqrt((_520 * (_520 + _295)) + _285), u_fragParams.u_earthCenter.w, _116);
+        highp float _526 = _276 + _520;
+        highp float _529 = (_279 + (_520 * _281)) / _525;
+        highp float _530 = _525 * _525;
+        highp float _533 = sqrt(max(_530 - _206, 0.0));
+        highp float _534 = _533 / _208;
+        highp float _536 = 0.015625 + (_534 * 0.96875);
+        highp float _539 = ((_526 * _526) - _530) + _206;
+        highp float _572;
+        if (_291)
         {
-            highp float _555 = _518 - u_fragParams.u_earthCenter.w;
-            _565 = 0.5 - (0.5 * (0.0078125 + (((_526 == _555) ? 0.0 : ((((-_519) - sqrt(max(_532, 0.0))) - _555) / (_526 - _555))) * 0.984375)));
+            highp float _562 = _525 - u_fragParams.u_earthCenter.w;
+            _572 = 0.5 - (0.5 * (0.0078125 + (((_533 == _562) ? 0.0 : ((((-_526) - sqrt(max(_539, 0.0))) - _562) / (_533 - _562))) * 0.984375)));
         }
         else
         {
-            highp float _542 = _113 - _518;
-            _565 = 0.5 + (0.5 * (0.0078125 + (((((-_519) + sqrt(max(_532 + (_201 * _201), 0.0))) - _542) / ((_526 + _201) - _542)) * 0.984375)));
+            highp float _549 = _116 - _525;
+            _572 = 0.5 + (0.5 * (0.0078125 + (((((-_526) + sqrt(max(_539 + (_208 * _208), 0.0))) - _549) / ((_533 + _208) - _549)) * 0.984375)));
         }
-        highp float _576 = (max((_460 * _522) + sqrt(max((_199 * ((_522 * _522) - 1.0)) + _198, 0.0)), 0.0) - _174) / _467;
-        highp float _583 = 0.015625 + ((max(1.0 - (_576 / _470), 0.0) / (1.0 + _576)) * 0.96875);
-        highp vec4 _591 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_480 + _583) * 0.125, _565, _529));
-        highp vec4 _594 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_485 + _583) * 0.125, _565, _529));
-        highp vec4 _596 = (_591 * _492) + (_594 * _481);
-        highp vec3 _597 = _596.xyz;
-        highp vec3 _610;
+        highp float _583 = (max((_467 * _529) + sqrt(max((_206 * ((_529 * _529) - 1.0)) + _205, 0.0)), 0.0) - _181) / _474;
+        highp float _590 = 0.015625 + ((max(1.0 - (_583 / _477), 0.0) / (1.0 + _583)) * 0.96875);
+        highp vec4 _598 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_487 + _590) * 0.125, _572, _536));
+        highp vec4 _601 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_492 + _590) * 0.125, _572, _536));
+        highp vec4 _603 = (_598 * _499) + (_601 * _488);
+        highp vec3 _604 = _603.xyz;
+        highp vec3 _617;
         switch (0u)
         {
             case 0u:
             {
-                highp float _600 = _596.x;
-                if (_600 == 0.0)
+                highp float _607 = _603.x;
+                if (_607 == 0.0)
                 {
-                    _610 = vec3(0.0);
+                    _617 = vec3(0.0);
                     break;
                 }
-                _610 = (((_597 * _596.w) / vec3(_600)) * 1.5) * vec3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
+                _617 = (((_604 * _603.w) / vec3(_607)) * 1.5) * vec3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
                 break;
             }
         }
-        highp vec3 _717;
-        if (_248 > 0.0)
+        highp vec3 _724;
+        if (_255 > 0.0)
         {
-            highp vec3 _716;
+            highp vec3 _723;
             switch (0u)
             {
                 case 0u:
                 {
-                    highp float _617 = clamp(_519 / _518, -1.0, 1.0);
-                    if (_284)
+                    highp float _624 = clamp(_526 / _525, -1.0, 1.0);
+                    if (_291)
                     {
-                        highp float _666 = -_617;
-                        highp float _677 = _113 - _518;
-                        highp float _690 = -_271;
-                        highp float _701 = _113 - _270;
-                        _716 = min(texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_518) * _666) + sqrt(max((_523 * ((_666 * _666) - 1.0)) + _198, 0.0)), 0.0) - _677) / ((_526 + _201) - _677)) * 0.99609375), 0.0078125 + (_527 * 0.984375))).xyz / texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_270) * _690) + sqrt(max((_278 * ((_690 * _690) - 1.0)) + _198, 0.0)), 0.0) - _701) / ((_416 + _201) - _701)) * 0.99609375), 0.0078125 + (_417 * 0.984375))).xyz, vec3(1.0));
+                        highp float _673 = -_624;
+                        highp float _684 = _116 - _525;
+                        highp float _697 = -_278;
+                        highp float _708 = _116 - _277;
+                        _723 = min(texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_525) * _673) + sqrt(max((_530 * ((_673 * _673) - 1.0)) + _205, 0.0)), 0.0) - _684) / ((_533 + _208) - _684)) * 0.99609375), 0.0078125 + (_534 * 0.984375))).xyz / texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_277) * _697) + sqrt(max((_285 * ((_697 * _697) - 1.0)) + _205, 0.0)), 0.0) - _708) / ((_423 + _208) - _708)) * 0.99609375), 0.0078125 + (_424 * 0.984375))).xyz, vec3(1.0));
                         break;
                     }
                     else
                     {
-                        highp float _628 = _113 - _270;
-                        highp float _651 = _113 - _518;
-                        _716 = min(texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_270) * _271) + sqrt(max(_281 + _198, 0.0)), 0.0) - _628) / ((_416 + _201) - _628)) * 0.99609375), 0.0078125 + (_417 * 0.984375))).xyz / texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_518) * _617) + sqrt(max((_523 * ((_617 * _617) - 1.0)) + _198, 0.0)), 0.0) - _651) / ((_526 + _201) - _651)) * 0.99609375), 0.0078125 + (_527 * 0.984375))).xyz, vec3(1.0));
+                        highp float _635 = _116 - _277;
+                        highp float _658 = _116 - _525;
+                        _723 = min(texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_277) * _278) + sqrt(max(_288 + _205, 0.0)), 0.0) - _635) / ((_423 + _208) - _635)) * 0.99609375), 0.0078125 + (_424 * 0.984375))).xyz / texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_525) * _624) + sqrt(max((_530 * ((_624 * _624) - 1.0)) + _205, 0.0)), 0.0) - _658) / ((_533 + _208) - _658)) * 0.99609375), 0.0078125 + (_534 * 0.984375))).xyz, vec3(1.0));
                         break;
                     }
                 }
             }
-            _717 = _716;
+            _724 = _723;
         }
         else
         {
-            _717 = _413;
+            _724 = _420;
         }
-        highp vec3 _719 = _498 - (_717 * _597);
-        highp vec3 _721 = _511 - (_717 * _610);
-        highp float _722 = _721.x;
-        highp float _723 = _719.x;
-        highp vec3 _738;
+        highp vec3 _726 = _505 - (_724 * _604);
+        highp vec3 _728 = _518 - (_724 * _617);
+        highp float _729 = _728.x;
+        highp float _730 = _726.x;
+        highp vec3 _745;
         switch (0u)
         {
             case 0u:
             {
-                if (_723 == 0.0)
+                if (_730 == 0.0)
                 {
-                    _738 = vec3(0.0);
+                    _745 = vec3(0.0);
                     break;
                 }
-                _738 = (((vec4(_723, _719.yz, _722).xyz * _722) / vec3(_723)) * 1.5) * vec3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
+                _745 = (((vec4(_730, _726.yz, _729).xyz * _729) / vec3(_730)) * 1.5) * vec3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
                 break;
             }
         }
-        highp float _742 = 1.0 + (_274 * _274);
-        _754 = (((_154.xyz * 0.3183098733425140380859375) * ((vec3(1.47399997711181640625, 1.85039997100830078125, 1.91198003292083740234375) * max((_229.xyz * smoothstep(_192 * (-0.004674999974668025970458984375), _192 * 0.004674999974668025970458984375, _172 - (-sqrt(max(1.0 - (_192 * _192), 0.0))))) * max(dot(_167, u_fragParams.u_sunDirection.xyz), 0.0), vec3(0.001000000047497451305389404296875))) + ((_185.xyz * (1.0 + (dot(_167, _166) / _170))) * 0.5))) * _413) + ((_719 * (0.0596831031143665313720703125 * _742)) + ((_738 * smoothstep(0.0, 0.00999999977648258209228515625, _273)) * ((0.01627720706164836883544921875 * _742) / pow(1.6400001049041748046875 - (1.60000002384185791015625 * _274), 1.5))));
+        highp float _749 = 1.0 + (_281 * _281);
+        _761 = (((_161.xyz * 0.3183098733425140380859375) * ((vec3(1.47399997711181640625, 1.85039997100830078125, 1.91198003292083740234375) * max((_236.xyz * smoothstep(_199 * (-0.004674999974668025970458984375), _199 * 0.004674999974668025970458984375, _179 - (-sqrt(max(1.0 - (_199 * _199), 0.0))))) * max(dot(_174, u_fragParams.u_sunDirection.xyz), 0.0), vec3(0.001000000047497451305389404296875))) + ((_192.xyz * (1.0 + (dot(_174, _173) / _177))) * 0.5))) * _420) + ((_726 * (0.0596831031143665313720703125 * _749)) + ((_745 * smoothstep(0.0, 0.00999999977648258209228515625, _280)) * ((0.01627720706164836883544921875 * _749) / pow(1.6400001049041748046875 - (1.60000002384185791015625 * _281), 1.5))));
     }
     else
     {
-        _754 = vec3(0.0);
+        _761 = vec3(0.0);
     }
-    highp vec3 _756 = u_fragParams.u_camera.xyz - u_fragParams.u_earthCenter.xyz;
-    highp float _757 = dot(_756, _126);
-    highp float _759 = _757 * _757;
-    highp float _761 = -_757;
-    highp float _762 = u_fragParams.u_earthCenter.w * u_fragParams.u_earthCenter.w;
-    highp float _765 = _761 - sqrt(_762 - (dot(_756, _756) - _759));
-    bool _766 = _765 > 0.0;
-    highp vec3 _1245;
-    if (_766)
+    highp vec3 _763 = u_fragParams.u_camera.xyz - u_fragParams.u_earthCenter.xyz;
+    highp float _764 = dot(_763, _129);
+    highp float _766 = _764 * _764;
+    highp float _768 = -_764;
+    highp float _769 = u_fragParams.u_earthCenter.w * u_fragParams.u_earthCenter.w;
+    highp float _772 = _768 - sqrt(_769 - (dot(_763, _763) - _766));
+    bool _773 = _772 > 0.0;
+    highp vec3 _1252;
+    if (_773)
     {
-        highp vec3 _771 = (u_fragParams.u_camera.xyz + (_126 * _765)) - u_fragParams.u_earthCenter.xyz;
-        highp vec3 _772 = normalize(_771);
-        highp float _775 = length(_771);
-        highp float _777 = dot(_771, u_fragParams.u_sunDirection.xyz) / _775;
-        highp float _779 = _113 - u_fragParams.u_earthCenter.w;
-        highp vec4 _790 = texture(SPIRV_Cross_CombinedirradianceTextureirradianceSampler, vec2(0.0078125 + (((_777 * 0.5) + 0.5) * 0.984375), 0.03125 + (((_775 - u_fragParams.u_earthCenter.w) / _779) * 0.9375)));
-        highp float _797 = u_fragParams.u_earthCenter.w / _775;
-        highp float _803 = _113 * _113;
-        highp float _805 = sqrt(_803 - _762);
-        highp float _806 = _775 * _775;
-        highp float _809 = sqrt(max(_806 - _762, 0.0));
-        highp float _820 = _113 - _775;
-        highp vec4 _833 = texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_775) * _777) + sqrt(max((_806 * ((_777 * _777) - 1.0)) + _803, 0.0)), 0.0) - _820) / ((_809 + _805) - _820)) * 0.99609375), 0.0078125 + ((_809 / _805) * 0.984375)));
-        highp vec3 _851 = normalize(_771 - _756);
-        highp float _852 = length(_756);
-        highp float _853 = dot(_756, _851);
-        highp float _860 = (-_853) - sqrt(((_853 * _853) - (_852 * _852)) + _803);
-        bool _861 = _860 > 0.0;
-        highp vec3 _867;
-        highp float _868;
-        if (_861)
+        highp vec3 _778 = (u_fragParams.u_camera.xyz + (_129 * _772)) - u_fragParams.u_earthCenter.xyz;
+        highp vec3 _779 = normalize(_778);
+        highp float _782 = length(_778);
+        highp float _784 = dot(_778, u_fragParams.u_sunDirection.xyz) / _782;
+        highp float _786 = _116 - u_fragParams.u_earthCenter.w;
+        highp vec4 _797 = texture(SPIRV_Cross_CombinedirradianceTextureirradianceSampler, vec2(0.0078125 + (((_784 * 0.5) + 0.5) * 0.984375), 0.03125 + (((_782 - u_fragParams.u_earthCenter.w) / _786) * 0.9375)));
+        highp float _804 = u_fragParams.u_earthCenter.w / _782;
+        highp float _810 = _116 * _116;
+        highp float _812 = sqrt(_810 - _769);
+        highp float _813 = _782 * _782;
+        highp float _816 = sqrt(max(_813 - _769, 0.0));
+        highp float _827 = _116 - _782;
+        highp vec4 _840 = texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_782) * _784) + sqrt(max((_813 * ((_784 * _784) - 1.0)) + _810, 0.0)), 0.0) - _827) / ((_816 + _812) - _827)) * 0.99609375), 0.0078125 + ((_816 / _812) * 0.984375)));
+        highp vec3 _858 = normalize(_778 - _763);
+        highp float _859 = length(_763);
+        highp float _860 = dot(_763, _858);
+        highp float _867 = (-_860) - sqrt(((_860 * _860) - (_859 * _859)) + _810);
+        bool _868 = _867 > 0.0;
+        highp vec3 _874;
+        highp float _875;
+        if (_868)
         {
-            _867 = _756 + (_851 * _860);
-            _868 = _853 + _860;
+            _874 = _763 + (_858 * _867);
+            _875 = _860 + _867;
         }
         else
         {
-            _867 = _756;
-            _868 = _853;
+            _874 = _763;
+            _875 = _860;
         }
-        highp float _887;
-        highp float _869 = _861 ? _113 : _852;
-        highp float _870 = _868 / _869;
-        highp float _871 = dot(_867, u_fragParams.u_sunDirection.xyz);
-        highp float _872 = _871 / _869;
-        highp float _873 = dot(_851, u_fragParams.u_sunDirection.xyz);
-        highp float _875 = length(_771 - _867);
-        highp float _877 = _869 * _869;
-        highp float _880 = _877 * ((_870 * _870) - 1.0);
-        bool _883 = (_870 < 0.0) && ((_880 + _762) >= 0.0);
-        highp vec3 _1012;
+        highp float _894;
+        highp float _876 = _868 ? _116 : _859;
+        highp float _877 = _875 / _876;
+        highp float _878 = dot(_874, u_fragParams.u_sunDirection.xyz);
+        highp float _879 = _878 / _876;
+        highp float _880 = dot(_858, u_fragParams.u_sunDirection.xyz);
+        highp float _882 = length(_778 - _874);
+        highp float _884 = _876 * _876;
+        highp float _887 = _884 * ((_877 * _877) - 1.0);
+        bool _890 = (_877 < 0.0) && ((_887 + _769) >= 0.0);
+        highp vec3 _1019;
         switch (0u)
         {
             case 0u:
             {
-                _887 = (2.0 * _869) * _870;
-                highp float _892 = clamp(sqrt((_875 * (_875 + _887)) + _877), u_fragParams.u_earthCenter.w, _113);
-                highp float _895 = clamp((_868 + _875) / _892, -1.0, 1.0);
-                if (_883)
+                _894 = (2.0 * _876) * _877;
+                highp float _899 = clamp(sqrt((_882 * (_882 + _894)) + _884), u_fragParams.u_earthCenter.w, _116);
+                highp float _902 = clamp((_875 + _882) / _899, -1.0, 1.0);
+                if (_890)
                 {
-                    highp float _953 = -_895;
-                    highp float _954 = _892 * _892;
-                    highp float _957 = sqrt(max(_954 - _762, 0.0));
-                    highp float _968 = _113 - _892;
-                    highp float _982 = -_870;
-                    highp float _985 = sqrt(max(_877 - _762, 0.0));
-                    highp float _996 = _113 - _869;
-                    _1012 = min(texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_892) * _953) + sqrt(max((_954 * ((_953 * _953) - 1.0)) + _803, 0.0)), 0.0) - _968) / ((_957 + _805) - _968)) * 0.99609375), 0.0078125 + ((_957 / _805) * 0.984375))).xyz / texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_869) * _982) + sqrt(max((_877 * ((_982 * _982) - 1.0)) + _803, 0.0)), 0.0) - _996) / ((_985 + _805) - _996)) * 0.99609375), 0.0078125 + ((_985 / _805) * 0.984375))).xyz, vec3(1.0));
+                    highp float _960 = -_902;
+                    highp float _961 = _899 * _899;
+                    highp float _964 = sqrt(max(_961 - _769, 0.0));
+                    highp float _975 = _116 - _899;
+                    highp float _989 = -_877;
+                    highp float _992 = sqrt(max(_884 - _769, 0.0));
+                    highp float _1003 = _116 - _876;
+                    _1019 = min(texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_899) * _960) + sqrt(max((_961 * ((_960 * _960) - 1.0)) + _810, 0.0)), 0.0) - _975) / ((_964 + _812) - _975)) * 0.99609375), 0.0078125 + ((_964 / _812) * 0.984375))).xyz / texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_876) * _989) + sqrt(max((_884 * ((_989 * _989) - 1.0)) + _810, 0.0)), 0.0) - _1003) / ((_992 + _812) - _1003)) * 0.99609375), 0.0078125 + ((_992 / _812) * 0.984375))).xyz, vec3(1.0));
                     break;
                 }
                 else
                 {
-                    highp float _901 = sqrt(max(_877 - _762, 0.0));
-                    highp float _909 = _113 - _869;
-                    highp float _923 = _892 * _892;
-                    highp float _926 = sqrt(max(_923 - _762, 0.0));
-                    highp float _937 = _113 - _892;
-                    _1012 = min(texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_869) * _870) + sqrt(max(_880 + _803, 0.0)), 0.0) - _909) / ((_901 + _805) - _909)) * 0.99609375), 0.0078125 + ((_901 / _805) * 0.984375))).xyz / texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_892) * _895) + sqrt(max((_923 * ((_895 * _895) - 1.0)) + _803, 0.0)), 0.0) - _937) / ((_926 + _805) - _937)) * 0.99609375), 0.0078125 + ((_926 / _805) * 0.984375))).xyz, vec3(1.0));
+                    highp float _908 = sqrt(max(_884 - _769, 0.0));
+                    highp float _916 = _116 - _876;
+                    highp float _930 = _899 * _899;
+                    highp float _933 = sqrt(max(_930 - _769, 0.0));
+                    highp float _944 = _116 - _899;
+                    _1019 = min(texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_876) * _877) + sqrt(max(_887 + _810, 0.0)), 0.0) - _916) / ((_908 + _812) - _916)) * 0.99609375), 0.0078125 + ((_908 / _812) * 0.984375))).xyz / texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_899) * _902) + sqrt(max((_930 * ((_902 * _902) - 1.0)) + _810, 0.0)), 0.0) - _944) / ((_933 + _812) - _944)) * 0.99609375), 0.0078125 + ((_933 / _812) * 0.984375))).xyz, vec3(1.0));
                     break;
                 }
             }
         }
-        highp float _1015 = sqrt(max(_877 - _762, 0.0));
-        highp float _1018 = 0.015625 + ((_1015 / _805) * 0.96875);
-        highp float _1021 = ((_868 * _868) - _877) + _762;
-        highp float _1054;
-        if (_883)
+        highp float _1022 = sqrt(max(_884 - _769, 0.0));
+        highp float _1025 = 0.015625 + ((_1022 / _812) * 0.96875);
+        highp float _1028 = ((_875 * _875) - _884) + _769;
+        highp float _1061;
+        if (_890)
         {
-            highp float _1044 = _869 - u_fragParams.u_earthCenter.w;
-            _1054 = 0.5 - (0.5 * (0.0078125 + (((_1015 == _1044) ? 0.0 : ((((-_868) - sqrt(max(_1021, 0.0))) - _1044) / (_1015 - _1044))) * 0.984375)));
+            highp float _1051 = _876 - u_fragParams.u_earthCenter.w;
+            _1061 = 0.5 - (0.5 * (0.0078125 + (((_1022 == _1051) ? 0.0 : ((((-_875) - sqrt(max(_1028, 0.0))) - _1051) / (_1022 - _1051))) * 0.984375)));
         }
         else
         {
-            highp float _1031 = _113 - _869;
-            _1054 = 0.5 + (0.5 * (0.0078125 + (((((-_868) + sqrt(max(_1021 + (_805 * _805), 0.0))) - _1031) / ((_1015 + _805) - _1031)) * 0.984375)));
+            highp float _1038 = _116 - _876;
+            _1061 = 0.5 + (0.5 * (0.0078125 + (((((-_875) + sqrt(max(_1028 + (_812 * _812), 0.0))) - _1038) / ((_1022 + _812) - _1038)) * 0.984375)));
         }
-        highp float _1059 = -u_fragParams.u_earthCenter.w;
-        highp float _1066 = _805 - _779;
-        highp float _1067 = (max((_1059 * _872) + sqrt(max((_762 * ((_872 * _872) - 1.0)) + _803, 0.0)), 0.0) - _779) / _1066;
-        highp float _1069 = (0.415823996067047119140625 * u_fragParams.u_earthCenter.w) / _1066;
-        highp float _1076 = 0.015625 + ((max(1.0 - (_1067 / _1069), 0.0) / (1.0 + _1067)) * 0.96875);
-        highp float _1078 = (_873 + 1.0) * 3.5;
-        highp float _1079 = floor(_1078);
-        highp float _1080 = _1078 - _1079;
-        highp float _1084 = _1079 + 1.0;
-        highp vec4 _1090 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_1079 + _1076) * 0.125, _1054, _1018));
-        highp float _1091 = 1.0 - _1080;
-        highp vec4 _1094 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_1084 + _1076) * 0.125, _1054, _1018));
-        highp vec4 _1096 = (_1090 * _1091) + (_1094 * _1080);
-        highp vec3 _1097 = _1096.xyz;
-        highp vec3 _1110;
+        highp float _1066 = -u_fragParams.u_earthCenter.w;
+        highp float _1073 = _812 - _786;
+        highp float _1074 = (max((_1066 * _879) + sqrt(max((_769 * ((_879 * _879) - 1.0)) + _810, 0.0)), 0.0) - _786) / _1073;
+        highp float _1076 = (0.415823996067047119140625 * u_fragParams.u_earthCenter.w) / _1073;
+        highp float _1083 = 0.015625 + ((max(1.0 - (_1074 / _1076), 0.0) / (1.0 + _1074)) * 0.96875);
+        highp float _1085 = (_880 + 1.0) * 3.5;
+        highp float _1086 = floor(_1085);
+        highp float _1087 = _1085 - _1086;
+        highp float _1091 = _1086 + 1.0;
+        highp vec4 _1097 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_1086 + _1083) * 0.125, _1061, _1025));
+        highp float _1098 = 1.0 - _1087;
+        highp vec4 _1101 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_1091 + _1083) * 0.125, _1061, _1025));
+        highp vec4 _1103 = (_1097 * _1098) + (_1101 * _1087);
+        highp vec3 _1104 = _1103.xyz;
+        highp vec3 _1117;
         switch (0u)
         {
             case 0u:
             {
-                highp float _1100 = _1096.x;
-                if (_1100 == 0.0)
+                highp float _1107 = _1103.x;
+                if (_1107 == 0.0)
                 {
-                    _1110 = vec3(0.0);
+                    _1117 = vec3(0.0);
                     break;
                 }
-                _1110 = (((_1097 * _1096.w) / vec3(_1100)) * 1.5) * vec3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
+                _1117 = (((_1104 * _1103.w) / vec3(_1107)) * 1.5) * vec3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
                 break;
             }
         }
-        highp float _1111 = max(_875, 0.0);
-        highp float _1116 = clamp(sqrt((_1111 * (_1111 + _887)) + _877), u_fragParams.u_earthCenter.w, _113);
-        highp float _1117 = _868 + _1111;
-        highp float _1120 = (_871 + (_1111 * _873)) / _1116;
-        highp float _1121 = _1116 * _1116;
-        highp float _1124 = sqrt(max(_1121 - _762, 0.0));
-        highp float _1127 = 0.015625 + ((_1124 / _805) * 0.96875);
-        highp float _1130 = ((_1117 * _1117) - _1121) + _762;
-        highp float _1163;
-        if (_883)
+        highp float _1118 = max(_882, 0.0);
+        highp float _1123 = clamp(sqrt((_1118 * (_1118 + _894)) + _884), u_fragParams.u_earthCenter.w, _116);
+        highp float _1124 = _875 + _1118;
+        highp float _1127 = (_878 + (_1118 * _880)) / _1123;
+        highp float _1128 = _1123 * _1123;
+        highp float _1131 = sqrt(max(_1128 - _769, 0.0));
+        highp float _1134 = 0.015625 + ((_1131 / _812) * 0.96875);
+        highp float _1137 = ((_1124 * _1124) - _1128) + _769;
+        highp float _1170;
+        if (_890)
         {
-            highp float _1153 = _1116 - u_fragParams.u_earthCenter.w;
-            _1163 = 0.5 - (0.5 * (0.0078125 + (((_1124 == _1153) ? 0.0 : ((((-_1117) - sqrt(max(_1130, 0.0))) - _1153) / (_1124 - _1153))) * 0.984375)));
+            highp float _1160 = _1123 - u_fragParams.u_earthCenter.w;
+            _1170 = 0.5 - (0.5 * (0.0078125 + (((_1131 == _1160) ? 0.0 : ((((-_1124) - sqrt(max(_1137, 0.0))) - _1160) / (_1131 - _1160))) * 0.984375)));
         }
         else
         {
-            highp float _1140 = _113 - _1116;
-            _1163 = 0.5 + (0.5 * (0.0078125 + (((((-_1117) + sqrt(max(_1130 + (_805 * _805), 0.0))) - _1140) / ((_1124 + _805) - _1140)) * 0.984375)));
+            highp float _1147 = _116 - _1123;
+            _1170 = 0.5 + (0.5 * (0.0078125 + (((((-_1124) + sqrt(max(_1137 + (_812 * _812), 0.0))) - _1147) / ((_1131 + _812) - _1147)) * 0.984375)));
         }
-        highp float _1174 = (max((_1059 * _1120) + sqrt(max((_762 * ((_1120 * _1120) - 1.0)) + _803, 0.0)), 0.0) - _779) / _1066;
-        highp float _1181 = 0.015625 + ((max(1.0 - (_1174 / _1069), 0.0) / (1.0 + _1174)) * 0.96875);
-        highp vec4 _1189 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_1079 + _1181) * 0.125, _1163, _1127));
-        highp vec4 _1192 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_1084 + _1181) * 0.125, _1163, _1127));
-        highp vec4 _1194 = (_1189 * _1091) + (_1192 * _1080);
-        highp vec3 _1195 = _1194.xyz;
-        highp vec3 _1208;
+        highp float _1181 = (max((_1066 * _1127) + sqrt(max((_769 * ((_1127 * _1127) - 1.0)) + _810, 0.0)), 0.0) - _786) / _1073;
+        highp float _1188 = 0.015625 + ((max(1.0 - (_1181 / _1076), 0.0) / (1.0 + _1181)) * 0.96875);
+        highp vec4 _1196 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_1086 + _1188) * 0.125, _1170, _1134));
+        highp vec4 _1199 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_1091 + _1188) * 0.125, _1170, _1134));
+        highp vec4 _1201 = (_1196 * _1098) + (_1199 * _1087);
+        highp vec3 _1202 = _1201.xyz;
+        highp vec3 _1215;
         switch (0u)
         {
             case 0u:
             {
-                highp float _1198 = _1194.x;
-                if (_1198 == 0.0)
+                highp float _1205 = _1201.x;
+                if (_1205 == 0.0)
                 {
-                    _1208 = vec3(0.0);
+                    _1215 = vec3(0.0);
                     break;
                 }
-                _1208 = (((_1195 * _1194.w) / vec3(_1198)) * 1.5) * vec3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
+                _1215 = (((_1202 * _1201.w) / vec3(_1205)) * 1.5) * vec3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
                 break;
             }
         }
-        highp vec3 _1210 = _1097 - (_1012 * _1195);
-        highp vec3 _1212 = _1110 - (_1012 * _1208);
-        highp float _1213 = _1212.x;
-        highp float _1214 = _1210.x;
-        highp vec3 _1229;
+        highp vec3 _1217 = _1104 - (_1019 * _1202);
+        highp vec3 _1219 = _1117 - (_1019 * _1215);
+        highp float _1220 = _1219.x;
+        highp float _1221 = _1217.x;
+        highp vec3 _1236;
         switch (0u)
         {
             case 0u:
             {
-                if (_1214 == 0.0)
+                if (_1221 == 0.0)
                 {
-                    _1229 = vec3(0.0);
+                    _1236 = vec3(0.0);
                     break;
                 }
-                _1229 = (((vec4(_1214, _1210.yz, _1213).xyz * _1213) / vec3(_1214)) * 1.5) * vec3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
+                _1236 = (((vec4(_1221, _1217.yz, _1220).xyz * _1220) / vec3(_1221)) * 1.5) * vec3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
                 break;
             }
         }
-        highp float _1233 = 1.0 + (_873 * _873);
-        _1245 = (((_154.xyz * 0.3183098733425140380859375) * ((vec3(1.47399997711181640625, 1.85039997100830078125, 1.91198003292083740234375) * max((_833.xyz * smoothstep(_797 * (-0.004674999974668025970458984375), _797 * 0.004674999974668025970458984375, _777 - (-sqrt(max(1.0 - (_797 * _797), 0.0))))) * max(dot(_772, u_fragParams.u_sunDirection.xyz), 0.0), vec3(0.001000000047497451305389404296875))) + ((_790.xyz * (1.0 + (dot(_772, _771) / _775))) * 0.5))) * _1012) + ((_1210 * (0.0596831031143665313720703125 * _1233)) + ((_1229 * smoothstep(0.0, 0.00999999977648258209228515625, _872)) * ((0.01627720706164836883544921875 * _1233) / pow(1.6400001049041748046875 - (1.60000002384185791015625 * _873), 1.5))));
+        highp float _1240 = 1.0 + (_880 * _880);
+        _1252 = (((_161.xyz * 0.3183098733425140380859375) * ((vec3(1.47399997711181640625, 1.85039997100830078125, 1.91198003292083740234375) * max((_840.xyz * smoothstep(_804 * (-0.004674999974668025970458984375), _804 * 0.004674999974668025970458984375, _784 - (-sqrt(max(1.0 - (_804 * _804), 0.0))))) * max(dot(_779, u_fragParams.u_sunDirection.xyz), 0.0), vec3(0.001000000047497451305389404296875))) + ((_797.xyz * (1.0 + (dot(_779, _778) / _782))) * 0.5))) * _1019) + ((_1217 * (0.0596831031143665313720703125 * _1240)) + ((_1236 * smoothstep(0.0, 0.00999999977648258209228515625, _879)) * ((0.01627720706164836883544921875 * _1240) / pow(1.6400001049041748046875 - (1.60000002384185791015625 * _880), 1.5))));
     }
     else
     {
-        _1245 = vec3(0.0);
+        _1252 = vec3(0.0);
     }
-    highp vec3 _1415;
-    highp vec3 _1416;
+    highp vec3 _1422;
+    highp vec3 _1423;
     switch (0u)
     {
         case 0u:
         {
-            highp float _1251 = length(_756);
-            highp float _1254 = _113 * _113;
-            highp float _1257 = _761 - sqrt((_759 - (_1251 * _1251)) + _1254);
-            bool _1258 = _1257 > 0.0;
-            highp vec3 _1268;
-            highp float _1269;
-            if (_1258)
+            highp float _1258 = length(_763);
+            highp float _1261 = _116 * _116;
+            highp float _1264 = _768 - sqrt((_766 - (_1258 * _1258)) + _1261);
+            bool _1265 = _1264 > 0.0;
+            highp vec3 _1275;
+            highp float _1276;
+            if (_1265)
             {
-                _1268 = _756 + (_126 * _1257);
-                _1269 = _757 + _1257;
+                _1275 = _763 + (_129 * _1264);
+                _1276 = _764 + _1264;
             }
             else
             {
-                if (_1251 > _113)
+                if (_1258 > _116)
                 {
-                    _1415 = vec3(1.0);
-                    _1416 = vec3(0.0);
+                    _1422 = vec3(1.0);
+                    _1423 = vec3(0.0);
                     break;
                 }
-                _1268 = _756;
-                _1269 = _757;
+                _1275 = _763;
+                _1276 = _764;
             }
-            highp float _1270 = _1258 ? _113 : _1251;
-            highp float _1271 = _1269 / _1270;
-            highp float _1273 = dot(_1268, u_fragParams.u_sunDirection.xyz) / _1270;
-            highp float _1274 = dot(_126, u_fragParams.u_sunDirection.xyz);
-            highp float _1276 = _1270 * _1270;
-            highp float _1279 = _1276 * ((_1271 * _1271) - 1.0);
-            bool _1282 = (_1271 < 0.0) && ((_1279 + _762) >= 0.0);
-            highp float _1284 = sqrt(_1254 - _762);
-            highp float _1287 = sqrt(max(_1276 - _762, 0.0));
-            highp float _1295 = _113 - _1270;
-            highp float _1298 = (_1287 + _1284) - _1295;
-            highp float _1300 = _1287 / _1284;
-            highp vec4 _1308 = texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_1270) * _1271) + sqrt(max(_1279 + _1254, 0.0)), 0.0) - _1295) / _1298) * 0.99609375), 0.0078125 + (_1300 * 0.984375)));
-            highp vec3 _1309 = _1308.xyz;
-            bvec3 _1310 = bvec3(_1282);
-            highp float _1313 = 0.015625 + (_1300 * 0.96875);
-            highp float _1316 = ((_1269 * _1269) - _1276) + _762;
-            highp float _1346;
-            if (_1282)
+            highp float _1277 = _1265 ? _116 : _1258;
+            highp float _1278 = _1276 / _1277;
+            highp float _1280 = dot(_1275, u_fragParams.u_sunDirection.xyz) / _1277;
+            highp float _1281 = dot(_129, u_fragParams.u_sunDirection.xyz);
+            highp float _1283 = _1277 * _1277;
+            highp float _1286 = _1283 * ((_1278 * _1278) - 1.0);
+            bool _1289 = (_1278 < 0.0) && ((_1286 + _769) >= 0.0);
+            highp float _1291 = sqrt(_1261 - _769);
+            highp float _1294 = sqrt(max(_1283 - _769, 0.0));
+            highp float _1302 = _116 - _1277;
+            highp float _1305 = (_1294 + _1291) - _1302;
+            highp float _1307 = _1294 / _1291;
+            highp vec4 _1315 = texture(SPIRV_Cross_CombinedtransmittanceTexturetransmittanceSampler, vec2(0.001953125 + (((max(((-_1277) * _1278) + sqrt(max(_1286 + _1261, 0.0)), 0.0) - _1302) / _1305) * 0.99609375), 0.0078125 + (_1307 * 0.984375)));
+            highp vec3 _1316 = _1315.xyz;
+            bvec3 _1317 = bvec3(_1289);
+            highp float _1320 = 0.015625 + (_1307 * 0.96875);
+            highp float _1323 = ((_1276 * _1276) - _1283) + _769;
+            highp float _1353;
+            if (_1289)
             {
-                highp float _1336 = _1270 - u_fragParams.u_earthCenter.w;
-                _1346 = 0.5 - (0.5 * (0.0078125 + (((_1287 == _1336) ? 0.0 : ((((-_1269) - sqrt(max(_1316, 0.0))) - _1336) / (_1287 - _1336))) * 0.984375)));
+                highp float _1343 = _1277 - u_fragParams.u_earthCenter.w;
+                _1353 = 0.5 - (0.5 * (0.0078125 + (((_1294 == _1343) ? 0.0 : ((((-_1276) - sqrt(max(_1323, 0.0))) - _1343) / (_1294 - _1343))) * 0.984375)));
             }
             else
             {
-                _1346 = 0.5 + (0.5 * (0.0078125 + (((((-_1269) + sqrt(max(_1316 + (_1284 * _1284), 0.0))) - _1295) / _1298) * 0.984375)));
+                _1353 = 0.5 + (0.5 * (0.0078125 + (((((-_1276) + sqrt(max(_1323 + (_1291 * _1291), 0.0))) - _1302) / _1305) * 0.984375)));
             }
-            highp float _1357 = _113 - u_fragParams.u_earthCenter.w;
-            highp float _1359 = _1284 - _1357;
-            highp float _1360 = (max(((-u_fragParams.u_earthCenter.w) * _1273) + sqrt(max((_762 * ((_1273 * _1273) - 1.0)) + _1254, 0.0)), 0.0) - _1357) / _1359;
-            highp float _1369 = 0.015625 + ((max(1.0 - (_1360 / ((0.415823996067047119140625 * u_fragParams.u_earthCenter.w) / _1359)), 0.0) / (1.0 + _1360)) * 0.96875);
-            highp float _1371 = (_1274 + 1.0) * 3.5;
-            highp float _1372 = floor(_1371);
-            highp float _1373 = _1371 - _1372;
-            highp vec4 _1383 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_1372 + _1369) * 0.125, _1346, _1313));
-            highp vec4 _1387 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3(((_1372 + 1.0) + _1369) * 0.125, _1346, _1313));
-            highp vec4 _1389 = (_1383 * (1.0 - _1373)) + (_1387 * _1373);
-            highp vec3 _1390 = _1389.xyz;
-            highp vec3 _1403;
+            highp float _1364 = _116 - u_fragParams.u_earthCenter.w;
+            highp float _1366 = _1291 - _1364;
+            highp float _1367 = (max(((-u_fragParams.u_earthCenter.w) * _1280) + sqrt(max((_769 * ((_1280 * _1280) - 1.0)) + _1261, 0.0)), 0.0) - _1364) / _1366;
+            highp float _1376 = 0.015625 + ((max(1.0 - (_1367 / ((0.415823996067047119140625 * u_fragParams.u_earthCenter.w) / _1366)), 0.0) / (1.0 + _1367)) * 0.96875);
+            highp float _1378 = (_1281 + 1.0) * 3.5;
+            highp float _1379 = floor(_1378);
+            highp float _1380 = _1378 - _1379;
+            highp vec4 _1390 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3((_1379 + _1376) * 0.125, _1353, _1320));
+            highp vec4 _1394 = texture(SPIRV_Cross_CombinedscatteringTexturescatteringSampler, vec3(((_1379 + 1.0) + _1376) * 0.125, _1353, _1320));
+            highp vec4 _1396 = (_1390 * (1.0 - _1380)) + (_1394 * _1380);
+            highp vec3 _1397 = _1396.xyz;
+            highp vec3 _1410;
             switch (0u)
             {
                 case 0u:
                 {
-                    highp float _1393 = _1389.x;
-                    if (_1393 == 0.0)
+                    highp float _1400 = _1396.x;
+                    if (_1400 == 0.0)
                     {
-                        _1403 = vec3(0.0);
+                        _1410 = vec3(0.0);
                         break;
                     }
-                    _1403 = (((_1390 * _1389.w) / vec3(_1393)) * 1.5) * vec3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
+                    _1410 = (((_1397 * _1396.w) / vec3(_1400)) * 1.5) * vec3(0.66666662693023681640625, 0.28571426868438720703125, 0.121212117373943328857421875);
                     break;
                 }
             }
-            highp float _1405 = 1.0 + (_1274 * _1274);
-            _1415 = vec3(_1310.x ? vec3(0.0).x : _1309.x, _1310.y ? vec3(0.0).y : _1309.y, _1310.z ? vec3(0.0).z : _1309.z);
-            _1416 = (_1390 * (0.0596831031143665313720703125 * _1405)) + (_1403 * ((0.01627720706164836883544921875 * _1405) / pow(1.6400001049041748046875 - (1.60000002384185791015625 * _1274), 1.5)));
+            highp float _1412 = 1.0 + (_1281 * _1281);
+            _1422 = vec3(_1317.x ? vec3(0.0).x : _1316.x, _1317.y ? vec3(0.0).y : _1316.y, _1317.z ? vec3(0.0).z : _1316.z);
+            _1423 = (_1397 * (0.0596831031143665313720703125 * _1412)) + (_1410 * ((0.01627720706164836883544921875 * _1412) / pow(1.6400001049041748046875 - (1.60000002384185791015625 * _1281), 1.5)));
             break;
         }
     }
-    highp vec3 _1424;
-    if (dot(_126, u_fragParams.u_sunDirection.xyz) > u_fragParams.u_sunSize.y)
+    highp vec3 _1431;
+    if (dot(_129, u_fragParams.u_sunDirection.xyz) > u_fragParams.u_sunSize.y)
     {
-        _1424 = _1416 + (_1415 * vec3(21467.642578125, 26949.611328125, 27846.474609375));
+        _1431 = _1423 + (_1422 * vec3(21467.642578125, 26949.611328125, 27846.474609375));
     }
     else
     {
-        _1424 = _1416;
+        _1431 = _1423;
     }
-    highp vec3 _1438 = pow(abs(vec3(1.0) - exp(((-mix(mix(_1424, _1245, vec3(float(_766))), _754, vec3(float(_163)))) / u_fragParams.u_whitePoint.xyz) * u_fragParams.u_camera.w)), vec3(0.4545454680919647216796875));
-    highp vec4 _1440 = vec4(_1438.x, _1438.y, _1438.z, _105.w);
-    _1440.w = 1.0;
-    out_var_SV_Target = _1440;
-    gl_FragDepth = _131;
+    highp vec3 _1445 = pow(abs(vec3(1.0) - exp(((-mix(mix(_1431, _1252, vec3(float(_773))), _761, vec3(float(_170)))) / u_fragParams.u_whitePoint.xyz) * u_fragParams.u_camera.w)), vec3(0.4545454680919647216796875));
+    highp vec4 _1447 = vec4(_1445.x, _1445.y, _1445.z, _108.w);
+    _1447.w = 1.0;
+    out_var_SV_Target0 = _1447;
+    out_var_SV_Target1 = _137;
+    gl_FragDepth = _142;
 }
 

--- a/src/gl/opengl/shaders/mobile/compassFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/compassFragmentShader.frag
@@ -15,15 +15,16 @@ in highp vec4 varying_COLOR1;
 in highp vec3 varying_COLOR2;
 in highp vec4 varying_COLOR3;
 in highp vec2 varying_TEXCOORD0;
-layout(location = 0) out highp vec4 out_var_SV_Target;
+layout(location = 0) out highp vec4 out_var_SV_Target0;
+layout(location = 1) out highp vec4 out_var_SV_Target1;
 
 void main()
 {
-    highp vec3 _50 = (varying_COLOR0 * vec3(2.0)) - vec3(1.0);
-    highp float _76 = log2(varying_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
-    highp vec4 _77 = vec4(((varying_COLOR1.xyz * (0.5 + (dot(varying_COLOR2, _50) * (-0.5)))) + (vec3(1.0, 1.0, 0.89999997615814208984375) * pow(max(0.0, -dot(-normalize(varying_COLOR3.xyz / vec3(varying_COLOR3.w)), _50)), 60.0))) * varying_COLOR1.w, 1.0);
-    _77.w = _76;
-    out_var_SV_Target = _77;
-    gl_FragDepth = _76;
+    highp vec3 _51 = (varying_COLOR0 * vec3(2.0)) - vec3(1.0);
+    highp float _77 = log2(varying_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    highp float _80 = 1.0 - varying_COLOR0.z;
+    out_var_SV_Target0 = vec4(((varying_COLOR1.xyz * (0.5 + (dot(varying_COLOR2, _51) * (-0.5)))) + (vec3(1.0, 1.0, 0.89999997615814208984375) * pow(max(0.0, -dot(-normalize(varying_COLOR3.xyz / vec3(varying_COLOR3.w)), _51)), 60.0))) * varying_COLOR1.w, 1.0);
+    out_var_SV_Target1 = vec4(varying_COLOR0.x / _80, varying_COLOR0.y / _80, 0.0, _77);
+    gl_FragDepth = _77;
 }
 

--- a/src/gl/opengl/shaders/mobile/depthOnlyFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/depthOnlyFragmentShader.frag
@@ -14,14 +14,12 @@ in highp vec2 varying_TEXCOORD0;
 in highp vec3 varying_NORMAL;
 in highp vec4 varying_COLOR0;
 in highp vec2 varying_TEXCOORD1;
-layout(location = 0) out highp vec4 out_var_SV_Target;
+in highp vec2 varying_TEXCOORD2;
+layout(location = 0) out highp vec4 out_var_SV_Target0;
 
 void main()
 {
-    highp float _39 = log2(varying_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
-    highp vec4 _40 = vec4(0.0);
-    _40.w = _39;
-    out_var_SV_Target = _40;
-    gl_FragDepth = _39;
+    out_var_SV_Target0 = vec4(0.0);
+    gl_FragDepth = log2(varying_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
 }
 

--- a/src/gl/opengl/shaders/mobile/fenceFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/fenceFragmentShader.frag
@@ -15,12 +15,15 @@ uniform highp sampler2D SPIRV_Cross_CombinedcolourTexturecolourSampler;
 in highp vec4 varying_COLOR0;
 in highp vec2 varying_TEXCOORD0;
 in highp vec2 varying_TEXCOORD1;
-layout(location = 0) out highp vec4 out_var_SV_Target;
+layout(location = 0) out highp vec4 out_var_SV_Target0;
+layout(location = 1) out highp vec4 out_var_SV_Target1;
 
 void main()
 {
-    highp vec4 _40 = texture(SPIRV_Cross_CombinedcolourTexturecolourSampler, varying_TEXCOORD0);
-    out_var_SV_Target = vec4(_40.xyz * varying_COLOR0.xyz, _40.w * varying_COLOR0.w);
-    gl_FragDepth = log2(varying_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    highp vec4 _42 = texture(SPIRV_Cross_CombinedcolourTexturecolourSampler, varying_TEXCOORD0);
+    highp float _60 = log2(varying_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    out_var_SV_Target0 = vec4(_42.xyz * varying_COLOR0.xyz, _42.w * varying_COLOR0.w);
+    out_var_SV_Target1 = vec4(0.0, 0.0, 0.0, _60);
+    gl_FragDepth = _60;
 }
 

--- a/src/gl/opengl/shaders/mobile/flatColourFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/flatColourFragmentShader.frag
@@ -2,26 +2,15 @@
 precision mediump float;
 precision highp int;
 
-layout(std140) uniform type_u_cameraPlaneParams
-{
-    highp float s_CameraNearPlane;
-    highp float s_CameraFarPlane;
-    highp float u_clipZNear;
-    highp float u_clipZFar;
-} u_cameraPlaneParams;
-
 in highp vec2 varying_TEXCOORD0;
 in highp vec3 varying_NORMAL;
 in highp vec4 varying_COLOR0;
 in highp vec2 varying_TEXCOORD1;
-layout(location = 0) out highp vec4 out_var_SV_Target;
+in highp vec2 varying_TEXCOORD2;
+layout(location = 0) out highp vec4 out_var_SV_Target0;
 
 void main()
 {
-    highp float _38 = log2(varying_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
-    highp vec4 _39 = varying_COLOR0;
-    _39.w = _38;
-    out_var_SV_Target = _39;
-    gl_FragDepth = _38;
+    out_var_SV_Target0 = varying_COLOR0;
 }
 

--- a/src/gl/opengl/shaders/mobile/imageRendererFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/imageRendererFragmentShader.frag
@@ -15,11 +15,14 @@ uniform highp sampler2D SPIRV_Cross_CombinedalbedoTexturealbedoSampler;
 in highp vec2 varying_TEXCOORD0;
 in highp vec4 varying_COLOR0;
 in highp vec2 varying_TEXCOORD1;
-layout(location = 0) out highp vec4 out_var_SV_Target;
+layout(location = 0) out highp vec4 out_var_SV_Target0;
+layout(location = 1) out highp vec4 out_var_SV_Target1;
 
 void main()
 {
-    out_var_SV_Target = texture(SPIRV_Cross_CombinedalbedoTexturealbedoSampler, varying_TEXCOORD0) * varying_COLOR0;
-    gl_FragDepth = log2(varying_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    highp float _50 = log2(varying_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    out_var_SV_Target0 = texture(SPIRV_Cross_CombinedalbedoTexturealbedoSampler, varying_TEXCOORD0) * varying_COLOR0;
+    out_var_SV_Target1 = vec4(0.0, 0.0, 0.0, _50);
+    gl_FragDepth = _50;
 }
 

--- a/src/gl/opengl/shaders/mobile/lineFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/lineFragmentShader.frag
@@ -12,11 +12,14 @@ layout(std140) uniform type_u_cameraPlaneParams
 
 in highp vec4 varying_COLOR0;
 in highp vec2 varying_TEXCOORD0;
-layout(location = 0) out highp vec4 out_var_SV_Target;
+layout(location = 0) out highp vec4 out_var_SV_Target0;
+layout(location = 1) out highp vec4 out_var_SV_Target1;
 
 void main()
 {
-    out_var_SV_Target = varying_COLOR0;
-    gl_FragDepth = log2(varying_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    highp float _36 = log2(varying_TEXCOORD0.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    out_var_SV_Target0 = varying_COLOR0;
+    out_var_SV_Target1 = vec4(0.0, 0.0, 0.0, _36);
+    gl_FragDepth = _36;
 }
 

--- a/src/gl/opengl/shaders/mobile/polygonImageFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/polygonImageFragmentShader.frag
@@ -16,14 +16,15 @@ in highp vec2 varying_TEXCOORD0;
 in highp vec3 varying_NORMAL;
 in highp vec4 varying_COLOR0;
 in highp vec2 varying_TEXCOORD1;
-layout(location = 0) out highp vec4 out_var_SV_Target;
+in highp vec2 varying_TEXCOORD2;
+layout(location = 0) out highp vec4 out_var_SV_Target0;
+layout(location = 1) out highp vec4 out_var_SV_Target1;
 
 void main()
 {
-    highp float _51 = log2(varying_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
-    highp vec4 _52 = texture(SPIRV_Cross_CombinedalbedoTexturealbedoSampler, varying_TEXCOORD0) * varying_COLOR0;
-    _52.w = _51;
-    out_var_SV_Target = _52;
-    gl_FragDepth = _51;
+    highp float _55 = log2(varying_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    out_var_SV_Target0 = texture(SPIRV_Cross_CombinedalbedoTexturealbedoSampler, varying_TEXCOORD0) * varying_COLOR0;
+    out_var_SV_Target1 = vec4(0.0, 0.0, varying_TEXCOORD2.x, _55);
+    gl_FragDepth = _55;
 }
 

--- a/src/gl/opengl/shaders/mobile/polygonP3N3UV2FragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/polygonP3N3UV2FragmentShader.frag
@@ -16,16 +16,17 @@ in highp vec2 varying_TEXCOORD0;
 in highp vec3 varying_NORMAL;
 in highp vec4 varying_COLOR0;
 in highp vec2 varying_TEXCOORD1;
-layout(location = 0) out highp vec4 out_var_SV_Target;
-
-float _39;
+in highp vec2 varying_TEXCOORD2;
+layout(location = 0) out highp vec4 out_var_SV_Target0;
+layout(location = 1) out highp vec4 out_var_SV_Target1;
 
 void main()
 {
-    highp float _67 = log2(varying_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
-    highp vec4 _68 = vec4((texture(SPIRV_Cross_CombinedalbedoTexturealbedoSampler, varying_TEXCOORD0) * varying_COLOR0).xyz * ((dot(varying_NORMAL, normalize(vec3(0.85000002384185791015625, 0.1500000059604644775390625, 0.5))) * 0.5) + 0.5), _39);
-    _68.w = _67;
-    out_var_SV_Target = _68;
-    gl_FragDepth = _67;
+    highp vec4 _51 = texture(SPIRV_Cross_CombinedalbedoTexturealbedoSampler, varying_TEXCOORD0) * varying_COLOR0;
+    highp float _70 = log2(varying_TEXCOORD1.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    highp float _74 = 1.0 - varying_NORMAL.z;
+    out_var_SV_Target0 = vec4(_51.xyz * ((dot(varying_NORMAL, normalize(vec3(0.85000002384185791015625, 0.1500000059604644775390625, 0.5))) * 0.5) + 0.5), _51.w);
+    out_var_SV_Target1 = vec4(varying_NORMAL.x / _74, varying_NORMAL.y / _74, varying_TEXCOORD2.x, _70);
+    gl_FragDepth = _70;
 }
 

--- a/src/gl/opengl/shaders/mobile/polygonP3N3UV2VertexShader.vert
+++ b/src/gl/opengl/shaders/mobile/polygonP3N3UV2VertexShader.vert
@@ -5,6 +5,7 @@ layout(std140) uniform type_u_EveryObject
     layout(row_major) mat4 u_worldViewProjectionMatrix;
     layout(row_major) mat4 u_worldMatrix;
     vec4 u_colour;
+    vec4 u_objectInfo;
 } u_EveryObject;
 
 layout(location = 0) in vec3 in_var_POSITION;
@@ -14,18 +15,22 @@ out vec2 varying_TEXCOORD0;
 out vec3 varying_NORMAL;
 out vec4 varying_COLOR0;
 out vec2 varying_TEXCOORD1;
+out vec2 varying_TEXCOORD2;
 
-vec2 _34;
+vec2 _37;
 
 void main()
 {
-    vec4 _54 = vec4(in_var_POSITION, 1.0) * u_EveryObject.u_worldViewProjectionMatrix;
-    vec2 _59 = _34;
-    _59.x = 1.0 + _54.w;
-    gl_Position = _54;
+    vec4 _57 = vec4(in_var_POSITION, 1.0) * u_EveryObject.u_worldViewProjectionMatrix;
+    vec2 _62 = _37;
+    _62.x = 1.0 + _57.w;
+    vec2 _65 = _37;
+    _65.x = u_EveryObject.u_objectInfo.x;
+    gl_Position = _57;
     varying_TEXCOORD0 = in_var_TEXCOORD0;
     varying_NORMAL = normalize((vec4(in_var_NORMAL, 0.0) * u_EveryObject.u_worldMatrix).xyz);
     varying_COLOR0 = u_EveryObject.u_colour;
-    varying_TEXCOORD1 = _59;
+    varying_TEXCOORD1 = _62;
+    varying_TEXCOORD2 = _65;
 }
 

--- a/src/gl/opengl/shaders/mobile/tileFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/tileFragmentShader.frag
@@ -15,14 +15,13 @@ uniform highp sampler2D SPIRV_Cross_CombinedcolourTexturecolourSampler;
 in highp vec4 varying_COLOR0;
 in highp vec2 varying_TEXCOORD0;
 in highp vec2 varying_TEXCOORD1;
-layout(location = 0) out highp vec4 out_var_SV_Target;
-
-float _32;
+in highp vec2 varying_TEXCOORD2;
+layout(location = 0) out highp vec4 out_var_SV_Target0;
+layout(location = 1) out highp vec4 out_var_SV_Target1;
 
 void main()
 {
-    highp vec4 _60 = vec4(texture(SPIRV_Cross_CombinedcolourTexturecolourSampler, varying_TEXCOORD0).xyz * varying_COLOR0.xyz, _32);
-    _60.w = ((varying_TEXCOORD1.x / varying_TEXCOORD1.y) * (1.0 / (u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear))) + (u_cameraPlaneParams.u_clipZNear * (-0.5));
-    out_var_SV_Target = _60;
+    out_var_SV_Target0 = vec4(texture(SPIRV_Cross_CombinedcolourTexturecolourSampler, varying_TEXCOORD0).xyz * varying_COLOR0.xyz, varying_COLOR0.w);
+    out_var_SV_Target1 = vec4(0.0, 0.0, varying_TEXCOORD2.x, ((varying_TEXCOORD1.x / varying_TEXCOORD1.y) * (1.0 / (u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear))) + (u_cameraPlaneParams.u_clipZNear * (-0.5)));
 }
 

--- a/src/gl/opengl/shaders/mobile/tileVertexShader.vert
+++ b/src/gl/opengl/shaders/mobile/tileVertexShader.vert
@@ -14,6 +14,7 @@ layout(std140) uniform type_u_EveryObject
     layout(row_major) mat4 u_view;
     vec4 u_eyePositions[9];
     vec4 u_colour;
+    vec4 u_objectInfo;
     vec4 u_uvOffsetScale;
     vec4 u_demUVOffsetScale;
     vec4 u_tileNormal;
@@ -25,30 +26,36 @@ layout(location = 0) in vec3 in_var_POSITION;
 out vec4 varying_COLOR0;
 out vec2 varying_TEXCOORD0;
 out vec2 varying_TEXCOORD1;
+out vec2 varying_TEXCOORD2;
+
+vec2 _55;
 
 void main()
 {
-    vec2 _57 = in_var_POSITION.xy * 2.0;
-    float _58 = _57.x;
-    float _59 = floor(_58);
-    float _60 = _57.y;
-    float _61 = floor(_60);
-    float _63 = min(2.0, _59 + 1.0);
-    float _66 = _58 - _59;
-    float _68 = _61 * 3.0;
-    int _70 = int(_68 + _59);
-    float _77 = min(2.0, _61 + 1.0) * 3.0;
-    int _79 = int(_77 + _59);
-    vec4 _88 = u_EveryObject.u_eyePositions[_70] + ((u_EveryObject.u_eyePositions[int(_68 + _63)] - u_EveryObject.u_eyePositions[_70]) * _66);
-    vec4 _104 = textureLod(SPIRV_Cross_CombineddemTexturedemSampler, u_EveryObject.u_demUVOffsetScale.xy + (u_EveryObject.u_demUVOffsetScale.zw * in_var_POSITION.xy), 0.0);
-    vec4 _127 = ((_88 + (((u_EveryObject.u_eyePositions[_79] + ((u_EveryObject.u_eyePositions[int(_77 + _63)] - u_EveryObject.u_eyePositions[_79]) * _66)) - _88) * (_60 - _61))) + ((vec4(u_EveryObject.u_tileNormal.xyz * (((_104.x * 255.0) + (_104.y * 65280.0)) - 32768.0), 1.0) * u_EveryObject.u_view) - (vec4(0.0, 0.0, 0.0, 1.0) * u_EveryObject.u_view))) * u_EveryObject.u_projection;
-    float _138 = _127.w;
-    float _144 = ((log2(max(9.9999999747524270787835121154785e-07, 1.0 + _138)) * ((u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear) / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0))) + u_cameraPlaneParams.u_clipZNear) * _138;
-    vec4 _145 = _127;
-    _145.z = _144;
-    gl_Position = _145;
+    vec2 _60 = in_var_POSITION.xy * 2.0;
+    float _61 = _60.x;
+    float _62 = floor(_61);
+    float _63 = _60.y;
+    float _64 = floor(_63);
+    float _66 = min(2.0, _62 + 1.0);
+    float _69 = _61 - _62;
+    float _71 = _64 * 3.0;
+    int _73 = int(_71 + _62);
+    float _80 = min(2.0, _64 + 1.0) * 3.0;
+    int _82 = int(_80 + _62);
+    vec4 _91 = u_EveryObject.u_eyePositions[_73] + ((u_EveryObject.u_eyePositions[int(_71 + _66)] - u_EveryObject.u_eyePositions[_73]) * _69);
+    vec4 _107 = textureLod(SPIRV_Cross_CombineddemTexturedemSampler, u_EveryObject.u_demUVOffsetScale.xy + (u_EveryObject.u_demUVOffsetScale.zw * in_var_POSITION.xy), 0.0);
+    vec4 _130 = ((_91 + (((u_EveryObject.u_eyePositions[_82] + ((u_EveryObject.u_eyePositions[int(_80 + _66)] - u_EveryObject.u_eyePositions[_82]) * _69)) - _91) * (_63 - _64))) + ((vec4(u_EveryObject.u_tileNormal.xyz * (((_107.x * 255.0) + (_107.y * 65280.0)) - 32768.0), 1.0) * u_EveryObject.u_view) - (vec4(0.0, 0.0, 0.0, 1.0) * u_EveryObject.u_view))) * u_EveryObject.u_projection;
+    float _141 = _130.w;
+    float _147 = ((log2(max(9.9999999747524270787835121154785e-07, 1.0 + _141)) * ((u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear) / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0))) + u_cameraPlaneParams.u_clipZNear) * _141;
+    vec4 _148 = _130;
+    _148.z = _147;
+    vec2 _160 = _55;
+    _160.x = u_EveryObject.u_objectInfo.x;
+    gl_Position = _148;
     varying_COLOR0 = u_EveryObject.u_colour;
     varying_TEXCOORD0 = u_EveryObject.u_uvOffsetScale.xy + (u_EveryObject.u_uvOffsetScale.zw * in_var_POSITION.xy);
-    varying_TEXCOORD1 = vec2(_144, _138);
+    varying_TEXCOORD1 = vec2(_147, _141);
+    varying_TEXCOORD2 = _160;
 }
 

--- a/src/gl/opengl/shaders/mobile/udFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/udFragmentShader.frag
@@ -6,15 +6,15 @@ uniform highp sampler2D SPIRV_Cross_CombinedsceneColourTexturesceneColourSampler
 uniform highp sampler2D SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler;
 
 in highp vec2 varying_TEXCOORD0;
-layout(location = 0) out highp vec4 out_var_SV_Target;
+layout(location = 0) out highp vec4 out_var_SV_Target0;
+layout(location = 1) out highp vec4 out_var_SV_Target1;
 
 void main()
 {
-    highp vec4 _34 = texture(SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler, varying_TEXCOORD0);
-    highp float _35 = _34.x;
-    highp vec4 _40 = vec4(texture(SPIRV_Cross_CombinedsceneColourTexturesceneColourSampler, varying_TEXCOORD0).zyx, 1.0);
-    _40.w = _35;
-    out_var_SV_Target = _40;
-    gl_FragDepth = _35;
+    highp vec4 _36 = texture(SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler, varying_TEXCOORD0);
+    highp float _37 = _36.x;
+    out_var_SV_Target0 = vec4(texture(SPIRV_Cross_CombinedsceneColourTexturesceneColourSampler, varying_TEXCOORD0).zyx, 1.0);
+    out_var_SV_Target1 = vec4(0.0, 0.0, 0.0, _37);
+    gl_FragDepth = _37;
 }
 

--- a/src/gl/opengl/shaders/mobile/viewShedFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/viewShedFragmentShader.frag
@@ -24,7 +24,7 @@ uniform highp sampler2D SPIRV_Cross_CombinedshadowMapAtlasTextureshadowMapAtlasS
 
 in highp vec4 varying_TEXCOORD0;
 in highp vec2 varying_TEXCOORD1;
-layout(location = 0) out highp vec4 out_var_SV_Target;
+layout(location = 0) out highp vec4 out_var_SV_Target0;
 
 void main()
 {
@@ -61,6 +61,6 @@ void main()
     {
         _225 = vec4(0.0);
     }
-    out_var_SV_Target = vec4(_225.xyz * _225.w, 1.0);
+    out_var_SV_Target0 = vec4(_225.xyz * _225.w, 1.0);
 }
 

--- a/src/gl/opengl/shaders/mobile/visualizationFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/visualizationFragmentShader.frag
@@ -28,6 +28,7 @@ layout(std140) uniform type_u_fragParams
 } u_fragParams;
 
 uniform highp sampler2D SPIRV_Cross_CombinedsceneColourTexturesceneColourSampler;
+uniform highp sampler2D SPIRV_Cross_CombinedsceneNormalTexturesceneNormalSampler;
 uniform highp sampler2D SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler;
 
 in highp vec4 varying_TEXCOORD0;
@@ -36,55 +37,56 @@ in highp vec2 varying_TEXCOORD2;
 in highp vec2 varying_TEXCOORD3;
 in highp vec2 varying_TEXCOORD4;
 in highp vec2 varying_TEXCOORD5;
-layout(location = 0) out highp vec4 out_var_SV_Target;
+layout(location = 0) out highp vec4 out_var_SV_Target0;
+layout(location = 1) out highp vec4 out_var_SV_Target1;
 
 void main()
 {
-    highp vec4 _78 = texture(SPIRV_Cross_CombinedsceneColourTexturesceneColourSampler, varying_TEXCOORD1);
-    highp vec4 _82 = texture(SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler, varying_TEXCOORD1);
-    highp float _83 = _82.x;
-    highp float _89 = u_cameraPlaneParams.s_CameraFarPlane / (u_cameraPlaneParams.s_CameraFarPlane - u_cameraPlaneParams.s_CameraNearPlane);
-    highp float _92 = (u_cameraPlaneParams.s_CameraFarPlane * u_cameraPlaneParams.s_CameraNearPlane) / (u_cameraPlaneParams.s_CameraNearPlane - u_cameraPlaneParams.s_CameraFarPlane);
-    highp float _94 = log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0);
-    highp float _104 = u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear;
-    highp float _106 = ((_89 + (_92 / (pow(2.0, _83 * _94) - 1.0))) * _104) + u_cameraPlaneParams.u_clipZNear;
-    highp vec4 _112 = vec4(varying_TEXCOORD0.xy, _106, 1.0) * u_fragParams.u_inverseProjection;
-    highp vec3 _116 = _78.xyz;
-    highp vec3 _117 = (_112 / vec4(_112.w)).xyz;
-    highp float _124 = dot(u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz, u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz);
-    highp vec3 _126 = u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz * (dot(_117, u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz) / _124);
-    highp float _132 = mix(length(u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz - _126), 0.0, float(dot(_126, _126) > _124));
-    highp vec3 _207 = mix(mix(mix(mix(mix(_116, u_fragParams.u_colourizeHeightColourMin.xyz, vec3(u_fragParams.u_colourizeHeightColourMin.w)), mix(_116, u_fragParams.u_colourizeHeightColourMax.xyz, vec3(u_fragParams.u_colourizeHeightColourMax.w)), vec3(clamp((_132 - u_fragParams.u_colourizeHeightParams.x) / (u_fragParams.u_colourizeHeightParams.y - u_fragParams.u_colourizeHeightParams.x), 0.0, 1.0))).xyz, u_fragParams.u_colourizeDepthColour.xyz, vec3(clamp((length(_117) - u_fragParams.u_colourizeDepthParams.x) / (u_fragParams.u_colourizeDepthParams.y - u_fragParams.u_colourizeDepthParams.x), 0.0, 1.0) * u_fragParams.u_colourizeDepthColour.w)).xyz, clamp(abs((fract(vec3(_132 * (1.0 / u_fragParams.u_contourParams.z), 1.0, 1.0).xxx + vec3(1.0, 0.666666686534881591796875, 0.3333333432674407958984375)) * 6.0) - vec3(3.0)) - vec3(1.0), vec3(0.0), vec3(1.0)) * 1.0, vec3(u_fragParams.u_contourParams.w)), u_fragParams.u_contourColour.xyz, vec3((1.0 - step(u_fragParams.u_contourParams.y, mod(abs(_132), u_fragParams.u_contourParams.x))) * u_fragParams.u_contourColour.w));
-    highp float _357;
-    highp vec4 _358;
+    highp vec4 _81 = texture(SPIRV_Cross_CombinedsceneColourTexturesceneColourSampler, varying_TEXCOORD1);
+    highp vec4 _85 = texture(SPIRV_Cross_CombinedsceneNormalTexturesceneNormalSampler, varying_TEXCOORD1);
+    highp vec4 _89 = texture(SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler, varying_TEXCOORD1);
+    highp float _90 = _89.x;
+    highp float _96 = u_cameraPlaneParams.s_CameraFarPlane / (u_cameraPlaneParams.s_CameraFarPlane - u_cameraPlaneParams.s_CameraNearPlane);
+    highp float _99 = (u_cameraPlaneParams.s_CameraFarPlane * u_cameraPlaneParams.s_CameraNearPlane) / (u_cameraPlaneParams.s_CameraNearPlane - u_cameraPlaneParams.s_CameraFarPlane);
+    highp float _101 = log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0);
+    highp float _111 = u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear;
+    highp float _113 = ((_96 + (_99 / (pow(2.0, _90 * _101) - 1.0))) * _111) + u_cameraPlaneParams.u_clipZNear;
+    highp vec4 _119 = vec4(varying_TEXCOORD0.xy, _113, 1.0) * u_fragParams.u_inverseProjection;
+    highp vec3 _123 = _81.xyz;
+    highp vec3 _124 = (_119 / vec4(_119.w)).xyz;
+    highp float _131 = dot(u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz, u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz);
+    highp vec3 _133 = u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz * (dot(_124, u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz) / _131);
+    highp float _139 = mix(length(u_fragParams.u_eyeToEarthSurfaceEyeSpace.xyz - _133), 0.0, float(dot(_133, _133) > _131));
+    highp vec3 _214 = mix(mix(mix(mix(mix(_123, u_fragParams.u_colourizeHeightColourMin.xyz, vec3(u_fragParams.u_colourizeHeightColourMin.w)), mix(_123, u_fragParams.u_colourizeHeightColourMax.xyz, vec3(u_fragParams.u_colourizeHeightColourMax.w)), vec3(clamp((_139 - u_fragParams.u_colourizeHeightParams.x) / (u_fragParams.u_colourizeHeightParams.y - u_fragParams.u_colourizeHeightParams.x), 0.0, 1.0))).xyz, u_fragParams.u_colourizeDepthColour.xyz, vec3(clamp((length(_124) - u_fragParams.u_colourizeDepthParams.x) / (u_fragParams.u_colourizeDepthParams.y - u_fragParams.u_colourizeDepthParams.x), 0.0, 1.0) * u_fragParams.u_colourizeDepthColour.w)).xyz, clamp(abs((fract(vec3(_139 * (1.0 / u_fragParams.u_contourParams.z), 1.0, 1.0).xxx + vec3(1.0, 0.666666686534881591796875, 0.3333333432674407958984375)) * 6.0) - vec3(3.0)) - vec3(1.0), vec3(0.0), vec3(1.0)) * 1.0, vec3(u_fragParams.u_contourParams.w)), u_fragParams.u_contourColour.xyz, vec3((1.0 - step(u_fragParams.u_contourParams.y, mod(abs(_139), u_fragParams.u_contourParams.x))) * u_fragParams.u_contourColour.w));
+    highp float _364;
+    highp vec4 _365;
     if ((u_fragParams.u_outlineParams.x > 0.0) && (u_fragParams.u_outlineColour.w > 0.0))
     {
-        highp vec4 _229 = vec4((varying_TEXCOORD1.x * 2.0) - 1.0, (varying_TEXCOORD1.y * 2.0) - 1.0, _106, 1.0) * u_fragParams.u_inverseProjection;
-        highp vec4 _234 = texture(SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler, varying_TEXCOORD2);
-        highp float _235 = _234.x;
-        highp vec4 _237 = texture(SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler, varying_TEXCOORD3);
-        highp float _238 = _237.x;
-        highp vec4 _240 = texture(SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler, varying_TEXCOORD4);
-        highp float _241 = _240.x;
-        highp vec4 _243 = texture(SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler, varying_TEXCOORD5);
-        highp float _244 = _243.x;
-        highp vec4 _259 = vec4((varying_TEXCOORD2.x * 2.0) - 1.0, (varying_TEXCOORD2.y * 2.0) - 1.0, ((_89 + (_92 / (pow(2.0, _235 * _94) - 1.0))) * _104) + u_cameraPlaneParams.u_clipZNear, 1.0) * u_fragParams.u_inverseProjection;
-        highp vec4 _274 = vec4((varying_TEXCOORD3.x * 2.0) - 1.0, (varying_TEXCOORD3.y * 2.0) - 1.0, ((_89 + (_92 / (pow(2.0, _238 * _94) - 1.0))) * _104) + u_cameraPlaneParams.u_clipZNear, 1.0) * u_fragParams.u_inverseProjection;
-        highp vec4 _289 = vec4((varying_TEXCOORD4.x * 2.0) - 1.0, (varying_TEXCOORD4.y * 2.0) - 1.0, ((_89 + (_92 / (pow(2.0, _241 * _94) - 1.0))) * _104) + u_cameraPlaneParams.u_clipZNear, 1.0) * u_fragParams.u_inverseProjection;
-        highp vec4 _304 = vec4((varying_TEXCOORD5.x * 2.0) - 1.0, (varying_TEXCOORD5.y * 2.0) - 1.0, ((_89 + (_92 / (pow(2.0, _244 * _94) - 1.0))) * _104) + u_cameraPlaneParams.u_clipZNear, 1.0) * u_fragParams.u_inverseProjection;
-        highp vec3 _317 = (_229 / vec4(_229.w)).xyz;
-        highp vec4 _354 = mix(vec4(_207, _83), vec4(mix(_207.xyz, u_fragParams.u_outlineColour.xyz, vec3(u_fragParams.u_outlineColour.w)), min(min(min(_235, _238), _241), _244)), vec4(1.0 - (((step(length(_317 - (_259 / vec4(_259.w)).xyz), u_fragParams.u_outlineParams.y) * step(length(_317 - (_274 / vec4(_274.w)).xyz), u_fragParams.u_outlineParams.y)) * step(length(_317 - (_289 / vec4(_289.w)).xyz), u_fragParams.u_outlineParams.y)) * step(length(_317 - (_304 / vec4(_304.w)).xyz), u_fragParams.u_outlineParams.y))));
-        _357 = _354.w;
-        _358 = vec4(_354.x, _354.y, _354.z, _78.w);
+        highp vec4 _236 = vec4((varying_TEXCOORD1.x * 2.0) - 1.0, (varying_TEXCOORD1.y * 2.0) - 1.0, _113, 1.0) * u_fragParams.u_inverseProjection;
+        highp vec4 _241 = texture(SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler, varying_TEXCOORD2);
+        highp float _242 = _241.x;
+        highp vec4 _244 = texture(SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler, varying_TEXCOORD3);
+        highp float _245 = _244.x;
+        highp vec4 _247 = texture(SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler, varying_TEXCOORD4);
+        highp float _248 = _247.x;
+        highp vec4 _250 = texture(SPIRV_Cross_CombinedsceneDepthTexturesceneDepthSampler, varying_TEXCOORD5);
+        highp float _251 = _250.x;
+        highp vec4 _266 = vec4((varying_TEXCOORD2.x * 2.0) - 1.0, (varying_TEXCOORD2.y * 2.0) - 1.0, ((_96 + (_99 / (pow(2.0, _242 * _101) - 1.0))) * _111) + u_cameraPlaneParams.u_clipZNear, 1.0) * u_fragParams.u_inverseProjection;
+        highp vec4 _281 = vec4((varying_TEXCOORD3.x * 2.0) - 1.0, (varying_TEXCOORD3.y * 2.0) - 1.0, ((_96 + (_99 / (pow(2.0, _245 * _101) - 1.0))) * _111) + u_cameraPlaneParams.u_clipZNear, 1.0) * u_fragParams.u_inverseProjection;
+        highp vec4 _296 = vec4((varying_TEXCOORD4.x * 2.0) - 1.0, (varying_TEXCOORD4.y * 2.0) - 1.0, ((_96 + (_99 / (pow(2.0, _248 * _101) - 1.0))) * _111) + u_cameraPlaneParams.u_clipZNear, 1.0) * u_fragParams.u_inverseProjection;
+        highp vec4 _311 = vec4((varying_TEXCOORD5.x * 2.0) - 1.0, (varying_TEXCOORD5.y * 2.0) - 1.0, ((_96 + (_99 / (pow(2.0, _251 * _101) - 1.0))) * _111) + u_cameraPlaneParams.u_clipZNear, 1.0) * u_fragParams.u_inverseProjection;
+        highp vec3 _324 = (_236 / vec4(_236.w)).xyz;
+        highp vec4 _361 = mix(vec4(_214, _90), vec4(mix(_214.xyz, u_fragParams.u_outlineColour.xyz, vec3(u_fragParams.u_outlineColour.w)), min(min(min(_242, _245), _248), _251)), vec4(1.0 - (((step(length(_324 - (_266 / vec4(_266.w)).xyz), u_fragParams.u_outlineParams.y) * step(length(_324 - (_281 / vec4(_281.w)).xyz), u_fragParams.u_outlineParams.y)) * step(length(_324 - (_296 / vec4(_296.w)).xyz), u_fragParams.u_outlineParams.y)) * step(length(_324 - (_311 / vec4(_311.w)).xyz), u_fragParams.u_outlineParams.y))));
+        _364 = _361.w;
+        _365 = vec4(_361.x, _361.y, _361.z, _81.w);
     }
     else
     {
-        _357 = _83;
-        _358 = vec4(_207.x, _207.y, _207.z, _78.w);
+        _364 = _90;
+        _365 = vec4(_214.x, _214.y, _214.z, _81.w);
     }
-    highp vec4 _363 = vec4(_358.xyz, 1.0);
-    _363.w = _357;
-    out_var_SV_Target = _363;
-    gl_FragDepth = _357;
+    out_var_SV_Target0 = vec4(_365.xyz, 1.0);
+    out_var_SV_Target1 = _85;
+    gl_FragDepth = _364;
 }
 

--- a/src/gl/opengl/shaders/mobile/waterFragmentShader.frag
+++ b/src/gl/opengl/shaders/mobile/waterFragmentShader.frag
@@ -25,19 +25,19 @@ in highp vec2 varying_TEXCOORD1;
 in highp vec4 varying_COLOR0;
 in highp vec4 varying_COLOR1;
 in highp vec2 varying_TEXCOORD2;
-layout(location = 0) out highp vec4 out_var_SV_Target;
+layout(location = 0) out highp vec4 out_var_SV_Target0;
+layout(location = 1) out highp vec4 out_var_SV_Target1;
 
 void main()
 {
-    highp vec3 _90 = normalize(((texture(SPIRV_Cross_CombinednormalMapTexturenormalMapSampler, varying_TEXCOORD0).xyz * vec3(2.0)) - vec3(1.0)) + ((texture(SPIRV_Cross_CombinednormalMapTexturenormalMapSampler, varying_TEXCOORD1).xyz * vec3(2.0)) - vec3(1.0)));
-    highp vec3 _92 = normalize(varying_COLOR0.xyz);
-    highp vec3 _108 = normalize((vec4(_90, 0.0) * u_EveryFrameFrag.u_eyeNormalMatrix).xyz);
-    highp vec3 _110 = normalize(reflect(_92, _108));
-    highp vec3 _134 = normalize((vec4(_110, 0.0) * u_EveryFrameFrag.u_inverseViewMatrix).xyz);
-    highp float _162 = log2(varying_TEXCOORD2.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
-    highp vec4 _165 = (vec4(mix(texture(SPIRV_Cross_CombinedskyboxTextureskyboxSampler, vec2(atan(_134.x, _134.y) + 3.1415927410125732421875, acos(_134.z)) * vec2(0.15915493667125701904296875, 0.3183098733425140380859375)).xyz, varying_COLOR1.xyz * mix(vec3(1.0, 1.0, 0.60000002384185791015625), vec3(0.3499999940395355224609375), vec3(pow(max(0.0, _90.z), 5.0))), vec3(((dot(_108, _92) * (-0.5)) + 0.5) * 0.75)) + vec3(pow(abs(dot(_110, normalize((vec4(normalize(u_EveryFrameFrag.u_specularDir.xyz), 0.0) * u_EveryFrameFrag.u_eyeNormalMatrix).xyz))), 50.0) * 0.5), 1.0) * 0.300000011920928955078125) + vec4(0.20000000298023223876953125, 0.4000000059604644775390625, 0.699999988079071044921875, 1.0);
-    _165.w = _162;
-    out_var_SV_Target = _165;
-    gl_FragDepth = _162;
+    highp vec3 _91 = normalize(((texture(SPIRV_Cross_CombinednormalMapTexturenormalMapSampler, varying_TEXCOORD0).xyz * vec3(2.0)) - vec3(1.0)) + ((texture(SPIRV_Cross_CombinednormalMapTexturenormalMapSampler, varying_TEXCOORD1).xyz * vec3(2.0)) - vec3(1.0)));
+    highp vec3 _93 = normalize(varying_COLOR0.xyz);
+    highp vec3 _109 = normalize((vec4(_91, 0.0) * u_EveryFrameFrag.u_eyeNormalMatrix).xyz);
+    highp vec3 _111 = normalize(reflect(_93, _109));
+    highp vec3 _135 = normalize((vec4(_111, 0.0) * u_EveryFrameFrag.u_inverseViewMatrix).xyz);
+    highp float _163 = log2(varying_TEXCOORD2.x) * (1.0 / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0));
+    out_var_SV_Target0 = (vec4(mix(texture(SPIRV_Cross_CombinedskyboxTextureskyboxSampler, vec2(atan(_135.x, _135.y) + 3.1415927410125732421875, acos(_135.z)) * vec2(0.15915493667125701904296875, 0.3183098733425140380859375)).xyz, varying_COLOR1.xyz * mix(vec3(1.0, 1.0, 0.60000002384185791015625), vec3(0.3499999940395355224609375), vec3(pow(max(0.0, _91.z), 5.0))), vec3(((dot(_109, _93) * (-0.5)) + 0.5) * 0.75)) + vec3(pow(abs(dot(_111, normalize((vec4(normalize(u_EveryFrameFrag.u_specularDir.xyz), 0.0) * u_EveryFrameFrag.u_eyeNormalMatrix).xyz))), 50.0) * 0.5), 1.0) * 0.300000011920928955078125) + vec4(0.20000000298023223876953125, 0.4000000059604644775390625, 0.699999988079071044921875, 1.0);
+    out_var_SV_Target1 = vec4(0.0, 0.0, 0.0, _163);
+    gl_FragDepth = _163;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1719,7 +1719,7 @@ void vcRenderScene_HandlePicking(vcState *pProgramState, vcRenderData &renderDat
     pProgramState->worldMousePosCartesian = pickResult.position;
   }
 
-  if(!pickResult.success && !selectPolygons && !selectUD)
+  if (!pickResult.success && !selectPolygons && !selectUD)
     pProgramState->pickingSuccess = false;
 
   if (useTool)
@@ -2372,6 +2372,9 @@ void vcMain_RenderSceneWindow(vcState *pProgramState)
 
     pProgramState->activeProject.pFolder->AddToScene(pProgramState, &renderData);
 
+    // Render scene to texture
+    vcRender_RenderScene(pProgramState, pProgramState->pRenderContext, renderData, pProgramState->pDefaultFramebuffer);
+
     vcRenderScene_HandlePicking(pProgramState, renderData, useTool);
 
     // Camera update has to be here because it depends on previous ImGui state
@@ -2427,9 +2430,6 @@ void vcMain_RenderSceneWindow(vcState *pProgramState)
       vcGizmo_ResetState();
     }
   }
-
-  // Render scene to texture
-  vcRender_RenderScene(pProgramState, pProgramState->pRenderContext, renderData, pProgramState->pDefaultFramebuffer);
 
   // Clean up
   renderData.models.Deinit();

--- a/src/rendering/vcAtmosphereRenderer.cpp
+++ b/src/rendering/vcAtmosphereRenderer.cpp
@@ -45,6 +45,7 @@ struct vcAtmosphereRenderer
     vcShaderSampler *uniform_scattering;
     vcShaderSampler *uniform_irradiance;
     vcShaderSampler *uniform_sceneColour;
+    vcShaderSampler *uniform_sceneNormal;
     vcShaderSampler *uniform_sceneDepth;
     vcShaderConstantBuffer *uniform_vertParams;
     vcShaderConstantBuffer *uniform_fragParams;
@@ -253,6 +254,7 @@ udResult vcAtmosphereRenderer_ReloadShaders(vcAtmosphereRenderer *pAtmosphereRen
   UD_ERROR_IF(!vcShader_GetSamplerIndex(&pAtmosphereRenderer->renderShader.uniform_scattering, pAtmosphereRenderer->renderShader.pProgram, "scattering"), udR_InternalError);
   UD_ERROR_IF(!vcShader_GetSamplerIndex(&pAtmosphereRenderer->renderShader.uniform_irradiance, pAtmosphereRenderer->renderShader.pProgram, "irradiance"), udR_InternalError);
   UD_ERROR_IF(!vcShader_GetSamplerIndex(&pAtmosphereRenderer->renderShader.uniform_sceneColour, pAtmosphereRenderer->renderShader.pProgram, "sceneColour"), udR_InternalError);
+  UD_ERROR_IF(!vcShader_GetSamplerIndex(&pAtmosphereRenderer->renderShader.uniform_sceneNormal, pAtmosphereRenderer->renderShader.pProgram, "sceneNormal"), udR_InternalError);
   UD_ERROR_IF(!vcShader_GetSamplerIndex(&pAtmosphereRenderer->renderShader.uniform_sceneDepth, pAtmosphereRenderer->renderShader.pProgram, "sceneDepth"), udR_InternalError);
   UD_ERROR_IF(!vcShader_GetConstantBuffer(&pAtmosphereRenderer->renderShader.uniform_vertParams, pAtmosphereRenderer->renderShader.pProgram, "u_vertParams", sizeof(pAtmosphereRenderer->renderShader.vertParams)), udR_InternalError);
   UD_ERROR_IF(!vcShader_GetConstantBuffer(&pAtmosphereRenderer->renderShader.uniform_fragParams, pAtmosphereRenderer->renderShader.pProgram, "u_fragParams", sizeof(pAtmosphereRenderer->renderShader.fragParams)), udR_InternalError);
@@ -343,7 +345,7 @@ void vcAtmosphereRenderer_SetVisualParams(vcState *pProgramState, vcAtmosphereRe
   pAtmosphereRenderer->sunDirection = udNormalize(pAtmosphereRenderer->sunDirection);
 }
 
-bool vcAtmosphereRenderer_Render(vcAtmosphereRenderer *pAtmosphereRenderer, vcState *pProgramState, vcTexture *pSceneColour, vcTexture *pSceneDepth)
+bool vcAtmosphereRenderer_Render(vcAtmosphereRenderer *pAtmosphereRenderer, vcState *pProgramState, vcTexture *pSceneColour, vcTexture *pSceneNormal, vcTexture *pSceneDepth)
 {
   bool result = true;
 
@@ -402,7 +404,8 @@ bool vcAtmosphereRenderer_Render(vcAtmosphereRenderer *pAtmosphereRenderer, vcSt
   vcShader_BindTexture(pAtmosphereRenderer->renderShader.pProgram, pAtmosphereRenderer->pModel->pScattering_texture_, 1, pAtmosphereRenderer->renderShader.uniform_scattering);
   vcShader_BindTexture(pAtmosphereRenderer->renderShader.pProgram, pAtmosphereRenderer->pModel->pIrradiance_texture_, 2, pAtmosphereRenderer->renderShader.uniform_irradiance);
   vcShader_BindTexture(pAtmosphereRenderer->renderShader.pProgram, pSceneColour, 3, pAtmosphereRenderer->renderShader.uniform_sceneColour);
-  vcShader_BindTexture(pAtmosphereRenderer->renderShader.pProgram, pSceneDepth, 4, pAtmosphereRenderer->renderShader.uniform_sceneDepth);
+  vcShader_BindTexture(pAtmosphereRenderer->renderShader.pProgram, pSceneNormal, 4, pAtmosphereRenderer->renderShader.uniform_sceneNormal);
+  vcShader_BindTexture(pAtmosphereRenderer->renderShader.pProgram, pSceneDepth, 5, pAtmosphereRenderer->renderShader.uniform_sceneDepth);
 
   vcShader_BindConstantBuffer(pAtmosphereRenderer->renderShader.pProgram, pAtmosphereRenderer->renderShader.uniform_vertParams, &pAtmosphereRenderer->renderShader.vertParams, sizeof(pAtmosphereRenderer->renderShader.vertParams));
   vcShader_BindConstantBuffer(pAtmosphereRenderer->renderShader.pProgram, pAtmosphereRenderer->renderShader.uniform_fragParams, &pAtmosphereRenderer->renderShader.fragParams, sizeof(pAtmosphereRenderer->renderShader.fragParams));

--- a/src/rendering/vcAtmosphereRenderer.h
+++ b/src/rendering/vcAtmosphereRenderer.h
@@ -14,6 +14,6 @@ udResult vcAtmosphereRenderer_ReloadShaders(vcAtmosphereRenderer *pAtmosphereRen
 
 void vcAtmosphereRenderer_SetVisualParams(vcState *pProgramState, vcAtmosphereRenderer *pAtmosphereRenderer);
 
-bool vcAtmosphereRenderer_Render(vcAtmosphereRenderer *pAtmosphereRenderer, vcState *pProgramState, vcTexture *pSceneColour, vcTexture *pSceneDepth);
+bool vcAtmosphereRenderer_Render(vcAtmosphereRenderer *pAtmosphereRenderer, vcState *pProgramState, vcTexture *pSceneColour, vcTexture *pSceneNormal, vcTexture *pSceneDepth);
 
 #endif//vcAtmosphereRenderer_h__

--- a/src/rendering/vcPolygonModel.cpp
+++ b/src/rendering/vcPolygonModel.cpp
@@ -44,6 +44,7 @@ static struct vcPolygonModelShader
     udFloat4x4 u_worldViewProjectionMatrix;
     udFloat4x4 u_world;
     udFloat4 u_colour;
+    udFloat4 u_objectInfo; //id.x, (unused).yzw
   } everyObject;
 
 } gShaders[vcPMST_Count];
@@ -487,7 +488,7 @@ epilogue:
   return result;
 }
 
-udResult vcPolygonModel_Render(vcPolygonModel *pModel, const udDouble4x4 &modelMatrix, const udDouble4x4 &viewProjectionMatrix, const vcPolyModelPass &passType /*= vcPMP_Standard*/, vcTexture *pDiffuseOverride /*= nullptr*/, const udFloat4 *pColourOverride /*= nullptr*/)
+udResult vcPolygonModel_Render(vcPolygonModel *pModel, const float encodedObjectId, const udDouble4x4 &modelMatrix, const udDouble4x4 &viewProjectionMatrix, const vcPolyModelPass &passType /*= vcPMP_Standard*/, vcTexture *pDiffuseOverride /*= nullptr*/, const udFloat4 *pColourOverride /*= nullptr*/)
 {
   if (pModel == nullptr)
     return udR_InvalidParameter_;
@@ -529,6 +530,7 @@ udResult vcPolygonModel_Render(vcPolygonModel *pModel, const udDouble4x4 &modelM
     if (pColourOverride)
       colour = *pColourOverride;
 
+    pPolygonShader->everyObject.u_objectInfo.x = encodedObjectId;
     pPolygonShader->everyObject.u_colour = colour;
     pPolygonShader->everyObject.u_world = udFloat4x4::create(modelMatrix);
     pPolygonShader->everyObject.u_worldViewProjectionMatrix = udFloat4x4::create(viewProjectionMatrix * modelMatrix * pModel->modelOffset);

--- a/src/rendering/vcPolygonModel.h
+++ b/src/rendering/vcPolygonModel.h
@@ -56,7 +56,7 @@ udResult vcPolygonModel_CreateFromURL(vcPolygonModel **ppModel, const char *pURL
 
 udResult vcPolygonModel_Destroy(vcPolygonModel **ppModel);
 
-udResult vcPolygonModel_Render(vcPolygonModel *pModel, const udDouble4x4 &modelMatrix, const udDouble4x4 &viewProjectionMatrix, const vcPolyModelPass &passType = vcPMP_Standard, vcTexture *pDiffuseOverride = nullptr, const udFloat4 *pColourOverride = nullptr);
+udResult vcPolygonModel_Render(vcPolygonModel *pModel, const float encodedObjectId, const udDouble4x4 &modelMatrix, const udDouble4x4 &viewProjectionMatrix, const vcPolyModelPass &passType = vcPMP_Standard, vcTexture *pDiffuseOverride = nullptr, const udFloat4 *pColourOverride = nullptr);
 
 // TODO: (EVC-570) Parsing formats should be in their own module, not here
 udResult vcPolygonModel_CreateFromVSMFInMemory(vcPolygonModel **ppModel, char *pData, int dataLength, udWorkerPool *pWorkerPool);

--- a/src/rendering/vcSceneLayerRenderer.h
+++ b/src/rendering/vcSceneLayerRenderer.h
@@ -2,9 +2,9 @@
 #define vcSceneLayerRenderer_h__
 
 #include "vcSceneLayer.h"
+#include "vcPolygonModel.h"
 
 struct vcTexture;
-
 struct vcSceneLayerRenderer
 {
   vcSceneLayer *pSceneLayer;
@@ -13,6 +13,6 @@ struct vcSceneLayerRenderer
 udResult vcSceneLayerRenderer_Create(vcSceneLayerRenderer **ppSceneLayerRenderer, udWorkerPool *pWorkerThreadPool, const char *pSceneLayerURL);
 udResult vcSceneLayerRenderer_Destroy(vcSceneLayerRenderer **ppSceneLayerRenderer);
 
-bool vcSceneLayerRenderer_Render(vcSceneLayerRenderer *pSceneLayerRenderer, const udDouble4x4 &worldMatrix, const udDouble4x4 &viewProjectionMatrix, const udDouble3 &cameraPosition, const udUInt2 &screenResolution, const udFloat4 *pColourOverride = nullptr, bool shadowsPass = false);
+bool vcSceneLayerRenderer_Render(vcSceneLayerRenderer *pSceneLayerRenderer, const float encodedObjectId, const udDouble4x4 &worldMatrix, const udDouble4x4 &viewProjectionMatrix, const udDouble3 &cameraPosition, const udUInt2 &screenResolution, const udFloat4 *pColourOverride = nullptr, vcPolyModelPass passType = vcPMP_Standard);
 
 #endif//vcSceneLayerRenderer_h__

--- a/src/rendering/vcTileRenderer.h
+++ b/src/rendering/vcTileRenderer.h
@@ -17,7 +17,7 @@ udResult vcTileRenderer_Destroy(vcTileRenderer **ppTileRenderer);
 udResult vcTileRenderer_ReloadShaders(vcTileRenderer *pTileRenderer);
 
 void vcTileRenderer_Update(vcTileRenderer *pTileRenderer, const double deltaTime, udGeoZone *pGeozone, const udInt3 &slippyCoords, const udDouble3 &cameraWorldPos, const udDouble3 &cameraZeroAltitude, const udDouble4x4 &viewProjectionMatrix);
-void vcTileRenderer_Render(vcTileRenderer *pTileRenderer, const udDouble4x4 &view, const udDouble4x4 &proj, const bool cameraInsideGround, const int passType);
+void vcTileRenderer_Render(vcTileRenderer *pTileRenderer, const udDouble4x4 &view, const udDouble4x4 &proj, const bool cameraInsideGround, const float encodedObjectId);
 
 void vcTileRenderer_ClearTiles(vcTileRenderer *pTileRenderer);
 


### PR DESCRIPTION
Scene rendering now happens before camera update.
Cleaned up all shaders to output exactly what is expected in the target Framebuffer.
Got transparent tiles working acceptably.
Removed separate 'pick' render.
Fixed an issue where having an active view shed would break picking.