### PR TITLE
Delete Hotkey now works when scene explorer is collapsed

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2528,6 +2528,9 @@ void vcMain_RenderSceneWindow(vcState *pProgramState)
       ImGui::GetWindowDrawList()->AddImage(pProgramState->pUITexture, ImVec2((float)sceneWindowPos.x, (float)sceneWindowPos.y), ImVec2((float)sceneWindowPos.x + 24, (float)sceneWindowPos.y + 24), ImVec2(0, 0.375), ImVec2(0.09375, 0.46875));
     }
 
+    if (vcHotkey::IsPressed(vcB_Remove) && !ImGui::IsAnyItemActive() && !pProgramState->modalOpen)
+      vcProject_RemoveSelected(pProgramState);
+
     pProgramState->activeProject.pFolder->AddToScene(pProgramState, &renderData);
 
     // Render scene to texture


### PR DESCRIPTION
Fixes [AB#1940](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1940)