### PR TITLE
saving projection orientation in the QueryFilter

### DIFF
--- a/src/scene/vcQueryNode.h
+++ b/src/scene/vcQueryNode.h
@@ -22,6 +22,8 @@ private:
 
   bool m_inverted;
 
+  udDoubleQuat m_currentProjection;
+
   udDouble3 m_center;
   udDouble3 m_extents;
   udDouble3 m_ypr;


### PR DESCRIPTION
This is the first fix for [AB#1728](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1728), but does not completely fix the issue. I just need filters to orientate correctly in ECEF, and is probably best if it's a separate PR.

EDIT: This also fixes the gizmo issue introduced in #708 