### PR TITLE
Non-native file dialogs correctly use Load and Save text

### DIFF
--- a/builds/assets/lang/enAU.json
+++ b/builds/assets/lang/enAU.json
@@ -11,6 +11,8 @@
   "popupClose": "Close",
   "popupConfirmYes": "Yes",
   "popupConfirmNo": "No",
+  "popupSave": "Save",
+  "popupLoad": "Load",
   "loginButton": "Login",
   "loginAbout": "About",
   "loginServerURL": "ServerURL",

--- a/src/imgui_ex/vcFileDialog.cpp
+++ b/src/imgui_ex/vcFileDialog.cpp
@@ -131,7 +131,13 @@ void vcFileDialog_ShowModal(vcState *pProgramState)
 
       ImGui::SameLine();
 
-      if (ImGui::Button(vcString::Get("convertLoadButton"), ImVec2(100.f, 0)))
+      const char *pLabel = "";
+      if (pProgramState->fileDialog.dialogType == vcFDT_OpenFile || pProgramState->fileDialog.dialogType == vcFDT_SelectDirectory)
+        pLabel = vcString::Get("popupLoad");
+      else // if (pProgramState->fileDialog.dialogType == vcFDT_SaveFile)
+        pLabel = vcString::Get("popupSave");
+
+      if (ImGui::Button(pLabel, ImVec2(100.f, 0)))
         loadFile = true;
       ImGui::SameLine();
 


### PR DESCRIPTION
Fixes [AB#1457](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1457)