### PR TITLE
Camera: Move To Point

### DIFF
--- a/src/scene/vcFolder.cpp
+++ b/src/scene/vcFolder.cpp
@@ -293,7 +293,18 @@ void vcFolder::HandleImGui(vcState *pProgramState, size_t *pItemID)
         if (pNode->itemtype != vdkPNT_Folder && pSceneItem->GetWorldSpacePivot() != udDouble3::zero() && ImGui::Selectable(vcString::Get("sceneExplorerMoveTo")))
         {
           // Trigger a camera movement path
-          pProgramState->cameraInput.inputState = vcCIS_MovingToPoint;
+          if (pNode->itemtype != vdkPNT_Viewpoint)
+          {
+            pProgramState->cameraInput.inputState = vcCIS_MovingToPoint;
+          }
+          else
+          {
+            pProgramState->cameraInput.inputState = vcCIS_MoveToViewpoint;
+            vdkProjectNode_GetMetadataDouble(pNode, "transform.heading", &pProgramState->cameraInput.headingPitch.x, 0.0);
+            vdkProjectNode_GetMetadataDouble(pNode, "transform.pitch", &pProgramState->cameraInput.headingPitch.y, 0.0);
+            pProgramState->cameraInput.targetAngle = vcGIS_HeadingPitchToQuaternion(pProgramState->geozone, pProgramState->camera.position, pProgramState->cameraInput.headingPitch);
+          }
+
           pProgramState->cameraInput.startPosition = pProgramState->camera.position;
           pProgramState->cameraInput.startAngle = vcGIS_HeadingPitchToQuaternion(pProgramState->geozone, pProgramState->camera.position, pProgramState->camera.headingPitch);
           pProgramState->cameraInput.progress = 0.0;

--- a/src/vcCamera.h
+++ b/src/vcCamera.h
@@ -57,6 +57,7 @@ enum vcInputState
   vcCIS_Panning,
   vcCIS_MovingForward,
   vcCIS_Rotate,
+  vcCIS_MoveToViewpoint,
 
   vcCIS_Count
 };
@@ -69,6 +70,7 @@ struct vcCameraInput
   udDoubleQuat startAngle;
   udDoubleQuat targetAngle;
   double progress;
+  udDouble2 headingPitch;
 
   vcCameraPivotMode currentPivotMode;
 


### PR DESCRIPTION
Fixed [AB#1703](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1703).

Add "vcCIS_MoveToViewpoint". 
"move to" for viewpoint will move to exact location and direction as saved, "move to" for other scene item or picked point (in the scene) will move to 90% of the way and face the point.