### PR TITLE
Changed ScanDirection to ScanAngle

### DIFF
--- a/src/vcRender.cpp
+++ b/src/vcRender.cpp
@@ -1605,7 +1605,7 @@ udResult vcRender_RenderUD(vcState *pProgramState, vcRenderContext *pRenderConte
           pVoxelShaderData[numVisibleModels].data.GPSTime.maxTime = pProgramState->settings.visualization.GPSTime.maxTime;
         }
       }
-      else if ((pVisSettings->mode == vcVM_Default || pVisSettings->mode == vcVM_ScanAngle) && vdkAttributeSet_GetOffsetOfStandardAttribute(&renderData.models[i]->m_pointCloudHeader.attributes, vdkSA_ScanDirection, &pVoxelShaderData[numVisibleModels].attributeOffset) == vE_Success)
+      else if ((pVisSettings->mode == vcVM_Default || pVisSettings->mode == vcVM_ScanAngle) && vdkAttributeSet_GetOffsetOfStandardAttribute(&renderData.models[i]->m_pointCloudHeader.attributes, vdkSA_ScanAngle, &pVoxelShaderData[numVisibleModels].attributeOffset) == vE_Success)
       {
         double minAngleNorm = (pProgramState->settings.visualization.scanAngle.minAngle + 180.0) / 360.0;
         double maxAngleNorm = (pProgramState->settings.visualization.scanAngle.maxAngle + 180.0) / 360.0;


### PR DESCRIPTION
There are 2 different attribute names: vdkSA_ScanAngle and vdkSA_ScanAngleRank. From what I understand these are the same thing. The ASPRS LIDAR Data Exchange Format Standard uses 'scan angle' and the The LAS 1.4 spec seems to use 'scan angle' and 'scan angle rank' interchangeably.

EDIT: Scan angle and scan angle rank I have just learned are two different things.