### PR TITLE
Fixed issue with screenshots in Metal having Red and Blue flipped

### DIFF
--- a/vcGL/src/metal/vcGLState.mm
+++ b/vcGL/src/metal/vcGLState.mm
@@ -381,10 +381,10 @@ void vcGLState_Scissor(int left, int top, int right, int bottom, bool force /*= 
   udUnused(force);
 
   MTLScissorRect rect = {
-      .x = (NSUInteger)left,
-      .y = (NSUInteger)top,
-      .width = (NSUInteger)right - left,
-      .height = (NSUInteger)bottom - top
+      .x = (NSUInteger)udMin(left, (int)g_pCurrFramebuffer->attachments[0]->width),
+      .y = (NSUInteger)udMin(top, (int)g_pCurrFramebuffer->attachments[0]->height),
+      .width = (NSUInteger)udMin(right - left, (int)g_pCurrFramebuffer->attachments[0]->width),
+      .height = (NSUInteger)udMin(bottom - top, (int)g_pCurrFramebuffer->attachments[0]->height)
   };
 
   if (g_pCurrFramebuffer == g_pDefaultFramebuffer && (g_pCurrFramebuffer->actions & vcRFA_Resize) != vcRFA_Resize)

--- a/vcGL/src/metal/vcTexture.mm
+++ b/vcGL/src/metal/vcTexture.mm
@@ -372,5 +372,17 @@ bool vcTexture_EndReadPixels(vcTexture *pTexture, uint32_t x, uint32_t y, uint32
     }
   }
 
+  // Flip R&B when required
+  if (pTexture->format == vcTextureFormat_RGBA8 && (pTexture->flags & vcTCF_RenderTarget))
+  {
+    pPixelData = (uint8_t*)pPixels;
+    for (int i = 0; i < (int)(height * width); ++i, pPixelData += pixelBytes)
+    {
+      uint8_t temp = pPixelData[0];
+      pPixelData[0] = pPixelData[2];
+      pPixelData[2] = temp;
+    }
+  }
+
   return result == udR_Success;
 }


### PR DESCRIPTION
- Fixed crash in debug when setting scissor on the default framebuffer with an out of bounds rectangle

Fixes [AB#1656](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1656)