### PR TITLE
Fixed various issues with the modals

### DIFF
--- a/src/vcProject.cpp
+++ b/src/vcProject.cpp
@@ -473,6 +473,25 @@ bool vcProject_SaveAs(vcState *pProgramState, const char *pPath, bool allowOverr
   return (projectError.resultCode == udR_Success);
 }
 
+vdkError vcProject_SaveAsServer(vcState *pProgramState, const char *pProjectID)
+{
+  if (pProgramState == nullptr || pProjectID == nullptr)
+    return vE_InvalidParameter;
+
+  vcState::ErrorItem projectError = {};
+  projectError.source = vcES_ProjectChange;
+  projectError.pData = udStrdup(pProjectID);
+
+  vdkError result = vdkProject_SaveToServer(pProgramState->pVDKContext, pProgramState->activeProject.pProject, pProjectID);
+  projectError.resultCode = (result == vE_Success ? udR_Success : udR_WriteFailure);
+  pProgramState->errorItems.PushBack(projectError);
+
+  vcModals_OpenModal(pProgramState, vcMT_ProjectChange);
+  vcProject_UpdateProjectHistory(pProgramState, pProjectID, true);
+
+  return result;
+}
+
 bool vcProject_AbleToChange(vcState *pProgramState)
 {
   if (pProgramState == nullptr || !pProgramState->hasContext)

--- a/src/vcProject.h
+++ b/src/vcProject.h
@@ -42,6 +42,7 @@ void vcProject_Deinit(vcState *pProgramData, vcProject *pProject);
 void vcProject_AutoCompletedName(udFilename *exportFilename, const char *pProjectName, const char *pFileName);
 bool vcProject_Save(vcState *pProgramState);
 bool vcProject_SaveAs(vcState *pProgramState, const char *pPath, bool allowOverride);
+vdkError vcProject_SaveAsServer(vcState *pProgramState, const char *pProjectID);
 
 bool vcProject_AbleToChange(vcState *pProgramState);
 


### PR DESCRIPTION
- "Save As" cloud project now closes popup
- "Save As" cloud project now adds new project to recently loaded list
- "Save As" cloud project now loads new project instead of staying on current project
- Loading a local project will now close the load project popup
- Input modal can now be dismissed with cancel key (Esc)
- Input modal only opens once per launch instead of every time the welcome screen is displayed