### PR TITLE
Fixed an issue with saving strings correctly in project history.

### DIFF
--- a/src/vcProject.cpp
+++ b/src/vcProject.cpp
@@ -104,6 +104,8 @@ bool vcProject_CreateFileScene(vcState *pProgramState, const char *pPath, const 
   pProgramState->activeProject.pProject = pNewProject;
   vcProject_InitScene(pProgramState, srid);
 
+  vcProject_UpdateProjectHistory(pProgramState, pPath, false);
+
   return true;
 }
 
@@ -121,6 +123,10 @@ bool vcProject_CreateServerScene(vcState *pProgramState, const char *pName, cons
 
   pProgramState->activeProject.pProject = pNewProject;
   vcProject_InitScene(pProgramState, srid);
+
+  const char *pProjectUUID = nullptr;
+  vdkProject_GetProjectUUID(pNewProject, &pProjectUUID);
+  vcProject_UpdateProjectHistory(pProgramState, pProjectUUID, true);
 
   return true;
 }

--- a/src/vcSettings.cpp
+++ b/src/vcSettings.cpp
@@ -884,8 +884,13 @@ bool vcSettings_Save(vcSettings *pSettings)
     vcProjectHistoryInfo *pProjectHistory = &pSettings->projectsHistory.projects[i];
 
     data.Set("projectsHistory.isServerProject[] = %s", pProjectHistory->isServerProject ? "true" : "false");
-    data.Set("projectsHistory.name[] = '%s'", pProjectHistory->pName);
-    data.Set("projectsHistory.path[] = '%s'", pProjectHistory->pPath);
+
+    udJSON temp;
+    temp.SetString(pProjectHistory->pName);
+    data.Set(&temp, "projectsHistory.name[]");
+
+    temp.SetString(pProjectHistory->pPath);
+    data.Set(&temp, "projectsHistory.path[]");
   }
 
   // Save


### PR DESCRIPTION
Server project UUIDs are now correctly saved.

Fixes [AB#1870](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1870)