### PR TITLE
PolyModel Default Tint

### DIFF
--- a/src/scene/vcPolyModelNode.cpp
+++ b/src/scene/vcPolyModelNode.cpp
@@ -104,6 +104,7 @@ void vcPolyModelNode::AddToScene(vcState * /*pProgramState*/, vcRenderData *pRen
   pModel->worldMat = m_matrix;
   pModel->cullFace = m_cullFace;
   pModel->selectable = true;
+  pModel->tint = udFloat4::one();
   if (m_ignoreTint)
     pModel->renderFlags = vcRenderPolyInstance::RenderFlags_IgnoreTint;
 }


### PR DESCRIPTION
- Set default tint for polymodels to white, instead of being unassigned
- Fixes [AB#1761](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1761)