### PR TITLE
awu/CameraMovementWASD

### DIFF
--- a/src/vcCamera.cpp
+++ b/src/vcCamera.cpp
@@ -472,7 +472,8 @@ void vcCamera_HandleSceneInput(vcState *pProgramState, udDouble3 oscMove, udFloa
     {
       const char *activeIdName = p->ActiveIdWindow->Name;
       size_t len = udStrlen(activeIdName);
-      if (len > 0 && udStrstr(activeIdName, len, "###sceneDock") == nullptr) enableMove = false;
+      if (len > 0 && udStrstr(activeIdName, len, "###sceneDock") == nullptr)
+        enableMove = false;
     }
 
     if(enableMove)

--- a/src/vcCamera.cpp
+++ b/src/vcCamera.cpp
@@ -5,7 +5,9 @@
 #include "vcRender.h"
 
 #include "imgui.h"
+#include "imgui_internal.h"
 #include "imgui_ex/ImGuizmo.h"
+#include "udStringUtil.h"
 
 #define ONE_PIXEL_SQ 0.0001
 
@@ -464,9 +466,22 @@ void vcCamera_HandleSceneInput(vcState *pProgramState, udDouble3 oscMove, udFloa
   // Allow camera movement when left mouse button is holding down.
   if (!pProgramState->modalOpen)
   {
-    keyboardInput.y += vcHotkey::IsDown(vcB_Forward) - vcHotkey::IsDown(vcB_Backward);
-    keyboardInput.x += vcHotkey::IsDown(vcB_Right) - vcHotkey::IsDown(vcB_Left);
-    keyboardInput.z += vcHotkey::IsDown(vcB_Up) - vcHotkey::IsDown(vcB_Down);
+    bool enableMove = true;
+    ImGuiContext *p = ImGui::GetCurrentContext();
+    if (p && p->ActiveIdWindow)
+    {
+      const char *activeIdName = p->ActiveIdWindow->Name;
+      size_t len = udStrlen(activeIdName);
+      if (len > 0 && udStrstr(activeIdName, len, "###sceneDock") == nullptr) enableMove = false;
+    }
+
+    if(enableMove)
+    {
+      keyboardInput.y += vcHotkey::IsDown(vcB_Forward) - vcHotkey::IsDown(vcB_Backward);
+      keyboardInput.x += vcHotkey::IsDown(vcB_Right) - vcHotkey::IsDown(vcB_Left);
+      keyboardInput.z += vcHotkey::IsDown(vcB_Up) - vcHotkey::IsDown(vcB_Down);
+    }
+    
   }
 
   if ((!ImGui::GetIO().WantCaptureKeyboard || isFocused) && !pProgramState->modalOpen && !ImGui::IsAnyItemActive())


### PR DESCRIPTION
Fixed [AB#1525](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1525).

The "WASD" only works when the "SceneDock" is active now. Activating input cursor in other panels(such as Cameraawu/CameraMovementWASD Setting Panel or Tool Panel) can no logner trigger camera movement.