### PR TITLE
Fixed issue with browser share link not having euclideon: prefix

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1673,7 +1673,7 @@ void vcRenderSceneUI(vcState *pProgramState, const ImVec2 &windowPos, const ImVe
 
           if (vdkProject_GetProjectUUID(pProgramState->activeProject.pProject, &pUUID) == vE_Success)
           {
-            udSprintf(shareLinkBrowser, "%s/client/?f=project/%s", pProgramState->settings.loginInfo.serverURL, pUUID);
+            udSprintf(shareLinkBrowser, "%s/client/?f=euclideon:project/%s", pProgramState->settings.loginInfo.serverURL, pUUID);
             udSprintf(shareLinkApp, "euclideon:project/%s", pUUID);
 
             foundProject = false;


### PR DESCRIPTION
Fixes [AB#1961](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1961)