### PR TITLE
Filters oriented correctly

### DIFF
--- a/src/scene/vcQueryNode.cpp
+++ b/src/scene/vcQueryNode.cpp
@@ -48,8 +48,6 @@ void vcQueryNode::OnNodeUpdate(vcState *pProgramState)
       m_shape = vcQNFS_Cylinder;
   }
 
-  ChangeProjection(pProgramState->geozone);
-
   vdkProjectNode_GetMetadataDouble(m_pNode, "size.x", &m_extents.x, 1.0);
   vdkProjectNode_GetMetadataDouble(m_pNode, "size.y", &m_extents.y, 1.0);
   vdkProjectNode_GetMetadataDouble(m_pNode, "size.z", &m_extents.z, 1.0);
@@ -57,6 +55,8 @@ void vcQueryNode::OnNodeUpdate(vcState *pProgramState)
   vdkProjectNode_GetMetadataDouble(m_pNode, "transform.rotation.y", &m_ypr.x, 0.0);
   vdkProjectNode_GetMetadataDouble(m_pNode, "transform.rotation.p", &m_ypr.y, 0.0);
   vdkProjectNode_GetMetadataDouble(m_pNode, "transform.rotation.r", &m_ypr.z, 0.0);
+
+  ChangeProjection(pProgramState->geozone);
 
   switch (m_shape)
   {

--- a/src/scene/vcQueryNode.cpp
+++ b/src/scene/vcQueryNode.cpp
@@ -48,6 +48,8 @@ void vcQueryNode::OnNodeUpdate(vcState *pProgramState)
       m_shape = vcQNFS_Cylinder;
   }
 
+  ChangeProjection(pProgramState->geozone);
+
   vdkProjectNode_GetMetadataDouble(m_pNode, "size.x", &m_extents.x, 1.0);
   vdkProjectNode_GetMetadataDouble(m_pNode, "size.y", &m_extents.y, 1.0);
   vdkProjectNode_GetMetadataDouble(m_pNode, "size.z", &m_extents.z, 1.0);
@@ -55,8 +57,6 @@ void vcQueryNode::OnNodeUpdate(vcState *pProgramState)
   vdkProjectNode_GetMetadataDouble(m_pNode, "transform.rotation.y", &m_ypr.x, 0.0);
   vdkProjectNode_GetMetadataDouble(m_pNode, "transform.rotation.p", &m_ypr.y, 0.0);
   vdkProjectNode_GetMetadataDouble(m_pNode, "transform.rotation.r", &m_ypr.z, 0.0);
-
-  ChangeProjection(pProgramState->geozone);
 
   switch (m_shape)
   {
@@ -188,6 +188,9 @@ void vcQueryNode::ChangeProjection(const udGeoZone &newZone)
     m_center = pPoint[0];
 
   udFree(pPoint);
+
+  udDoubleQuat q = vcGIS_GetQuaternion(newZone, m_center);
+  m_ypr = q.eulerAngles();
 
   switch (m_shape)
   {

--- a/src/vcGIS.cpp
+++ b/src/vcGIS.cpp
@@ -96,6 +96,19 @@ void vcGIS_GetOrthonormalBasis(const udGeoZone &zone, udDouble3 localPosition, u
   //Shouldn't need to normalise north
 }
 
+udDoubleQuat vcGIS_GetQuaternion(const udGeoZone &zone, udDouble3 localPosition)
+{
+  udDouble3 up, north, east;
+  vcGIS_GetOrthonormalBasis(zone, localPosition, &up, &north, &east);
+
+  udDouble4x4 m = udDouble4x4::create(-north.x, -north.y, -north.z, 0,
+                                       east.x,   east.y,   east.z,  0,
+                                       up.x,     up.y,     up.z,    0,
+                                       0,        0,        0,       1);
+
+  return m.extractQuaternion();
+}
+
 udDouble3 vcGIS_GetWorldLocalUp(const udGeoZone &zone, udDouble3 localCoords)
 {
   if (zone.projection == udGZPT_Unknown || zone.projection >= udGZPT_TransverseMercator)

--- a/src/vcGIS.h
+++ b/src/vcGIS.h
@@ -18,6 +18,7 @@ bool vcGIS_SlippyToLocal(const udGeoZone &zone, udDouble3 *pLocalCoords, const u
 
 // Helpers
 void vcGIS_GetOrthonormalBasis(const udGeoZone &zone, udDouble3 localPosition, udDouble3 *pUp, udDouble3 *pNorth, udDouble3 *pEast);
+udDoubleQuat vcGIS_GetQuaternion(const udGeoZone &zone, udDouble3 localPosition); // Get rotational transform from cartesian space to the world position
 udDouble3 vcGIS_GetWorldLocalUp(const udGeoZone &zone, udDouble3 localCoords); // Returns which direction is "up" at a given coordinate
 udDouble3 vcGIS_GetWorldLocalNorth(const udGeoZone &zone, udDouble3 localCoords); // Returns which direction is "north"
 udDouble2 vcGIS_QuaternionToHeadingPitch(const udGeoZone &zone, udDouble3 localPosition, udDoubleQuat orientation); // Returns HPR from a Quaternion at a specific location

--- a/vcTesting/src/vcGISTests.cpp
+++ b/vcTesting/src/vcGISTests.cpp
@@ -96,4 +96,30 @@ TEST(vcGIS, LocalAxis)
     udDouble2 headingPitchKanasStLouis = vcGIS_GetHeadingPitchFromLatLong(rZone, kansasCityLatLong, stLouisLatLong);
     EXPECT_TRUE(udEqualApprox(headingPitchKanasStLouis, udDouble2::create(UD_DEG2RAD(96.51), 0.0)));
   }
+
+  {
+    udDouble3 localPosition = udGeoZone_LatLongToCartesian(lZone, { 0.0, 0.0, 6371000.0 });
+    udDoubleQuat q = vcGIS_GetQuaternion(lZone, localPosition);
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 0, -1), q.apply({ 1, 0, 0 })));
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 1, 0), q.apply({ 0, 1, 0 })));
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(1, 0, 0), q.apply({ 0, 0, 1 })));
+
+    localPosition = udGeoZone_LatLongToCartesian(lZone, { 0.0, 90.0, 6371000.0 });
+    q = vcGIS_GetQuaternion(lZone, localPosition);
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 0, -1), q.apply({ 1, 0, 0 })));
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(-1, 0, 0), q.apply({ 0, 1, 0 })));
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 1, 0), q.apply({ 0, 0, 1 })));
+
+    localPosition = udGeoZone_LatLongToCartesian(lZone, { 0.0, 180.0, 6371000.0 });
+    q = vcGIS_GetQuaternion(lZone, localPosition);
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 0, -1), q.apply({ 1, 0, 0 })));
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(0, -1, 0), q.apply({ 0, 1, 0 })));
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(-1, 0, 0), q.apply({ 0, 0, 1 })));
+
+    localPosition = udGeoZone_LatLongToCartesian(lZone, { 0.0, -90.0, 6371000.0 });
+    q = vcGIS_GetQuaternion(lZone, localPosition);
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 0, -1), q.apply({ 1, 0, 0 })));
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(1, 0, 0), q.apply({ 0, 1, 0 })));
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(0, -1, 0), q.apply({ 0, 0, 1 })));
+  }
 }


### PR DESCRIPTION
[AB#1515](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1515)
Ok so filters now orientate correctly, but there is an issue with queries not playing well with the octree. ~~This will be the next fix in this PR.~~

EDIT: This PR should be standalone. The fact that queries are broken in ECEF should be another PR.