### PR TITLE
Remove Height Measurement Label size options

### DIFF
--- a/src/rendering/vcLabelRenderer.cpp
+++ b/src/rendering/vcLabelRenderer.cpp
@@ -87,7 +87,7 @@ bool vcLabelRenderer_Render(ImDrawList *drawList, vcLabelInfo *pLabelRenderer, f
   };
   UDCOMPILEASSERT(udLengthOf(fontScales) == vcLFS_Count, "Font sizes count doesn't match");
 
-  ImGui::SetWindowFontScale(fontScales[pLabelRenderer->textSize]);
+  ImGui::SetWindowFontScale(fontScales[vcLFS_Medium]);
 
   ImVec2 labelSize = ImGui::CalcTextSize(pLabelRenderer->pText);
   ImVec2 halfLabelSize = ImVec2(labelSize.x * 0.5f, labelSize.y * 0.5f);

--- a/src/rendering/vcLabelRenderer.h
+++ b/src/rendering/vcLabelRenderer.h
@@ -20,7 +20,6 @@ struct vcLabelInfo
   udDouble3 worldPosition;
 
   const char *pText;
-  vcLabelFontSize textSize;
   uint32_t textColourRGBA;
   uint32_t backColourRGBA;
 

--- a/src/scene/vcLiveFeed.cpp
+++ b/src/scene/vcLiveFeed.cpp
@@ -252,15 +252,6 @@ void vcLiveFeed_UpdateFeed(void *pUserData)
 
               udFree(lodRef.pLabelText);
               lodRef.pLabelText = udStrdup(labelObj.Get("text").AsString("[?]"));
-
-              const char *pTextSize = labelObj.Get("size").AsString();
-              if (udStrEquali(pTextSize, "x-small") || udStrEquali(pTextSize, "small"))
-                lodRef.pLabelInfo->textSize = vcLFS_Small;
-              else if (udStrEquali(pTextSize, "large") || udStrEquali(pTextSize, "x-large"))
-                lodRef.pLabelInfo->textSize = vcLFS_Large;
-              else
-                lodRef.pLabelInfo->textSize = vcLFS_Medium;
-
               lodRef.pLabelInfo->pText = lodRef.pLabelText;
               lodRef.pLabelInfo->pSceneItem = pInfo->pFeed;
               lodRef.pLabelInfo->sceneItemInternalId = j + 1;

--- a/src/scene/vcPOI.cpp
+++ b/src/scene/vcPOI.cpp
@@ -475,7 +475,6 @@ vcPOI::vcPOI(vcProject *pProject, vdkProjectNode *pNode, vcState *pProgramState)
 {
   m_nameColour =  0xFFFFFFFF;
   m_backColour = 0x7F000000;
-  m_namePt = vcLFS_Medium;
 
   m_showArea = false;
   m_showLength = false;
@@ -547,14 +546,6 @@ void vcPOI::OnNodeUpdate(vcState *pProgramState)
   }
 
   const char *pTemp;
-  vdkProjectNode_GetMetadataString(m_pNode, "textSize", &pTemp, "Medium");
-  if (udStrEquali(pTemp, "x-small") || udStrEquali(pTemp, "small"))
-    m_namePt = vcLFS_Small;
-  else if (udStrEquali(pTemp, "large") || udStrEquali(pTemp, "x-large"))
-    m_namePt = vcLFS_Large;
-  else
-    m_namePt = vcLFS_Medium;
-
   vdkProjectNode_GetMetadataUint(m_pNode, "nameColour", &m_nameColour, vcIGSW_ImGuiToBGRA(pProgramState->settings.tools.label.textColour));
   vdkProjectNode_GetMetadataUint(m_pNode, "backColour", &m_backColour, vcIGSW_ImGuiToBGRA(pProgramState->settings.tools.label.backgroundColour));
   vdkProjectNode_GetMetadataUint(m_pNode, "lineColourPrimary", &m_line.colourPrimary, vcIGSW_ImGuiToBGRA(pProgramState->settings.tools.line.colour));
@@ -750,7 +741,6 @@ void vcPOI::UpdatePoints(vcState *pProgramState)
   m_pLabelInfo->pText = m_pLabelText;
   m_pLabelInfo->textColourRGBA = vcIGSW_BGRAToRGBAUInt32(m_nameColour);
   m_pLabelInfo->backColourRGBA = vcIGSW_BGRAToRGBAUInt32(m_backColour);
-  m_pLabelInfo->textSize = m_namePt;
   m_pLabelInfo->pSceneItem = this;
 
   for (size_t i = 0; i < m_lengthLabels.length; ++i)
@@ -758,7 +748,6 @@ void vcPOI::UpdatePoints(vcState *pProgramState)
     vcLabelInfo* pLabel = m_lengthLabels.GetElement(i);
     pLabel->textColourRGBA = vcIGSW_BGRAToRGBAUInt32(m_nameColour);
     pLabel->backColourRGBA = vcIGSW_BGRAToRGBAUInt32(m_backColour);
