### PR TITLE
Added time reference conversions

### DIFF
--- a/src/vcUnitConversion.cpp
+++ b/src/vcUnitConversion.cpp
@@ -65,7 +65,7 @@ double vcUnitConversion_ConvertTemperature(double sourceValue, vcTemperatureUnit
 
 vcTimeReferenceData vcUnitConversion_ConvertTimeReference(vcTimeReferenceData sourceValue, vcTimeReference sourceReference, vcTimeReference requiredReference)
 {
-  vcTimeReferenceData result = {false, 0.0};
+  vcTimeReferenceData result = {false, {0.0}};
 
   static double const s_weekSeconds = 60.0 * 60.0 * 24.0 * 7.0;
   static double const s_secondsBetweenEpochs_TAI_Unix = 378691200.0;

--- a/src/vcUnitConversion.cpp
+++ b/src/vcUnitConversion.cpp
@@ -1,4 +1,5 @@
 #include "vcUnitConversion.h"
+#include "udMath.h"
 
 double vcUnitConversion_ConvertDistance(double sourceValue, vcDistanceUnit sourceUnit, vcDistanceUnit requiredUnit)
 {
@@ -60,4 +61,130 @@ double vcUnitConversion_ConvertTemperature(double sourceValue, vcTemperatureUnit
     return (9.0 / 5.0) * celciusVal + 32;
 
   return celciusVal;
+}
+
+vcTimeReferenceData vcUnitConversion_ConvertTimeReference(vcTimeReferenceData sourceValue, vcTimeReference sourceReference, vcTimeReference requiredReference)
+{
+  if (sourceReference == requiredReference)
+    return sourceValue;
+
+  vcTimeReferenceData result = sourceValue;
+  result.success = true;
+
+  static double const s_weekSeconds = 60.0 * 60.0 * 24.0 * 7.0;
+  static double const s_secondsBetweenEpochs_TAI_Unix = 378691200.0;
+  static double const s_secondsBetweenEpochs_TAI_GPS = 694656000.0;
+
+  //TODO this will have to be updated every time a leap second is introduced.
+  //The next leap second date may be December 2020.
+  static const double s_leapSeconds[] = {
+    78796811.0,   // 1 - 6  - 1972
+    94694412.0,   // 1 - 12 - 1972
+    126230413.0,  // 1 - 12 - 1973
+    157766414.0,  // 1 - 12 - 1974
+    189302415.0,  // 1 - 12 - 1975
+    220924816.0,  // 1 - 12 - 1976
+    252460817.0,  // 1 - 12 - 1977
+    283996818.0,  // 1 - 12 - 1978
+    315532819.0,  // 1 - 12 - 1979
+    362793620.0,  // 1 - 6  - 1981
+    394329621.0,  // 1 - 6  - 1982
+    425865622.0,  // 1 - 6  - 1983
+    489024023.0,  // 1 - 6  - 1985
+    567993624.0,  // 1 - 12 - 1987
+    631152025.0,  // 1 - 12 - 1988
+    662688026.0,  // 1 - 12 - 1990
+    709948827.0,  // 1 - 6  - 1992
+    741484828.0,  // 1 - 6  - 1993
+    773020829.0,  // 1 - 6  - 1994
+    820454430.0,  // 1 - 12 - 1995
+    867715231.0,  // 1 - 6  - 1997
+    915148832.0,  // 1 - 12 - 1998
+    1136073633.0, // 1 - 12 - 2005
+    1230768034.0, // 1 - 12 - 2008
+    1341100835.0, // 1 - 6  - 2012
+    1435708836.0, // 1 - 6  - 2015
+    1483228837.0  // 1 - 12 - 2016
+  };
+
+  static const size_t s_leapSecondsCount = sizeof(s_leapSeconds) / sizeof(s_leapSeconds[0]);
+
+  //Convert sourceValue to TAI
+  if (sourceReference == vcTimeReference_Unix)
+  {
+    if (sourceValue.seconds < 0.0)
+    {
+      result.success = false;
+      return result;
+    }
+
+    double leapSeconds = 0.0;
+    for (size_t i = 0; i < s_leapSecondsCount; ++i)
+    {
+      if (result.seconds < s_leapSeconds[i])
+        break;
+      leapSeconds++;
+    }
+    result.seconds = s_secondsBetweenEpochs_TAI_Unix + result.seconds + leapSeconds;
+  }
+  else if (sourceReference == vcTimeReference_GPS)
+  {
+    result.seconds += s_secondsBetweenEpochs_TAI_GPS;
+  }
+  else if (sourceReference == vcTimeReference_GPSAdjusted)
+  {
+    result.seconds += s_secondsBetweenEpochs_TAI_GPS + 1.0e9;
+  }
+  else if (sourceReference == vcTimeReference_GPSWeek)
+  {
+    if (sourceValue.GPSWeek.seconds < 0.0)
+    {
+      result.success = false;
+      return result;
+    }
+
+    result.seconds = s_secondsBetweenEpochs_TAI_GPS + sourceValue.GPSWeek.seconds + s_weekSeconds * double(sourceValue.GPSWeek.weeks);
+  }
+
+  //Required Reference
+  if (requiredReference == vcTimeReference_Unix)
+  {
+    if (sourceValue.seconds < s_secondsBetweenEpochs_TAI_Unix)
+    {
+      result.success = false;
+      return result;
+    }
+
+    result.seconds -= s_secondsBetweenEpochs_TAI_Unix;
+    double leapSeconds = 0.0;
+    for (size_t i = 0; i < s_leapSecondsCount; ++i)
+    {
+      if (result.seconds < s_leapSeconds[i])
+        break;
+      leapSeconds++;
+    }
+    result.seconds = result.seconds - leapSeconds;
+  }
+  else if (requiredReference == vcTimeReference_GPS)
+  {
+    result.seconds -= s_secondsBetweenEpochs_TAI_GPS;
+  }
+  else if (requiredReference == vcTimeReference_GPSAdjusted)
+  {
+    result.seconds -= (s_secondsBetweenEpochs_TAI_GPS + 1.0e9);
+  }
+  else if (requiredReference == vcTimeReference_GPSWeek)
+  {
+    if (sourceValue.seconds < s_secondsBetweenEpochs_TAI_GPS)
+    {
+      result.success = false;
+      return result;
+    }
+
+    result.seconds -= s_secondsBetweenEpochs_TAI_GPS;
+    result.GPSWeek.weeks = (unsigned)udFloor(result.seconds / s_weekSeconds);
+    result.GPSWeek.seconds = result.seconds - (s_weekSeconds * result.GPSWeek.weeks);
+  }
+
+  return result;
 }

--- a/src/vcUnitConversion.cpp
+++ b/src/vcUnitConversion.cpp
@@ -65,7 +65,7 @@ double vcUnitConversion_ConvertTemperature(double sourceValue, vcTemperatureUnit
 
 vcTimeReferenceData vcUnitConversion_ConvertTimeReference(vcTimeReferenceData sourceValue, vcTimeReference sourceReference, vcTimeReference requiredReference)
 {
-  vcTimeReferenceData result = {false};
+  vcTimeReferenceData result = {false, 0.0};
 
   static double const s_weekSeconds = 60.0 * 60.0 * 24.0 * 7.0;
   static double const s_secondsBetweenEpochs_TAI_Unix = 378691200.0;

--- a/src/vcUnitConversion.h
+++ b/src/vcUnitConversion.h
@@ -78,8 +78,6 @@ enum vcTimeReference
   vcTimeReference_GPS,          //seconds since UTC 00:00:00, 6/1/1980
   vcTimeReference_GPSAdjusted,  //seconds since UTC 00:00:00, 6/1/1980 - 1'000'000'000
   vcTimeReference_GPSWeek,      //seconds of the week + week number since UTC 00:00:00, 6/1/1980 (sunday)
-
-  vcTimeReference_Count
 };
 
 struct vcTimeReferenceData

--- a/src/vcUnitConversion.h
+++ b/src/vcUnitConversion.h
@@ -1,6 +1,8 @@
 #ifndef vcUnitConversion_h__
 #define vcUnitConversion_h__
 
+#include <stdint.h>
+
 enum vcDistanceUnit
 {
   vcDistance_Metres,
@@ -88,8 +90,8 @@ struct vcTimeReferenceData
     double seconds;
     struct
     {
-      double seconds;
-      unsigned weeks;
+      double secondsOfTheWeek;
+      uint32_t weeks;
     } GPSWeek;
   };
 };

--- a/src/vcUnitConversion.h
+++ b/src/vcUnitConversion.h
@@ -69,6 +69,34 @@ enum vcTemperatureUnit
   vcTemperature_Count
 };
 
+enum vcTimeReference
+{
+  vcTimeReference_TAI,          //seconds since UTC 00:00:00, 1/1/1958
+  vcTimeReference_Unix,         //seconds since UTC 00:00:00, 1/1/1970, not including leap seconds
+  vcTimeReference_GPS,          //seconds since UTC 00:00:00, 6/1/1980
+  vcTimeReference_GPSAdjusted,  //seconds since UTC 00:00:00, 6/1/1980 - 1'000'000'000
+  vcTimeReference_GPSWeek,      //seconds of the week + week number since UTC 00:00:00, 6/1/1980 (sunday)
+
+  vcTimeReference_Count
+};
+
+struct vcTimeReferenceData
+{
+  bool success;
+  union
+  {
+    double seconds;
+    struct
+    {
+      double seconds;
+      unsigned weeks;
+    } GPSWeek;
+  };
+};
+
+// Trying to convert to or from a Unix time before the 1970 epoch will fail.
+// Trying to convert to or from GPSWeek time using a negative value of seconds will fail.
+vcTimeReferenceData vcUnitConversion_ConvertTimeReference(vcTimeReferenceData sourceValue, vcTimeReference sourceReference, vcTimeReference requiredReference);
 double vcUnitConversion_ConvertDistance(double sourceValue, vcDistanceUnit sourceUnit, vcDistanceUnit requiredUnit);
 double vcUnitConversion_ConvertArea(double sourceValue, vcAreaUnit sourceUnit, vcAreaUnit requiredUnit);
 double vcUnitConversion_ConvertVolume(double sourceValue, vcVolumeUnit sourceUnit, vcVolumeUnit requiredUnit);

--- a/vcTesting/src/vcUnitConversionTests.cpp
+++ b/vcTesting/src/vcUnitConversionTests.cpp
@@ -127,12 +127,12 @@ void VerifyTimeReference(vcTimeReference sourceType, double in, vcTimeReference 
 
   inData.seconds = in;
   outData = vcUnitConversion_ConvertTimeReference(inData, sourceType, destType);
-  EXPECT_TRUE(outData.success);
+  EXPECT_TRUE(outData.success) << "fwd-" << vcTimeReference_GPSWeek << " to " << vcTimeReference_TAI;
   EXPECT_NEAR(outData.seconds, out, 0.0001) << "fwd-" << sourceType << " to " << destType;
 
   inData.seconds = out;
   outData = vcUnitConversion_ConvertTimeReference(inData, destType, sourceType);
-  EXPECT_TRUE(outData.success);
+  EXPECT_TRUE(outData.success) << "fwd-" << vcTimeReference_GPSWeek << " to " << vcTimeReference_TAI;
   EXPECT_NEAR(outData.seconds, in, 0.0001) << "fwd-" << sourceType << " to " << destType;
 }
 
@@ -143,12 +143,12 @@ void VerifyTimeReferenceWeek(double seconds, unsigned weeks, double out)
   inData.GPSWeek.seconds = seconds;
   inData.GPSWeek.weeks =weeks;
   outData = vcUnitConversion_ConvertTimeReference(inData, vcTimeReference_GPSWeek, vcTimeReference_TAI);
-  EXPECT_TRUE(outData.success);
+  EXPECT_TRUE(outData.success) << "fwd-" << vcTimeReference_GPSWeek << " to " << vcTimeReference_TAI;
   EXPECT_NEAR(outData.seconds, out, 0.0001) << "fwd-" << vcTimeReference_GPSWeek << " to " << vcTimeReference_TAI;
 
   inData.seconds = out;
   outData = vcUnitConversion_ConvertTimeReference(inData, vcTimeReference_TAI, vcTimeReference_GPSWeek);
-  EXPECT_TRUE(outData.success);
+  EXPECT_TRUE(outData.success) << "fwd-" << vcTimeReference_GPSWeek << " to " << vcTimeReference_TAI;
   EXPECT_EQ(outData.GPSWeek.weeks, weeks) << "fwd-" << vcTimeReference_TAI << " to " << vcTimeReference_GPSWeek;;
   EXPECT_EQ(outData.GPSWeek.seconds, seconds) << "fwd-" << vcTimeReference_TAI << " to " << vcTimeReference_GPSWeek;;
 }

--- a/vcTesting/src/vcUnitConversionTests.cpp
+++ b/vcTesting/src/vcUnitConversionTests.cpp
@@ -127,13 +127,13 @@ void VerifyTimeReference(vcTimeReference sourceType, double in, vcTimeReference 
 
   inData.seconds = in;
   outData = vcUnitConversion_ConvertTimeReference(inData, sourceType, destType);
-  EXPECT_TRUE(outData.success) << "fwd-" << vcTimeReference_GPSWeek << " to " << vcTimeReference_TAI;
+  EXPECT_TRUE(outData.success) << "fwd-" << sourceType << " to " << destType;
   EXPECT_NEAR(outData.seconds, out, 0.0001) << "fwd-" << sourceType << " to " << destType;
 
   inData.seconds = out;
   outData = vcUnitConversion_ConvertTimeReference(inData, destType, sourceType);
-  EXPECT_TRUE(outData.success) << "fwd-" << vcTimeReference_GPSWeek << " to " << vcTimeReference_TAI;
-  EXPECT_NEAR(outData.seconds, in, 0.0001) << "fwd-" << sourceType << " to " << destType;
+  EXPECT_TRUE(outData.success) << "back-" << sourceType << " to " << destType;
+  EXPECT_NEAR(outData.seconds, in, 0.0001) << "back-" << sourceType << " to " << destType;
 }
 
 void VerifyTimeReferenceWeek(double seconds, unsigned weeks, double out)
@@ -148,9 +148,9 @@ void VerifyTimeReferenceWeek(double seconds, unsigned weeks, double out)
 
   inData.seconds = out;
   outData = vcUnitConversion_ConvertTimeReference(inData, vcTimeReference_TAI, vcTimeReference_GPSWeek);
-  EXPECT_TRUE(outData.success) << "fwd-" << vcTimeReference_GPSWeek << " to " << vcTimeReference_TAI;
-  EXPECT_EQ(outData.GPSWeek.weeks, weeks) << "fwd-" << vcTimeReference_TAI << " to " << vcTimeReference_GPSWeek;;
-  EXPECT_EQ(outData.GPSWeek.seconds, seconds) << "fwd-" << vcTimeReference_TAI << " to " << vcTimeReference_GPSWeek;;
+  EXPECT_TRUE(outData.success) << "back-" << vcTimeReference_GPSWeek << " to " << vcTimeReference_TAI;
+  EXPECT_EQ(outData.GPSWeek.weeks, weeks) << "back-" << vcTimeReference_GPSWeek << " to " << vcTimeReference_TAI;;
+  EXPECT_EQ(outData.GPSWeek.seconds, seconds) << "back-" << vcTimeReference_GPSWeek << " to " << vcTimeReference_TAI;;
 }
 
 TEST(UnitConversion, TimeReference)

