### PR TITLE
limit the position xyz range to +-1e7 to fix client crash.

### DIFF
--- a/src/scene/vcModel.cpp
+++ b/src/scene/vcModel.cpp
@@ -420,7 +420,12 @@ void vcModel::HandleSceneExplorerUI(vcState *pProgramState, size_t * /*pItemID*/
   ImGui::InputScalarN(vcString::Get("sceneModelPosition"), ImGuiDataType_Double, &position.x, 3);
 
   if (ImGui::IsItemDeactivatedAfterEdit())
+  {
     repackMatrix = true;
+    static udDouble3 minDouble = udDouble3::create(-1e7, -1e7, -1e7);
+    static udDouble3 maxDouble = udDouble3::create(1e7, 1e7, 1e7);
+    position = udClamp(position, minDouble, maxDouble);
+  }    
 
   udDouble3 eulerRotation = UD_RAD2DEG(orientation.eulerAngles());
   ImGui::InputScalarN(vcString::Get("sceneModelRotation"), ImGuiDataType_Double, &eulerRotation.x, 3);

--- a/src/scene/vcPolyModelNode.cpp
+++ b/src/scene/vcPolyModelNode.cpp
@@ -156,7 +156,12 @@ void vcPolyModelNode::HandleSceneExplorerUI(vcState *pProgramState, size_t *pIte
     bool repackMatrix = false;
     ImGui::InputScalarN(vcString::Get("sceneModelPosition"), ImGuiDataType_Double, &position.x, 3);
     if (ImGui::IsItemDeactivatedAfterEdit())
+    {
       repackMatrix = true;
+      static udDouble3 minDouble = udDouble3::create(-1e7, -1e7, -1e7);
+      static udDouble3 maxDouble = udDouble3::create(1e7, 1e7, 1e7);
+      position = udClamp(position, minDouble, maxDouble);
+    }
 
     udDouble3 eulerRotation = UD_RAD2DEG(orientation.eulerAngles());
     ImGui::InputScalarN(vcString::Get("sceneModelRotation"), ImGuiDataType_Double, &eulerRotation.x, 3);


### PR DESCRIPTION
Fixed [AB#1718](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1718).

