### PR TITLE
Added ISO 8601 time format

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1917,6 +1917,19 @@ void vcRenderScene_HandlePicking(vcState *pProgramState, vcRenderData &renderDat
               continue;
             }
 
+            if (pHeader->attributes.pDescriptors[i].typeInfo == vdkAttributeTypeInfo_float64 && udStrEqual(pHeader->attributes.pDescriptors[i].name, "udGPSTime"))
+            {
+              double GPSTime;
+              udReadFromPointer(&GPSTime, pAttributePtr);
+
+              char buffer[128];
+              vcTimeReferenceData timeData;
+              timeData.seconds = GPSTime;
+              vcUnitConversion_ConvertAndFormatTimeReference(buffer, 128, timeData, pProgramState->settings.visualization.GPSTime.inputFormat, &pProgramState->settings.unitConversionData);
+              pProgramState->udModelNodeAttributes.Set("%s = '%s'", pHeader->attributes.pDescriptors[i].name, buffer);
+              continue;
+            }
+
             // Do Stuff
             switch (pHeader->attributes.pDescriptors[i].typeInfo)
             {

--- a/src/vcSettings.cpp
+++ b/src/vcSettings.cpp
@@ -296,7 +296,8 @@ bool vcSettings_Load(vcSettings *pSettings, bool forceReset /*= false*/, vcSetti
     //GPSTime
     pSettings->visualization.GPSTime.minTime = data.Get("visualization.GPSTime.minTime").AsDouble(0.0);
     pSettings->visualization.GPSTime.maxTime = data.Get("visualization.GPSTime.maxTime").AsDouble(0.0);
-
+    pSettings->visualization.GPSTime.inputFormat = (vcTimeReference)data.Get("visualization.GPSTime.inputFormat").AsInt((int)vcTimeReference_GPS);
+    
     //Scan Angle
     pSettings->visualization.scanAngle.minAngle = data.Get("visualization.scanAngle.minAngle").AsDouble(-180.0);
     pSettings->visualization.scanAngle.maxAngle = data.Get("visualization.scanAngle.maxAngle").AsDouble(180.0);
@@ -707,7 +708,8 @@ bool vcSettings_Save(vcSettings *pSettings)
   //GPS Time
   data.Set("visualization.GPSTime.minTime = %f", pSettings->visualization.GPSTime.minTime);
   data.Set("visualization.GPSTime.maxTime = %f", pSettings->visualization.GPSTime.maxTime);
-
+  data.Set("visualization.GPSTime.inputFormat = %u", pSettings->visualization.GPSTime.inputFormat);
+  
   //Scan angle
   data.Set("visualization.scanAngle.minAngle = %f", pSettings->visualization.scanAngle.minAngle);
   data.Set("visualization.scanAngle.maxAngle = %f", pSettings->visualization.scanAngle.maxAngle);

--- a/src/vcSettings.h
+++ b/src/vcSettings.h
@@ -159,6 +159,7 @@ struct vcVisualizationSettings
   {
     double minTime;
     double maxTime;
+    vcTimeReference inputFormat; //This should ony be GPS or GPSAdjusted 
   } GPSTime;
 
   struct

--- a/src/vcSettingsUI.cpp
+++ b/src/vcSettingsUI.cpp
@@ -235,7 +235,7 @@ void vcSettingsUI_Show(vcState *pProgramState)
             if (measurementSystem == 0)
               vcUnitConversion_SetMetric(&pProgramState->settings.unitConversionData);
             else if (measurementSystem == 1)
-              vcUnitConversion_SetImperial(&pProgramState->settings.unitConversionData);
+              vcUnitConversion_SetUSSurvey(&pProgramState->settings.unitConversionData);
           }
 
           ImGui::Checkbox(vcString::Get("sceneCameraInfo"), &pProgramState->settings.presentation.showCameraInfo);
@@ -1123,8 +1123,18 @@ bool vcSettingsUI_VisualizationSettings(vcVisualizationSettings *pVisualizationS
   }
   case vcVM_GPSTime:
   {
+    vcTimeReference GPSTimeInIntToEnum[] = {vcTimeReference_GPS, vcTimeReference_GPSAdjusted};
+    int GPSTimeInEnumToInt[] = {0, 0, 0, 1, 0, 0};
+
+    static int GPSTimeFormatIn = GPSTimeInEnumToInt[pVisualizationSettings->GPSTime.inputFormat];
+    const char *GPSTimeFormatInOptions[] = {"GPS", "GPS Adjusted"};
+
+    retVal |= ImGui::Combo("Input GPS Time format", &GPSTimeFormatIn, GPSTimeFormatInOptions, (int)udLengthOf(GPSTimeFormatInOptions));
+
     bool minEdited = ImGui::InputDouble(vcString::Get("settingsVisGPSTimeMin"), &pVisualizationSettings->GPSTime.minTime, 0.0, 0.0, "%.1f");
     bool maxEdited = ImGui::InputDouble(vcString::Get("settingsVisGPSTimeMax"), &pVisualizationSettings->GPSTime.maxTime, 0.0, 0.0, "%.1f");
+
+    pVisualizationSettings->GPSTime.inputFormat = GPSTimeInIntToEnum[GPSTimeFormatIn];
 
     retVal |= (minEdited || maxEdited);
 

--- a/src/vcUnitConversion.cpp
+++ b/src/vcUnitConversion.cpp
@@ -597,7 +597,7 @@ udResult vcUnitConversion_ConvertAndFormatTimeReference(char *pBuffer, size_t bu
   finalValue = vcUnitConversion_ConvertTimeReference(timeRefData, unit, pData->timeReference);
 
   sigFigs = udClamp<uint32_t>(pData->timeSigFigs, 0, gSigFigCount - 1);
-  convertResult = vcUnitConversion_ConvertTimeToString(pBuffer, bufferSize, finalValue, pData->timeReference, "%02.0f");
+  convertResult = vcUnitConversion_ConvertTimeToString(pBuffer, bufferSize, finalValue, pData->timeReference, gTimeSigFigsFormats[sigFigs]);
 
   result = convertResult < 0 ? udR_WriteFailure : udR_Success;
 

--- a/src/vcUnitConversion.h
+++ b/src/vcUnitConversion.h
@@ -6,14 +6,14 @@
 
 enum vcDistanceUnit
 {
+  vcDistance_Millimetres,
+  vcDistance_Centimetres,
   vcDistance_Metres,
   vcDistance_Kilometres,
-  vcDistance_Centimetres,
-  vcDistance_Millimetres,
 
+  vcDistance_USSurveyInches,
   vcDistance_USSurveyFeet,
   vcDistance_USSurveyMiles,
-  vcDistance_USSurveyInches,
 
   vcDistance_NauticalMiles,
 
@@ -23,7 +23,7 @@ enum vcDistanceUnit
 enum vcAreaUnit
 {
   vcArea_SquareMetres,
-  vcArea_SquareKilometers,
+  vcArea_SquareKilometres,
   vcArea_Hectare,
 
   vcArea_SquareFoot,
@@ -35,16 +35,16 @@ enum vcAreaUnit
 
 enum vcVolumeUnit
 {
-  vcVolume_CubicMeter,
-  vcVolume_MegaLiter,
+  vcVolume_CubicMetre,
   vcVolume_Litre,
+  vcVolume_MegaLitre,
 
-  vcVolume_CubicInch,
-  vcVolume_CubicFoot,
+  vcVolume_USSurveyCubicInch,
+  vcVolume_USSurveyCubicFoot,
+  vcVolume_USSurveyCubicYard,
 
-  vcVolume_USSGallons,
-  vcVolume_USSQuart,
-  vcVolume_CubicYard,
+  vcVolume_USQuart,
+  vcVolume_USGallons,
 
   vcVolume_Count
 };
@@ -152,7 +152,7 @@ int vcUnitConversion_ConvertTemperatureToString(char *pBuffer, size_t bufferSize
 
 //Functions to set up some quick defaults.
 udResult vcUnitConversion_SetMetric(vcUnitConversionData *pData);
-udResult vcUnitConversion_SetImperial(vcUnitConversionData *pData);
+udResult vcUnitConversion_SetUSSurvey(vcUnitConversionData *pData);
 
 udResult vcUnitConversion_ConvertAndFormatDistance(char *pBuffer, size_t bufferSize, double value, vcDistanceUnit unit, const vcUnitConversionData *pData);
 udResult vcUnitConversion_ConvertAndFormatArea(char *pBuffer, size_t bufferSize, double value, vcAreaUnit unit, const vcUnitConversionData *pData);

--- a/vcTesting/src/vcUnitConversionTests.cpp
+++ b/vcTesting/src/vcUnitConversionTests.cpp
@@ -10,6 +10,20 @@ void VerifyDistance(vcDistanceUnit sourceType, double in, vcDistanceUnit destTyp
 
 TEST(UnitConversion, Distance)
 {
+  VerifyDistance(vcDistance_Metres, 1.0, vcDistance_Millimetres, 1000.0);
+  VerifyDistance(vcDistance_Metres, 1.0, vcDistance_Centimetres, 100.0);
+  VerifyDistance(vcDistance_Metres, 1.0, vcDistance_Metres, 1.0);
+  VerifyDistance(vcDistance_Metres, 1.0, vcDistance_Kilometres, 0.001);
+
+  VerifyDistance(vcDistance_Millimetres, 1.0, vcDistance_Metres, 0.001);
+  VerifyDistance(vcDistance_Centimetres, 1.0, vcDistance_Metres, 0.01);
+  VerifyDistance(vcDistance_Metres, 1.0, vcDistance_Metres, 1.0);
+  VerifyDistance(vcDistance_Kilometres, 1.0, vcDistance_Metres, 1000.0);
+
+  VerifyDistance(vcDistance_Metres, 1.0, vcDistance_USSurveyInches, 39.37);
+  VerifyDistance(vcDistance_Metres, 1.0, vcDistance_USSurveyFeet, 39.37 / 12);
+  VerifyDistance(vcDistance_Metres, 1.0, vcDistance_USSurveyMiles, 39.37 / 12 / 5280);
+
   VerifyDistance(vcDistance_Kilometres, 100.0, vcDistance_NauticalMiles, 53.995680);
   VerifyDistance(vcDistance_Metres, 100.0, vcDistance_Centimetres, 10000.0);
   VerifyDistance(vcDistance_USSurveyFeet, 1.0, vcDistance_Millimetres, 304.800610);
@@ -35,7 +49,7 @@ void VerifyArea(vcAreaUnit sourceType, double in, vcAreaUnit destType, double ou
 
 TEST(UnitConversion, Area)
 {
-  VerifyArea(vcArea_SquareMetres, 100.0, vcArea_SquareKilometers, 0.0001);
+  VerifyArea(vcArea_SquareMetres, 100.0, vcArea_SquareKilometres, 0.0001);
   VerifyArea(vcArea_SquareMetres, 100.0, vcArea_Hectare, 0.01);
   VerifyArea(vcArea_SquareMetres, 100.0, vcArea_SquareFoot, 1076.391041670972072097356431186199188232421875);
   VerifyArea(vcArea_SquareMetres, 100.0, vcArea_SquareMiles, 0.0000386102160083283757);
@@ -59,23 +73,29 @@ void VerifyVolume(vcVolumeUnit sourceType, double in, vcVolumeUnit destType, dou
 
 TEST(UnitConversion, Volume)
 {
-  VerifyVolume(vcVolume_CubicMeter, 1.0, vcVolume_USSQuart, 1056.6882607957347);
-  VerifyVolume(vcVolume_CubicMeter, 1.0, vcVolume_USSGallons, 264.17203728418462);
-  VerifyVolume(vcVolume_CubicMeter, 159.0, vcVolume_CubicInch, 9702775.311062432825565);
-  VerifyVolume(vcVolume_CubicMeter, 1.0, vcVolume_CubicMeter, 1.0);
-  VerifyVolume(vcVolume_CubicMeter, 1.0, vcVolume_MegaLiter, 0.001);
-  VerifyVolume(vcVolume_CubicInch, 159.0, vcVolume_CubicMeter, 0.00260554317599999983);
-  VerifyVolume(vcVolume_CubicMeter, 1.0, vcVolume_CubicYard, 1.30795061586555);
-  VerifyVolume(vcVolume_CubicMeter, 1.0, vcVolume_CubicFoot, 35.31466621266132221990);
-  VerifyVolume(vcVolume_CubicYard, 1.0, vcVolume_CubicMeter, 0.764554859999999995);
+  VerifyVolume(vcVolume_CubicMetre, 1.0, vcVolume_CubicMetre, 1.0);
+  VerifyVolume(vcVolume_CubicMetre, 1.0, vcVolume_Litre, 1000.0);
+  VerifyVolume(vcVolume_CubicMetre, 1.0, vcVolume_MegaLitre, 1.0 / 1000.0);
+  VerifyVolume(vcVolume_CubicMetre, 1.0, vcVolume_USSurveyCubicInch, 39.37 * 39.37 * 39.37);
+  VerifyVolume(vcVolume_CubicMetre, 1.0, vcVolume_USSurveyCubicFoot, 35.31466621266132221990);
+  VerifyVolume(vcVolume_CubicMetre, 1.0, vcVolume_USSurveyCubicYard, 1.30795061586555);
+  VerifyVolume(vcVolume_CubicMetre, 1.0, vcVolume_USQuart, 1056.6882607957347);
+  VerifyVolume(vcVolume_CubicMetre, 1.0, vcVolume_USGallons, 264.17203728418462);
 
+  VerifyVolume(vcVolume_CubicMetre, 159.0, vcVolume_USSurveyCubicInch, 9702717.0945269987);
+  VerifyVolume(vcVolume_CubicMetre, 1.0, vcVolume_MegaLitre, 0.001);
+  VerifyVolume(vcVolume_USSurveyCubicInch, 159.0, vcVolume_CubicMetre, 0.00260554317599999983);
+  VerifyVolume(vcVolume_CubicMetre, 1.0, vcVolume_USSurveyCubicYard, 1.30795061586555);
+  VerifyVolume(vcVolume_CubicMetre, 1.0, vcVolume_USSurveyCubicFoot, 35.31466621266132221990);
+  VerifyVolume(vcVolume_USSurveyCubicYard, 1.0, vcVolume_CubicMetre, 0.764554859999999995);
+  
   for (int i = 0; i < vcVolume_Count; ++i)
   {
     // Round trips
-    EXPECT_DOUBLE_EQ(10000.0, vcUnitConversion_ConvertVolume(vcUnitConversion_ConvertVolume(10000.0, vcVolume_CubicMeter, (vcVolumeUnit)i), (vcVolumeUnit)i, vcVolume_CubicMeter));
-
+    EXPECT_DOUBLE_EQ(10000.0, vcUnitConversion_ConvertVolume(vcUnitConversion_ConvertVolume(10000.0, vcVolume_CubicMetre, (vcVolumeUnit)i), (vcVolumeUnit)i, vcVolume_CubicMetre));
+  
     // All should be 0 from 0
-    EXPECT_DOUBLE_EQ(0.0, vcUnitConversion_ConvertVolume(0.0, vcVolume_CubicMeter, (vcVolumeUnit)i));
+    EXPECT_DOUBLE_EQ(0.0, vcUnitConversion_ConvertVolume(0.0, vcVolume_CubicMetre, (vcVolumeUnit)i));
   }
 }
 
@@ -176,7 +196,7 @@ void VerifyTimeReferenceUTC(double seconds, vcTimeReference reference, const vcT
 TEST(UnitConversion, TimeReference)
 {
   static double const s_seconds_TAI_Unix_epoch = 378691200.0;
-  static double const s_seconds_TAI_GPS_epoch  = 694656000.0;
+  static double const s_seconds_TAI_GPS_epoch  = 694656009.0;
   static double const s_weekSeconds = 60.0 * 60.0 * 24.0 * 7.0;
 
   vcTimeReferenceData in, out;
@@ -236,6 +256,10 @@ TEST(UnitConversion, StringFormating)
     EXPECT_TRUE(vcUnitConversion_ConvertTimeToString(buffer, bufSze, timeData, vcTimeReference_GPSWeek) != -1);
     EXPECT_EQ(udStrcmp(buffer, "42 weeks, 13.000000s"), 0);
 
+    vcUnitConversion_SetUTC(&timeData, 2020, 7, 3, 15, 29, 42);
+    EXPECT_TRUE(vcUnitConversion_ConvertTimeToString(buffer, bufSze, timeData, vcTimeReference_UTC) != -1);
+    EXPECT_EQ(udStrcmp(buffer, "2020-07-03T15:29:42Z"), 0);
+
     timeData.seconds= 42.0;
     EXPECT_TRUE(vcUnitConversion_ConvertTimeToString(buffer, bufSze, timeData, vcTimeReference_TAI) != -1);
     EXPECT_EQ(udStrcmp(buffer, "42.000000s"), 0);
@@ -253,6 +277,10 @@ TEST(UnitConversion, StringFormating)
     timeData.GPSWeek.secondsOfTheWeek = 13.0;
     EXPECT_TRUE(vcUnitConversion_ConvertTimeToString(buffer, bufSze, timeData, vcTimeReference_GPSWeek, "%0.0f") != -1);
     EXPECT_EQ(udStrcmp(buffer, "42 weeks, 13s"), 0);
+
+    vcUnitConversion_SetUTC(&timeData, 2020, 7, 3, 15, 29, 42);
+    EXPECT_TRUE(vcUnitConversion_ConvertTimeToString(buffer, bufSze, timeData, vcTimeReference_UTC, "%0.0f") != -1);
+    EXPECT_EQ(udStrcmp(buffer, "2020-07-03T15:29:42Z"), 0);
 
     timeData.seconds= 42.0;
     EXPECT_TRUE(vcUnitConversion_ConvertTimeToString(buffer, bufSze, timeData, vcTimeReference_TAI, "%0.0f") != -1);
@@ -322,37 +350,37 @@ TEST(UnitConversion, StringFormating)
 
   {
     EXPECT_TRUE(vcUnitConversion_ConvertAreaToString(buffer, bufSze, value, vcArea_SquareMetres) != -1);
-    EXPECT_EQ(udStrcmp(buffer, "42.000000m sq"), 0);
+    EXPECT_EQ(udStrcmp(buffer, "42.000000sqm"), 0);
 
-    EXPECT_TRUE(vcUnitConversion_ConvertAreaToString(buffer, bufSze, value, vcArea_SquareKilometers) != -1);
-    EXPECT_EQ(udStrcmp(buffer, "42.000000km sq"), 0);
+    EXPECT_TRUE(vcUnitConversion_ConvertAreaToString(buffer, bufSze, value, vcArea_SquareKilometres) != -1);
+    EXPECT_EQ(udStrcmp(buffer, "42.000000sqkm"), 0);
 
     EXPECT_TRUE(vcUnitConversion_ConvertAreaToString(buffer, bufSze, value, vcArea_Hectare) != -1);
     EXPECT_EQ(udStrcmp(buffer, "42.000000ha"), 0);
 
     EXPECT_TRUE(vcUnitConversion_ConvertAreaToString(buffer, bufSze, value, vcArea_SquareFoot) != -1);
-    EXPECT_EQ(udStrcmp(buffer, "42.000000ft sq"), 0);
+    EXPECT_EQ(udStrcmp(buffer, "42.000000sqft"), 0);
 
     EXPECT_TRUE(vcUnitConversion_ConvertAreaToString(buffer, bufSze, value, vcArea_SquareMiles) != -1);
-    EXPECT_EQ(udStrcmp(buffer, "42.000000mi sq"), 0);
+    EXPECT_EQ(udStrcmp(buffer, "42.000000sqmi"), 0);
 
     EXPECT_TRUE(vcUnitConversion_ConvertAreaToString(buffer, bufSze, value, vcArea_Acre) != -1);
     EXPECT_EQ(udStrcmp(buffer, "42.000000ac"), 0);
 
     EXPECT_TRUE(vcUnitConversion_ConvertAreaToString(buffer, bufSze, value, vcArea_SquareMetres, "%0.0f") != -1);
-    EXPECT_EQ(udStrcmp(buffer, "42m sq"), 0);
+    EXPECT_EQ(udStrcmp(buffer, "42sqm"), 0);
 
-    EXPECT_TRUE(vcUnitConversion_ConvertAreaToString(buffer, bufSze, value, vcArea_SquareKilometers, "%0.0f") != -1);
-    EXPECT_EQ(udStrcmp(buffer, "42km sq"), 0);
+    EXPECT_TRUE(vcUnitConversion_ConvertAreaToString(buffer, bufSze, value, vcArea_SquareKilometres, "%0.0f") != -1);
+    EXPECT_EQ(udStrcmp(buffer, "42sqkm"), 0);
 
     EXPECT_TRUE(vcUnitConversion_ConvertAreaToString(buffer, bufSze, value, vcArea_Hectare, "%0.0f") != -1);
     EXPECT_EQ(udStrcmp(buffer, "42ha"), 0);
 
     EXPECT_TRUE(vcUnitConversion_ConvertAreaToString(buffer, bufSze, value, vcArea_SquareFoot, "%0.0f") != -1);
-    EXPECT_EQ(udStrcmp(buffer, "42ft sq"), 0);
+    EXPECT_EQ(udStrcmp(buffer, "42sqft"), 0);
 
     EXPECT_TRUE(vcUnitConversion_ConvertAreaToString(buffer, bufSze, value, vcArea_SquareMiles, "%0.0f") != -1);
-    EXPECT_EQ(udStrcmp(buffer, "42mi sq"), 0);
+    EXPECT_EQ(udStrcmp(buffer, "42sqmi"), 0);
 
     EXPECT_TRUE(vcUnitConversion_ConvertAreaToString(buffer, bufSze, value, vcArea_Acre, "%0.0f") != -1);
     EXPECT_EQ(udStrcmp(buffer, "42ac"), 0);
@@ -361,52 +389,52 @@ TEST(UnitConversion, StringFormating)
   }
 
   {
-    EXPECT_TRUE(vcUnitConversion_ConvertVolumeToString(buffer, bufSze, value, vcVolume_CubicMeter) != -1);
+    EXPECT_TRUE(vcUnitConversion_ConvertVolumeToString(buffer, bufSze, value, vcVolume_CubicMetre) != -1);
     EXPECT_EQ(udStrcmp(buffer, "42.000000cbm"), 0);
 
-    EXPECT_TRUE(vcUnitConversion_ConvertVolumeToString(buffer, bufSze, value, vcVolume_MegaLiter) != -1);
+    EXPECT_TRUE(vcUnitConversion_ConvertVolumeToString(buffer, bufSze, value, vcVolume_MegaLitre) != -1);
     EXPECT_EQ(udStrcmp(buffer, "42.000000ML"), 0);
 
     EXPECT_TRUE(vcUnitConversion_ConvertVolumeToString(buffer, bufSze, value, vcVolume_Litre) != -1);
     EXPECT_EQ(udStrcmp(buffer, "42.000000L"), 0);
 
-    EXPECT_TRUE(vcUnitConversion_ConvertVolumeToString(buffer, bufSze, value, vcVolume_CubicInch) != -1);
+    EXPECT_TRUE(vcUnitConversion_ConvertVolumeToString(buffer, bufSze, value, vcVolume_USSurveyCubicInch) != -1);
     EXPECT_EQ(udStrcmp(buffer, "42.000000cbin"), 0);
 
-    EXPECT_TRUE(vcUnitConversion_ConvertVolumeToString(buffer, bufSze, value, vcVolume_CubicFoot) != -1);
+    EXPECT_TRUE(vcUnitConversion_ConvertVolumeToString(buffer, bufSze, value, vcVolume_USSurveyCubicFoot) != -1);
     EXPECT_EQ(udStrcmp(buffer, "42.000000cbft"), 0);
 
-    EXPECT_TRUE(vcUnitConversion_ConvertVolumeToString(buffer, bufSze, value, vcVolume_USSGallons) != -1);
+    EXPECT_TRUE(vcUnitConversion_ConvertVolumeToString(buffer, bufSze, value, vcVolume_USGallons) != -1);
     EXPECT_EQ(udStrcmp(buffer, "42.000000gal US"), 0);
 
-    EXPECT_TRUE(vcUnitConversion_ConvertVolumeToString(buffer, bufSze, value, vcVolume_USSQuart) != -1);
+    EXPECT_TRUE(vcUnitConversion_ConvertVolumeToString(buffer, bufSze, value, vcVolume_USQuart) != -1);
     EXPECT_EQ(udStrcmp(buffer, "42.000000qt US"), 0);
 
-    EXPECT_TRUE(vcUnitConversion_ConvertVolumeToString(buffer, bufSze, value, vcVolume_CubicYard) != -1);
+    EXPECT_TRUE(vcUnitConversion_ConvertVolumeToString(buffer, bufSze, value, vcVolume_USSurveyCubicYard) != -1);
     EXPECT_EQ(udStrcmp(buffer, "42.000000cbyd"), 0);
 
-    EXPECT_TRUE(vcUnitConversion_ConvertVolumeToString(buffer, bufSze, value, vcVolume_CubicMeter, "%0.0f") != -1);
+    EXPECT_TRUE(vcUnitConversion_ConvertVolumeToString(buffer, bufSze, value, vcVolume_CubicMetre, "%0.0f") != -1);
     EXPECT_EQ(udStrcmp(buffer, "42cbm"), 0);
 
-    EXPECT_TRUE(vcUnitConversion_ConvertVolumeToString(buffer, bufSze, value, vcVolume_MegaLiter, "%0.0f") != -1);
+    EXPECT_TRUE(vcUnitConversion_ConvertVolumeToString(buffer, bufSze, value, vcVolume_MegaLitre, "%0.0f") != -1);
     EXPECT_EQ(udStrcmp(buffer, "42ML"), 0);
 
     EXPECT_TRUE(vcUnitConversion_ConvertVolumeToString(buffer, bufSze, value, vcVolume_Litre, "%0.0f") != -1);
     EXPECT_EQ(udStrcmp(buffer, "42L"), 0);
 
-    EXPECT_TRUE(vcUnitConversion_ConvertVolumeToString(buffer, bufSze, value, vcVolume_CubicInch, "%0.0f") != -1);
+    EXPECT_TRUE(vcUnitConversion_ConvertVolumeToString(buffer, bufSze, value, vcVolume_USSurveyCubicInch, "%0.0f") != -1);
     EXPECT_EQ(udStrcmp(buffer, "42cbin"), 0);
 
-    EXPECT_TRUE(vcUnitConversion_ConvertVolumeToString(buffer, bufSze, value, vcVolume_CubicFoot, "%0.0f") != -1);
+    EXPECT_TRUE(vcUnitConversion_ConvertVolumeToString(buffer, bufSze, value, vcVolume_USSurveyCubicFoot, "%0.0f") != -1);
     EXPECT_EQ(udStrcmp(buffer, "42cbft"), 0);
 
-    EXPECT_TRUE(vcUnitConversion_ConvertVolumeToString(buffer, bufSze, value, vcVolume_USSGallons, "%0.0f") != -1);
+    EXPECT_TRUE(vcUnitConversion_ConvertVolumeToString(buffer, bufSze, value, vcVolume_USGallons, "%0.0f") != -1);
     EXPECT_EQ(udStrcmp(buffer, "42gal US"), 0);
 
-    EXPECT_TRUE(vcUnitConversion_ConvertVolumeToString(buffer, bufSze, value, vcVolume_USSQuart, "%0.0f") != -1);
+    EXPECT_TRUE(vcUnitConversion_ConvertVolumeToString(buffer, bufSze, value, vcVolume_USQuart, "%0.0f") != -1);
     EXPECT_EQ(udStrcmp(buffer, "42qt US"), 0);
 
-    EXPECT_TRUE(vcUnitConversion_ConvertVolumeToString(buffer, bufSze, value, vcVolume_CubicYard, "%0.0f") != -1);
+    EXPECT_TRUE(vcUnitConversion_ConvertVolumeToString(buffer, bufSze, value, vcVolume_USSurveyCubicYard, "%0.0f") != -1);
     EXPECT_EQ(udStrcmp(buffer, "42cbyd"), 0);
 
     EXPECT_EQ(vcUnitConversion_ConvertVolumeToString(buffer, bufSze, value, vcVolume_Count), -1);
@@ -489,7 +517,7 @@ TEST(UnitConversion, ConvertAndStringifyMetric)
     timeData.GPSWeek.weeks = 0;
     timeData.GPSWeek.secondsOfTheWeek = 0.0;
     EXPECT_EQ(vcUnitConversion_ConvertAndFormatTimeReference(buffer, bufSze, timeData, vcTimeReference_GPSWeek, &conversionData), udR_Success);
-    EXPECT_EQ(udStrcmp(buffer, "315964791.0s"), 0);
+    EXPECT_EQ(udStrcmp(buffer, "1980-01-06T00:00:00Z"), 0);
   }
 
   {
@@ -544,16 +572,16 @@ TEST(UnitConversion, ConvertAndStringifyMetric)
 
   {
     EXPECT_EQ(vcUnitConversion_ConvertAndFormatArea(buffer, bufSze, metricVal, vcArea_SquareMetres, &conversionData), udR_Success);
-    EXPECT_EQ(udStrcmp(buffer, "5.733m sq"), 0);
+    EXPECT_EQ(udStrcmp(buffer, "5.733sqm"), 0);
 
     EXPECT_EQ(vcUnitConversion_ConvertAndFormatArea(buffer, bufSze, metricVal * 1000.0 * 1000.0, vcArea_SquareMetres, &conversionData), udR_Success);
-    EXPECT_EQ(udStrcmp(buffer, "5.733km sq"), 0);
+    EXPECT_EQ(udStrcmp(buffer, "5.733sqkm"), 0);
 
-    EXPECT_EQ(vcUnitConversion_ConvertAndFormatArea(buffer, bufSze, metricVal / 1000.0 / 1000.0, vcArea_SquareKilometers, &conversionData), udR_Success);
-    EXPECT_EQ(udStrcmp(buffer, "5.733m sq"), 0);
+    EXPECT_EQ(vcUnitConversion_ConvertAndFormatArea(buffer, bufSze, metricVal / 1000.0 / 1000.0, vcArea_SquareKilometres, &conversionData), udR_Success);
+    EXPECT_EQ(udStrcmp(buffer, "5.733sqm"), 0);
 
-    EXPECT_EQ(vcUnitConversion_ConvertAndFormatArea(buffer, bufSze, metricVal, vcArea_SquareKilometers, &conversionData), udR_Success);
-    EXPECT_EQ(udStrcmp(buffer, "5.733km sq"), 0);
+    EXPECT_EQ(vcUnitConversion_ConvertAndFormatArea(buffer, bufSze, metricVal, vcArea_SquareKilometres, &conversionData), udR_Success);
+    EXPECT_EQ(udStrcmp(buffer, "5.733sqkm"), 0);
   }
 
   {
@@ -563,10 +591,10 @@ TEST(UnitConversion, ConvertAndStringifyMetric)
     EXPECT_EQ(vcUnitConversion_ConvertAndFormatVolume(buffer, bufSze, metricVal * 1000.0 * 1000.0, vcVolume_Litre, &conversionData), udR_Success);
     EXPECT_EQ(udStrcmp(buffer, "5.733ML"), 0);
 
-    EXPECT_EQ(vcUnitConversion_ConvertAndFormatVolume(buffer, bufSze, metricVal / 1000.0 / 1000.0, vcVolume_MegaLiter, &conversionData), udR_Success);
+    EXPECT_EQ(vcUnitConversion_ConvertAndFormatVolume(buffer, bufSze, metricVal / 1000.0 / 1000.0, vcVolume_MegaLitre, &conversionData), udR_Success);
     EXPECT_EQ(udStrcmp(buffer, "5.733L"), 0);
 
-    EXPECT_EQ(vcUnitConversion_ConvertAndFormatVolume(buffer, bufSze, metricVal, vcVolume_MegaLiter, &conversionData), udR_Success);
+    EXPECT_EQ(vcUnitConversion_ConvertAndFormatVolume(buffer, bufSze, metricVal, vcVolume_MegaLitre, &conversionData), udR_Success);
     EXPECT_EQ(udStrcmp(buffer, "5.733ML"), 0);
   }
 
@@ -595,13 +623,13 @@ TEST(UnitConversion, ConvertAndStringifyImperial)
 
   vcUnitConversionData conversionData;
 
-  vcUnitConversion_SetImperial(&conversionData);
+  vcUnitConversion_SetUSSurvey(&conversionData);
   {
     vcTimeReferenceData timeData;
     timeData.GPSWeek.weeks = 0;
     timeData.GPSWeek.secondsOfTheWeek = 0.0;
     EXPECT_EQ(vcUnitConversion_ConvertAndFormatTimeReference(buffer, bufSze, timeData, vcTimeReference_GPSWeek, &conversionData), udR_Success);
-    EXPECT_EQ(udStrcmp(buffer, "315964791.0s"), 0);
+    EXPECT_EQ(udStrcmp(buffer, "1980-01-06T00:00:00Z"), 0);
   }
 
   {
@@ -636,20 +664,20 @@ TEST(UnitConversion, ConvertAndStringifyImperial)
 
   {
     EXPECT_EQ(vcUnitConversion_ConvertAndFormatArea(buffer, bufSze, imperialVal, vcArea_SquareFoot, &conversionData), udR_Success);
-    EXPECT_EQ(udStrcmp(buffer, "5.733ft sq"), 0);
+    EXPECT_EQ(udStrcmp(buffer, "5.733sqft"), 0);
 
     EXPECT_EQ(vcUnitConversion_ConvertAndFormatArea(buffer, bufSze, imperialVal * 5280.0 * 5280.0, vcArea_SquareFoot, &conversionData), udR_Success);
-    EXPECT_EQ(udStrcmp(buffer, "5.733mi sq"), 0);
+    EXPECT_EQ(udStrcmp(buffer, "5.733sqmi"), 0);
 
     EXPECT_EQ(vcUnitConversion_ConvertAndFormatArea(buffer, bufSze, imperialVal / 5280.0 / 5280.0, vcArea_SquareMiles, &conversionData), udR_Success);
-    EXPECT_EQ(udStrcmp(buffer, "5.733ft sq"), 0);
+    EXPECT_EQ(udStrcmp(buffer, "5.733sqft"), 0);
 
     EXPECT_EQ(vcUnitConversion_ConvertAndFormatArea(buffer, bufSze, imperialVal, vcArea_SquareMiles, &conversionData), udR_Success);
-    EXPECT_EQ(udStrcmp(buffer, "5.733mi sq"), 0);
+    EXPECT_EQ(udStrcmp(buffer, "5.733sqmi"), 0);
   }
 
   {
-    EXPECT_EQ(vcUnitConversion_ConvertAndFormatVolume(buffer, bufSze, imperialVal, vcVolume_USSGallons, &conversionData), udR_Success);
+    EXPECT_EQ(vcUnitConversion_ConvertAndFormatVolume(buffer, bufSze, imperialVal, vcVolume_USGallons, &conversionData), udR_Success);
     EXPECT_EQ(udStrcmp(buffer, "5.733gal US"), 0);
   }
 


### PR DESCRIPTION
Fixes [AB#1846](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1846)

This PR also fixes spelling and formatting inconsistencies in the `vcUnit` enums. In hindsight, this could probably have been a separate PR.