### PR TITLE
awu/GizmoToolDirection

### DIFF
--- a/src/imgui_ex/ImGuizmo.h
+++ b/src/imgui_ex/ImGuizmo.h
@@ -35,12 +35,12 @@ enum vcGizmoAllowedControls
 void vcGizmo_SetDrawList(); // call inside your own window and before vcGizmo_Manipulate() in order to draw gizmo to that window.
 
 void vcGizmo_BeginFrame(); // call vcGizmo_BeginFrame right after ImGui_XXXX_NewFrame();
-bool vcGizmo_IsHovered(); // return true if mouse cursor is over any gizmo control (axis, plan or screen component)
+bool vcGizmo_IsHovered(const udDouble3 direction[]); // return true if mouse cursor is over any gizmo control (axis, plan or screen component)
 bool vcGizmo_IsActive(); // return true if mouse vcGizmo_IsHovered or if the gizmo is in moving state
 
 void vcGizmo_SetRect(float x, float y, float width, float height);
 
-void vcGizmo_Manipulate(const vcCamera *pCamera, vcGizmoOperation operation, vcGizmoCoordinateSystem mode, const udDouble4x4 &matrix, udDouble4x4 *pDeltaMatrix, vcGizmoAllowedControls allowedControls, double snap = 0.0);
+void vcGizmo_Manipulate(const vcCamera *pCamera, const udDouble3 direction[], vcGizmoOperation operation, vcGizmoCoordinateSystem mode, const udDouble4x4 &matrix, udDouble4x4 *pDeltaMatrix, vcGizmoAllowedControls allowedControls, double snap = 0.0);
 void vcGizmo_ResetState();
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2454,7 +2454,9 @@ void vcMain_RenderSceneWindow(vcState *pProgramState)
         for (vcSceneItemRef &ref : pProgramState->sceneExplorer.selectedItems)
           allowedControls = (vcGizmoAllowedControls)(allowedControls & ((vcSceneItem*)ref.pItem->pUserData)->GetAllowedControls());
 
-        vcGizmo_Manipulate(&pProgramState->camera, pProgramState->gizmo.operation, pProgramState->gizmo.coordinateSystem, temp, &delta, allowedControls, io.KeyShift ? snapAmt : 0.0);
+        //read direction axes again.
+        vcGIS_GetOrthonormalBasis(pProgramState->geozone, pProgramState->camera.position, &pProgramState->gizmo.direction[2], &pProgramState->gizmo.direction[1], &pProgramState->gizmo.direction[0]);
+        vcGizmo_Manipulate(&pProgramState->camera, pProgramState->gizmo.direction, pProgramState->gizmo.operation, pProgramState->gizmo.coordinateSystem, temp, &delta, allowedControls, io.KeyShift ? snapAmt : 0.0);
 
         if (!(delta == udDouble4x4::identity()))
         {

--- a/src/vcCamera.cpp
+++ b/src/vcCamera.cpp
@@ -375,7 +375,8 @@ void vcCamera_HandleSceneInput(vcState *pProgramState, udDouble3 oscMove, udFloa
   bool forceClearMouseState = !isFocused;
 
   // Was the gizmo just clicked on?
-  gizmoCapturedMouse = gizmoCapturedMouse || (pProgramState->gizmo.operation != 0 && vcGizmo_IsHovered() && (isBtnClicked[0] || isBtnClicked[1] || isBtnClicked[2]));
+  vcGIS_GetOrthonormalBasis(pProgramState->geozone, pProgramState->camera.position, &pProgramState->gizmo.direction[2], &pProgramState->gizmo.direction[1], &pProgramState->gizmo.direction[0]);
+  gizmoCapturedMouse = gizmoCapturedMouse || (pProgramState->gizmo.operation != 0 && vcGizmo_IsHovered(pProgramState->gizmo.direction) && (isBtnClicked[0] || isBtnClicked[1] || isBtnClicked[2]));
   if (gizmoCapturedMouse)
   {
     // was the gizmo just released?

--- a/src/vcState.h
+++ b/src/vcState.h
@@ -169,6 +169,7 @@ struct vcState
     bool inUse;
     vcGizmoOperation operation;
     vcGizmoCoordinateSystem coordinateSystem;
+    udDouble3 direction[3]; // 0-x-east; 1-y-north; 2-z-up
   } gizmo;
 
   vcActiveTool activeTool;


### PR DESCRIPTION
Fixed [AB#1389](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1389).

sDirectionUnary removed. Using vcGIS_GetOrthonormalBasis to get gizmo tools direction.