### PR TITLE
Updated Interpolated Transparency

### DIFF
--- a/vcGL/src/opengl/vcGLState.cpp
+++ b/vcGL/src/opengl/vcGLState.cpp
@@ -161,7 +161,7 @@ bool vcGLState_SetBlendMode(vcGLStateBlendMode blendMode, bool force /*= false*/
     case vcGLSBM_None:
       break;
     case vcGLSBM_Interpolative:
-      glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ZERO);
+      glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_SRC_ALPHA, GL_DST_ALPHA);
       break;
     case vcGLSBM_Additive:
       glBlendFuncSeparate(GL_ONE, GL_ONE, GL_ONE, GL_ZERO);


### PR DESCRIPTION
Fixes [AB#1676](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1676) , [AB#1677](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1677)

`glBlendFuncSeparate()` seems to operate slightly differently on different platforms. This combination of alpha blending arguments seems to work best for both OpenGL and WebGL. I've tested all entities that use this blending function on OpenGL and WebGL builds including:
 - Screen images
    - Standard
    - Panorama
    - Sphere
 - Screen shot
 - ImGui / labels
 - Euclideon watermark
 - Screen lines
 - Fences / Horizontal fences
 - Transparent polygons (filters)