### PR TITLE
Above-surface bug fix

### DIFF
--- a/src/vcCamera.cpp
+++ b/src/vcCamera.cpp
@@ -629,7 +629,7 @@ void vcCamera_HandleSceneInput(vcState *pProgramState, udDouble3 oscMove, udFloa
   cameraSurfacePosition += pProgramState->camera.cameraUp * CameraGroundBufferDistanceMeters;
 
   // Calculate if camera is underneath earth surface
-  pProgramState->camera.cameraIsUnderSurface = pProgramState->geozone.srid == 0 ? false : udDot3(pProgramState->camera.cameraUp, udNormalize3(pProgramState->camera.position - cameraSurfacePosition)) < 0;
+  pProgramState->camera.cameraIsUnderSurface = (pProgramState->geozone.projection != udGZPT_Unknown) && (udDot3(pProgramState->camera.cameraUp, udNormalize3(pProgramState->camera.position - cameraSurfacePosition)) < 0);
   if (pProgramState->settings.maptiles.mapEnabled && pProgramState->settings.camera.keepAboveSurface && pProgramState->camera.cameraIsUnderSurface)
   {
     pProgramState->camera.cameraIsUnderSurface = false;

--- a/src/vcCamera.cpp
+++ b/src/vcCamera.cpp
@@ -629,7 +629,7 @@ void vcCamera_HandleSceneInput(vcState *pProgramState, udDouble3 oscMove, udFloa
   cameraSurfacePosition += pProgramState->camera.cameraUp * CameraGroundBufferDistanceMeters;
 
   // Calculate if camera is underneath earth surface
-  pProgramState->camera.cameraIsUnderSurface = udDot3(pProgramState->camera.cameraUp, udNormalize3(pProgramState->camera.position - cameraSurfacePosition)) < 0;
+  pProgramState->camera.cameraIsUnderSurface = pProgramState->geozone.srid == 0 ? false : udDot3(pProgramState->camera.cameraUp, udNormalize3(pProgramState->camera.position - cameraSurfacePosition)) < 0;
   if (pProgramState->settings.maptiles.mapEnabled && pProgramState->settings.camera.keepAboveSurface && pProgramState->camera.cameraIsUnderSurface)
   {
     pProgramState->camera.cameraIsUnderSurface = false;


### PR DESCRIPTION
- Fixed a bug where if keepAboveSurface == true, then non-geolocated scenes are bugged. bug is exposed on ResetAll on a model
- Fixes [AB#1688](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1688)