### PR TITLE
Screenshot Fixes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2138,6 +2138,9 @@ void vcMain_RenderSceneWindow(vcState *pProgramState)
 
     vcRender_ResizeScene(pProgramState, pProgramState->pRenderContext, pProgramState->settings.screenshot.resolution.x, pProgramState->settings.screenshot.resolution.y);
     vcFramebuffer_Bind(pProgramState->pDefaultFramebuffer);
+
+    // Immediately update camera
+    vcCamera_UpdateMatrices(pProgramState->geozone, &pProgramState->camera, pProgramState->settings.camera, udFloat2::create(pProgramState->sceneResolution));
   }
 
   if (vcHotkey::IsPressed(vcB_Fullscreen) || ImGui::IsNavInputTest(ImGuiNavInput_TweakFast, ImGuiInputReadMode_Released))

--- a/vcGL/src/vcTextureHelper.cpp
+++ b/vcGL/src/vcTextureHelper.cpp
@@ -263,10 +263,6 @@ udResult vcTexture_SaveImage(vcTexture *pTexture, vcFramebuffer *pFramebuffer, c
 
   vcTexture_BeginReadPixels(pTexture, 0, 0, currSize.x, currSize.y, pPixels, pFramebuffer);
 
-#if (GRAPHICS_API_OPENGL)
-  stbi_flip_vertically_on_write(1);
-#endif
-
   pWriteData = stbi_write_png_to_mem(pPixels, 0, currSize.x, currSize.y, 4, &outLen);
   UD_ERROR_NULL(pWriteData, udR_InternalError);
 


### PR DESCRIPTION
OpenGL screenshots are now no longer flipped.
Screenshots are now unaffected by scene window aspect.

Resolves [AB#1020](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1020)