### PR TITLE
Use udSprintf instead of udTempStr to avoid using udStrdup

### DIFF
--- a/src/vcSettings.h
+++ b/src/vcSettings.h
@@ -479,9 +479,6 @@ bool vcSettings_Save(vcSettings *pSettings);
 
 void vcSettings_Cleanup(vcSettings *pSettings);
 
-// Uses udTempStr internally.
-const char *vcSettings_GetAssetPath(const char *pFilename);
-
 // Provides a handler for "asset://" files
 udResult vcSettings_RegisterAssetFileHandler();
 


### PR DESCRIPTION
Resolves [AB#1923](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1923)