--- a/vcTesting/src/vcUnitConversionTests.cpp
+++ b/vcTesting/src/vcUnitConversionTests.cpp
@@ -140,7 +140,7 @@ void VerifyTimeReferenceWeek(double seconds, unsigned weeks, double out)
 {
   vcTimeReferenceData inData, outData;
 
-  inData.GPSWeek.seconds = seconds;
+  inData.GPSWeek.secondsOfTheWeek = seconds;
   inData.GPSWeek.weeks =weeks;
   outData = vcUnitConversion_ConvertTimeReference(inData, vcTimeReference_GPSWeek, vcTimeReference_TAI);
   EXPECT_TRUE(outData.success) << "fwd-" << vcTimeReference_GPSWeek << " to " << vcTimeReference_TAI;
@@ -150,7 +150,7 @@ void VerifyTimeReferenceWeek(double seconds, unsigned weeks, double out)
   outData = vcUnitConversion_ConvertTimeReference(inData, vcTimeReference_TAI, vcTimeReference_GPSWeek);
   EXPECT_TRUE(outData.success) << "back-" << vcTimeReference_GPSWeek << " to " << vcTimeReference_TAI;
   EXPECT_EQ(outData.GPSWeek.weeks, weeks) << "back-" << vcTimeReference_GPSWeek << " to " << vcTimeReference_TAI;;
-  EXPECT_EQ(outData.GPSWeek.seconds, seconds) << "back-" << vcTimeReference_GPSWeek << " to " << vcTimeReference_TAI;;
+  EXPECT_EQ(outData.GPSWeek.secondsOfTheWeek, seconds) << "back-" << vcTimeReference_GPSWeek << " to " << vcTimeReference_TAI;;
 }
 
 TEST(UnitConversion, TimeReference)
@@ -186,7 +186,7 @@ TEST(UnitConversion, TimeReference)
   VerifyTimeReferenceWeek(0.0, 42, s_seconds_TAI_GPS_epoch + 42.0 * s_weekSeconds);
   VerifyTimeReferenceWeek(1234.0, 42, s_seconds_TAI_GPS_epoch + 42.0 * s_weekSeconds + 1234.0);
 
-  in.GPSWeek.seconds = -42.0;
+  in.GPSWeek.secondsOfTheWeek = -42.0;
   in.GPSWeek.weeks = 0;
   out = vcUnitConversion_ConvertTimeReference(in, vcTimeReference_GPSWeek, vcTimeReference_TAI);
   EXPECT_FALSE(out.success);


### PR DESCRIPTION
For converting to and from the following time references:
 - Unix time : seconds since the 1/1/1970 epoch
 - TAI (International Atomic Time): seconds since the 1/1/1958 epoch, ignoring leap seconds
 - GPS: seconds since the 6/1/1980 epoch, ignoring leap seconds
 - GPS Adjusted: seconds since the 6/1/1980 epoch, ignoring leap seconds, minus 1 billion
 - GPS week:  weeks and seconds of the week since the 6/1/1980 epoch, ignoring leap seconds