-    pLabel->textSize = m_namePt;
     pLabel->pSceneItem = this;
   }
 
@@ -802,28 +791,6 @@ void vcPOI::HandleImGui(vcState *pProgramState, size_t *pItemID)
   {
     m_pLabelInfo->backColourRGBA = vcIGSW_BGRAToRGBAUInt32(m_backColour);
     vdkProjectNode_SetMetadataUint(m_pNode, "backColour", m_backColour);
-  }
-
-  const char *labelSizeOptions[] = { vcString::Get("scenePOILabelSizeNormal"), vcString::Get("scenePOILabelSizeSmall"), vcString::Get("scenePOILabelSizeLarge") };
-  if (ImGui::Combo(udTempStr("%s##POILabelSize%zu", vcString::Get("scenePOILabelSize"), *pItemID), (int *)&m_namePt, labelSizeOptions, (int)udLengthOf(labelSizeOptions)))
-  {
-    UpdatePoints(pProgramState);
-    const char *pTemp;
-    m_pLabelInfo->textSize = m_namePt;
-    switch (m_namePt)
-    {
-    case vcLFS_Small:
-      pTemp = "small";
-      break;
-    case vcLFS_Large:
-      pTemp = "large";
-      break;
-    case vcLFS_Medium:
-    default: // Falls through
-      pTemp = "medium";
-      break;
-    }
-    vdkProjectNode_SetMetadataString(m_pNode, "textSize", pTemp);
   }
 
   if (vcIGSW_InputText(vcString::Get("scenePOILabelHyperlink"), m_hyperlink, vcMaxPathLength, ImGuiInputTextFlags_EnterReturnsTrue))

--- a/src/scene/vcPOI.h
+++ b/src/scene/vcPOI.h
@@ -47,7 +47,6 @@ private:
   uint32_t m_measurementAreaFillColour;
   uint32_t m_nameColour;
   uint32_t m_backColour;
-  vcLabelFontSize m_namePt;
   char m_hyperlink[vcMaxPathLength];
   char m_description[vcMaxPathLength];
 

--- a/src/scene/vcVerticalMeasureTool.cpp
+++ b/src/scene/vcVerticalMeasureTool.cpp
@@ -33,7 +33,6 @@ vcVerticalMeasureTool::vcVerticalMeasureTool(vcProject *pProject, vdkProjectNode
     label.pText = nullptr;
     label.textColourRGBA = vcIGSW_BGRAToRGBAUInt32(vcIGSW_ImGuiToBGRA(pProgramState->settings.tools.label.textColour));
     label.backColourRGBA = vcIGSW_BGRAToRGBAUInt32(vcIGSW_ImGuiToBGRA(pProgramState->settings.tools.label.backgroundColour));
-    label.textSize = (vcLabelFontSize)pProgramState->settings.tools.label.textSize;
   }
   
 
@@ -183,15 +182,6 @@ void vcVerticalMeasureTool::HandleImGui(vcState *pProgramState, size_t *pItemID)
       vdkProjectNode_SetMetadataUint(m_pNode, "backColour", m_textBackgroundBGRA);
     }
 
-    const char *labelSizeOptions[] = { vcString::Get("scenePOILabelSizeNormal"), vcString::Get("scenePOILabelSizeSmall"), vcString::Get("scenePOILabelSizeLarge") };
-    int32_t size = m_labelList[0].textSize;
-    if (ImGui::Combo(udTempStr("%s##VerticalLabelSize%zu", vcString::Get("scenePOILabelSize"), *pItemID), &size, labelSizeOptions, (int)udLengthOf(labelSizeOptions)))
-    {
-      for (auto &label : m_labelList)
-        label.textSize = (vcLabelFontSize)size;
-      vdkProjectNode_SetMetadataInt(m_pNode, "textSize", size);
-    }
-
     if (vcIGSW_InputText(vcString::Get("scenePOILabelDescription"), m_description, sizeof(m_description), ImGuiInputTextFlags_EnterReturnsTrue))
       vdkProjectNode_SetMetadataString(m_pNode, "description", m_description);
 
@@ -280,7 +270,6 @@ void vcVerticalMeasureTool::UpdateSetting(vcState *pProgramState)
   {
     label.textColourRGBA = textColourRGBA;
     label.backColourRGBA = backColourRGBA;
-    label.textSize = (vcLabelFontSize)size;
   }
 
   vdkProjectNode_GetMetadataUint(m_pNode, "lineColour", &m_lineColour, vcIGSW_ImGuiToBGRA(pProgramState->settings.tools.line.colour));
@@ -292,7 +281,6 @@ void vcVerticalMeasureTool::UpdateSetting(vcState *pProgramState)
   const char *pTemp;
   vdkProjectNode_GetMetadataString(m_pNode, "description", &pTemp, "");
   udStrcpy(m_description, pTemp);
-  
 }
 
 void vcVerticalMeasureTool::HandleToolUI(vcState * pProgramState)


### PR DESCRIPTION
- Removed Height Measurement Label size options because small is unreadable
- Fixes [AB#1752](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1752)