### PR TITLE
show hints if the creation of new project fails.

### DIFF
--- a/builds/assets/lang/enAU.json
+++ b/builds/assets/lang/enAU.json
@@ -672,6 +672,7 @@
   "errorReadFailure": "Failed to read.",
   "errorWriteFailure": "Failed to write to file. Drive may be full or file may already be in use.",
   "errorCloseFailure": "Failed to close file. Data may be corrupt.",
+  "errorInvalidParameter": "Wrong input.",
   "settingsScreenshot": "Screenshot",
   "settingsScreenshotResLabel": "Resolution",
   "settingsScreenshotRes720p": "720p",

--- a/builds/assets/lang/zhCN.json
+++ b/builds/assets/lang/zhCN.json
@@ -607,6 +607,7 @@
   "bindingsToggleInspectionTool": "切换查看工具",
   "errorWriteFailure": "文件保存失败。 磁盘已满或者文件正在使用。",
   "errorCloseFailure": "关闭文件失败。数据可能在使用种。",
+  "errorInvalidParameter": "输入错误",
   "settingsScreenshotPathAlert": "第一次创建照片时将会自动创建文件夹。",
   "settingsMissingStrings": "缺少字符串",
   "settingsTranslation": "翻译表",

--- a/src/vcModals.cpp
+++ b/src/vcModals.cpp
@@ -434,6 +434,15 @@ void vcModals_DrawNewProject(vcState *pProgramState)
       //TODO: Additional export settings
     }
 
+    static vdkError result = vE_Success;
+    if (result != vE_Success)
+    {
+      ImGui::NextColumn();
+      ImGui::Spacing();
+      ImGui::Spacing();
+      ImGui::TextColored(ImVec4(1.0, 1.0, 0.5, 1.0), "%s", vcProject_ErrorToString(result));
+    }    
+
     // Position control buttons in the bottom right corner
     ImVec2 windowSize = ImGui::GetWindowSize();
     ImGui::SetCursorPos(ImVec2(windowSize.x - 280, windowSize.y - 30));
@@ -443,39 +452,38 @@ void vcModals_DrawNewProject(vcState *pProgramState)
       {
         pProgramState->modelPath[0] = '\0';
         creatingNewProjectType = -1;
+        result = vE_Success;
         ImGui::CloseCurrentPopup();
       }
     }
     else
     {
       if (ImGui::Button("Back", ImVec2(100.f, 0)))
+      {        
         creatingNewProjectType = -1;
+        result = vE_Success;
+      }
 
       ImGui::SameLine();
       if (ImGui::Button(vcString::Get("modalProjectNewCreate"), ImVec2(150.f, 0)) && vcProject_AbleToChange(pProgramState))
       {
-        bool createSucceeded = false;
         if (localOrServerProject == 0) // local
         {
           // TODO: CONFIRM FILE OVERRIDE IF EXISTS
 
-          createSucceeded = vcProject_CreateFileScene(pProgramState, pProjectPath, pProgramState->modelPath, zoneCustomSRID);
+          result = vcProject_CreateFileScene(pProgramState, pProjectPath, pProgramState->modelPath, zoneCustomSRID);
         }
         else // server
         {
-          createSucceeded = vcProject_CreateServerScene(pProgramState, pProgramState->modelPath, udUUID_GetAsString(selectedGroup), zoneCustomSRID);
+          result = vcProject_CreateServerScene(pProgramState, pProgramState->modelPath, udUUID_GetAsString(selectedGroup), zoneCustomSRID);
         }
 
-        if (createSucceeded)
+        if (vE_Success == result)
         {
           pProgramState->modelPath[0] = '\0';
           creatingNewProjectType = -1;
 
           ImGui::CloseCurrentPopup();
-        }
-        else
-        {
-          // Errors!
         }
       }
     }

--- a/src/vcModals.cpp
+++ b/src/vcModals.cpp
@@ -478,7 +478,7 @@ void vcModals_DrawNewProject(vcState *pProgramState)
           result = vcProject_CreateServerScene(pProgramState, pProgramState->modelPath, udUUID_GetAsString(selectedGroup), zoneCustomSRID);
         }
 
-        if (vE_Success == result)
+        if (result == vE_Success )
         {
           pProgramState->modelPath[0] = '\0';
           creatingNewProjectType = -1;

--- a/src/vcProject.h
+++ b/src/vcProject.h
@@ -27,9 +27,11 @@ enum vcProjectStandardZones
   vcPSZ_WGS84ECEF = 4978
 };
 
+const char* vcProject_ErrorToString(vdkError error);
+
 bool vcProject_CreateBlankScene(vcState *pProgramState, const char *pName, int srid);
-bool vcProject_CreateFileScene(vcState *pProgramState, const char *pPath, const char *pName, int srid);
-bool vcProject_CreateServerScene(vcState *pProgramState, const char *pName, const char *pGroupUUID, int srid);
+vdkError vcProject_CreateFileScene(vcState *pProgramState, const char *pPath, const char *pName, int srid);
+vdkError vcProject_CreateServerScene(vcState *pProgramState, const char *pName, const char *pGroupUUID, int srid);
 
 bool vcProject_LoadFromURI(vcState *pProgramState, const char *pFilename);
 bool vcProject_LoadFromServer(vcState *pProgramState, const char *pProjectID);


### PR DESCRIPTION
The user experience of [AB#1877](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1877) has been improved, but it still needs to be fixed in the VDK. And fixed the empty string comparison when creating a new project.