### PR TITLE
Added better error message for when running on an unsupported architecture

### DIFF
--- a/buildscripts/android/res/values/strings.xml
+++ b/buildscripts/android/res/values/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Euclideon Vault</string>
+    <string name="app_name">udStream</string>
 </resources>

--- a/buildscripts/android/src/com/euclideon/udStream.java
+++ b/buildscripts/android/src/com/euclideon/udStream.java
@@ -1,6 +1,8 @@
 
 package com.euclideon;
 
+import java.io.File;
+
 import android.os.Bundle;
 import android.util.*;
 
@@ -8,14 +10,53 @@ import org.libsdl.app.SDLActivity;
 
 public class udStream extends SDLActivity
 {
-  @Override
-  protected String[] getLibraries() {
+    @Override
+    protected String[] getLibraries() {
         return new String[] {
 //            "hidapi",
             "SDL2",
             "vaultSDK",
             "udStream"
         };
+    }
+
+    public Boolean IsArchitectureSupported()
+    {
+        File nativeLibraryDir = new File(getApplicationInfo().nativeLibraryDir);
+        String[] primaryNativeLibraries = nativeLibraryDir.list();
+        String[] requiredLibraries = getLibraries();
+
+        if (primaryNativeLibraries != null) {
+            for (String reqLib : requiredLibraries) {
+                Boolean found = false;
+                for (String lib : primaryNativeLibraries) {
+                    if (lib.contains(reqLib)) {
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (!found) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public void loadLibraries() {
+        if (!IsArchitectureSupported()) {
+            try {
+                super.loadLibraries();
+            } catch(UnsatisfiedLinkError e) {
+            } catch(Exception e) {
+            }
+            throw new UnsatisfiedLinkError("The architecture of this device is unsupported by this application.");
+        }
+
+        super.loadLibraries();
     }
 
     @Override


### PR DESCRIPTION
- App name is now "udStream" instead of "Euclideon Client"

Fixes AB#1781