### PR TITLE
IOT items now correctly orient in ECEF

### DIFF
--- a/builds/assets/lang/enAU.json
+++ b/builds/assets/lang/enAU.json
@@ -537,6 +537,7 @@
   "liveFeedMaxDisplayTime": "Oldest display time",
   "liveFeedDisplayDistance": "Maximum distance to display",
   "liveFeedTween": "Enable Tweening / Position Smoothing",
+  "liveFeedSnapMap": "Snap to map",
   "liveFeedDiagInfo": "Total Cached Items: {0}\nCurrently displaying {1} items.\nNext Update in {2} seconds.",
   "liveFeedGroupID": "Group ID",
   "liveFeedLODModifier": "LOD Distance Modifier",

--- a/src/scene/vcLiveFeed.h
+++ b/src/scene/vcLiveFeed.h
@@ -53,6 +53,7 @@ public:
   double m_decayFrequency; // Remove items if they haven't updated more recently than this
   double m_maxDisplayDistance; // Distance to stop displaying entirely
   double m_labelLODModifier; // Distance modifier for label LOD
+  bool m_snapToMap; // snaps items to the map
 
   udUUID m_groupID; // Required for updating group mode
 


### PR DESCRIPTION
IOT items can now optionally snap exactly to terrain (position and orientation).

Resolves [AB#1518](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1518)