### PR TITLE
Don't display fill mesh of <= 2 Point Area Measurement

### DIFF
--- a/src/scene/vcPOI.cpp
+++ b/src/scene/vcPOI.cpp
@@ -1187,7 +1187,7 @@ void vcPOI::AddLabelsToScene(vcRenderData *pRenderData)
 
 void vcPOI::AddFillPolygonToScene(vcState *pProgramState, vcRenderData *pRenderData)
 {
-  if (m_pPolyModel == nullptr)
+  if (m_pPolyModel == nullptr || m_line.numPoints < 3)
     return;
   
   vcRenderPolyInstance *pInstance = pRenderData->polyModels.PushBack();


### PR DESCRIPTION
- Fixed Area Measurement not removing the fill when there's 2 or less points
- Fixes [AB#1820](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1820)