### PR TITLE
Shift-select start item is now cleared on selection removal

### DIFF
--- a/src/vcProject.cpp
+++ b/src/vcProject.cpp
@@ -333,6 +333,7 @@ void vcProject_RemoveSelected(vcState *pProgramState)
 {
   vcProject_RemoveSelectedFolder(pProgramState, pProgramState->activeProject.pRoot);
 
+  pProgramState->sceneExplorer.selectStartItem = {};
   pProgramState->sceneExplorer.selectedItems.clear();
   pProgramState->sceneExplorer.clickedItem = {};
 }


### PR DESCRIPTION
Fixes [AB#1767](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1767)