### PR TITLE
Fix camera movement

### DIFF
--- a/src/vcCamera.cpp
+++ b/src/vcCamera.cpp
@@ -449,12 +449,16 @@ void vcCamera_HandleSceneInput(vcState *pProgramState, udDouble3 oscMove, udFloa
     pProgramState->settings.camera.moveSpeed = udMin(pProgramState->settings.camera.moveSpeed, vcSL_CameraMaxMoveSpeed);
   }
 
-  if ((!ImGui::GetIO().WantCaptureKeyboard || isFocused) && !pProgramState->modalOpen && !ImGui::IsAnyItemActive())
+  // Allow camera movement when left mouse button is holding down.
+  if (!pProgramState->modalOpen)
   {
     keyboardInput.y += vcHotkey::IsDown(vcB_Forward) - vcHotkey::IsDown(vcB_Backward);
     keyboardInput.x += vcHotkey::IsDown(vcB_Right) - vcHotkey::IsDown(vcB_Left);
     keyboardInput.z += vcHotkey::IsDown(vcB_Up) - vcHotkey::IsDown(vcB_Down);
+  }
 
+  if ((!ImGui::GetIO().WantCaptureKeyboard || isFocused) && !pProgramState->modalOpen && !ImGui::IsAnyItemActive())
+  {
     if (vcHotkey::IsPressed(vcB_LockAltitude, false))
       pProgramState->settings.camera.lockAltitude = !pProgramState->settings.camera.lockAltitude;
     if (vcHotkey::IsPressed(vcB_GizmoTranslate))


### PR DESCRIPTION
[AB#1629](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1629).

Allow keyboard inputs to be read to enable camera movement when holding down left mouse button.