### PR TITLE
Can optionally prevent camera from going below earth surface

### DIFF
--- a/builds/assets/lang/enAU.json
+++ b/builds/assets/lang/enAU.json
@@ -396,6 +396,7 @@
   "sceneCameraOutOfBounds": "Camera is outside recommended limits of this GeoZone",
   "sceneCameraOSCMove": "Move Camera",
   "sceneCameraOSCUpDown": "U/D",
+  "sceneCameraKeepAboveSurface": "Keep Camera Above Ground",
   "sceneExplorerTitle": "Scene Explorer",
   "sceneExplorerRemove": "Remove Selected",
   "sceneExplorerRemoveItem": "Remove Item",

--- a/src/vcCamera.h
+++ b/src/vcCamera.h
@@ -26,6 +26,8 @@ struct vcCamera
   udDouble2 headingPitch;
   udDouble3 cameraUp;
 
+  bool cameraIsUnderSurface; 
+
   udRay<double> worldMouseRay;
 
   struct
@@ -96,6 +98,8 @@ struct vcCameraSettings
   bool lockAltitude;
   vcCameraPivotMode cameraMouseBindings[3]; // bindings for camera settings
   vcCameraScrollWheelMode scrollWheelMode;
+
+  bool keepAboveSurface;
 };
 
 // Lens Sizes

--- a/src/vcRender.cpp
+++ b/src/vcRender.cpp
@@ -845,14 +845,6 @@ void vcRenderTerrain(vcState *pProgramState, vcRenderContext *pRenderContext)
 
     int currentZoom = 21;
 
-    // TODO: Fix this
-    // determine if camera is 'inside' the ground
-    //udDouble3 zoneRoot = udGeoZone_LatLongToCartesian(pProgramState->gis.zone, udDouble3::zero());
-    //udDouble3 surfaceNormal = udNormalize3(cameraZeroAltitude - zoneRoot);
-    //if (udAbs(surfaceNormal.z) <= UD_EPSILON) // can this be assumed?
-    //  surfaceNormal = udDouble3::create(0.0, 0.0, 1.0);
-    bool cameraInsideGround = false;//udDot3(cameraToZeroAltitude, surfaceNormal) < 0;
-
     // These values were trial and errored.
     const double BaseViewDistance = 10000.0;
     const double HeightViewDistanceScale = 35.0;
@@ -893,7 +885,7 @@ void vcRenderTerrain(vcState *pProgramState, vcRenderContext *pRenderContext)
     vcTileRenderer_Update(pRenderContext->pTileRenderer, pProgramState->deltaTime, &pProgramState->geozone, udInt3::create(slippyCorners[0], currentZoom), localCamPos, pRenderContext->cameraZeroAltitude, viewProjection);
 
     float terrainId = vcRender_EncodeModelId(vcObjectId_Terrain);
-    vcTileRenderer_Render(pRenderContext->pTileRenderer, pProgramState->camera.matrices.view, pProgramState->camera.matrices.projection, cameraInsideGround, terrainId);
+    vcTileRenderer_Render(pRenderContext->pTileRenderer, pProgramState->camera.matrices.view, pProgramState->camera.matrices.projection, pProgramState->camera.cameraIsUnderSurface, terrainId);
   }
 }
 

--- a/src/vcSettings.cpp
+++ b/src/vcSettings.cpp
@@ -181,6 +181,7 @@ bool vcSettings_Load(vcSettings *pSettings, bool forceReset /*= false*/, vcSetti
     pSettings->camera.cameraMouseBindings[1] = (vcCameraPivotMode)data.Get("camera.cameraMouseBindings[1]").AsInt(vcCPM_Pan);
     pSettings->camera.cameraMouseBindings[2] = (vcCameraPivotMode)data.Get("camera.cameraMouseBindings[2]").AsInt(vcCPM_Orbit);
     pSettings->camera.scrollWheelMode = (vcCameraScrollWheelMode)data.Get("camera.scrollwheelBinding").AsInt(vcCSWM_Dolly);
+    pSettings->camera.keepAboveSurface = data.Get("camera.keepAboveSurface").AsBool(false);
 
     pSettings->mouseSnap.enable = data.Get("mouseSnap.enable").AsBool(true);
     pSettings->mouseSnap.range = data.Get("mouseSnap.range").AsInt(8);
@@ -567,6 +568,7 @@ bool vcSettings_Save(vcSettings *pSettings)
   data.Set("camera.moveMode = %d", pSettings->camera.lockAltitude ? 1 : 0);
   data.Set("camera.cameraMouseBindings = [%d, %d, %d]", pSettings->camera.cameraMouseBindings[0], pSettings->camera.cameraMouseBindings[1], pSettings->camera.cameraMouseBindings[2]);
   data.Set("camera.scrollwheelBinding = %d", pSettings->camera.scrollWheelMode);
+  data.Set("camera.keepAboveSurface = %s", pSettings->camera.keepAboveSurface ? "true" : "false");
 
   // Visualization
   data.Set("visualization.mode = %d", pSettings->visualization.mode - 1);

--- a/src/vcSettingsUI.cpp
+++ b/src/vcSettingsUI.cpp
@@ -286,6 +286,8 @@ void vcSettingsUI_Show(vcState *pProgramState)
           ImGui::Combo(vcString::Get("settingsControlsMiddle"), (int*)&pProgramState->settings.camera.cameraMouseBindings[2], mouseModes, (int)udLengthOf(mouseModes));
           ImGui::Combo(vcString::Get("settingsControlsRight"), (int*)&pProgramState->settings.camera.cameraMouseBindings[1], mouseModes, (int)udLengthOf(mouseModes));
           ImGui::Combo(vcString::Get("settingsControlsScrollWheel"), (int*)&pProgramState->settings.camera.scrollWheelMode, scrollwheelModes, (int)udLengthOf(scrollwheelModes));
+
+          ImGui::Checkbox(vcString::Get("sceneCameraKeepAboveSurface"), &pProgramState->settings.camera.keepAboveSurface);
         }
 
         if (pProgramState->activeSetting == vcSR_Maps)


### PR DESCRIPTION
Camera can now optionally prevent itself from going beneath the earth surface.
When underneath surface, culling order of tiles is now flipped - so terrain will now be visible from below.