### PR TITLE
Ensuring the current selected point is still valid when removing a point

### DIFF
--- a/src/scene/vcPOI.cpp
+++ b/src/scene/vcPOI.cpp
@@ -994,6 +994,9 @@ void vcPOI::RemovePoint(vcState *pProgramState, int index)
 
   --m_line.numPoints;
 
+  if (m_line.selectedPoint == m_line.numPoints)
+    --m_line.selectedPoint;
+
   UpdatePoints(pProgramState);
   vcProject_UpdateNodeGeometryFromCartesian(m_pProject, m_pNode, pProgramState->geozone, m_pState->GetGeometryType(), m_line.pPoints, m_line.numPoints);
 


### PR DESCRIPTION
Fixes [AB#1842](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1842)