### PR TITLE
Fixed crash moving non-geolocated models

### DIFF
--- a/src/scene/vcModel.cpp
+++ b/src/scene/vcModel.cpp
@@ -325,7 +325,7 @@ void vcModel::ApplyDelta(vcState *pProgramState, const udDouble4x4 &delta)
   m_sceneMatrix = delta * m_sceneMatrix;
 
   // Save it to the node...
-  if (m_pCurrentZone != nullptr || m_pProject->baseZone.srid == 0)
+  if (m_pCurrentZone != nullptr)
   {
     udDouble3 position;
     udDouble3 scale;


### PR DESCRIPTION
- Fixed Moving of non-geolocated models causing a crash
- Fixes [AB#1655](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1655)