### PR TITLE
Fixed an issue with getting the rotations for non projections

### DIFF
--- a/src/vcGIS.cpp
+++ b/src/vcGIS.cpp
@@ -98,6 +98,10 @@ void vcGIS_GetOrthonormalBasis(const udGeoZone &zone, udDouble3 localPosition, u
 
 udDoubleQuat vcGIS_GetQuaternion(const udGeoZone &zone, udDouble3 localPosition)
 {
+  //Flat projections just return the unit quaternion.
+  if (zone.srid != 4978)
+    return udDoubleQuat{0.0, 0.0, 0.0, 1.0};
+
   udDouble3 up, north, east;
   vcGIS_GetOrthonormalBasis(zone, localPosition, &up, &north, &east);
 

--- a/src/vcGIS.cpp
+++ b/src/vcGIS.cpp
@@ -98,19 +98,25 @@ void vcGIS_GetOrthonormalBasis(const udGeoZone &zone, udDouble3 localPosition, u
 
 udDoubleQuat vcGIS_GetQuaternion(const udGeoZone &zone, udDouble3 localPosition)
 {
-  //Flat projections just return the unit quaternion.
-  if (zone.srid != 4978)
-    return udDoubleQuat{0.0, 0.0, 0.0, 1.0};
+  udDoubleQuat q{0.0, 0.0, 0.0, 1.0};
 
-  udDouble3 up, north, east;
-  vcGIS_GetOrthonormalBasis(zone, localPosition, &up, &north, &east);
+  if (zone.projection == udGZPT_LatLong)
+  {
+    q = udDoubleQuat::create(-UD_HALF_PI, 0.0, 0.0);
+  }
+  if (zone.projection == udGZPT_ECEF)
+  {
+    udDouble3 up, north, east;
+    vcGIS_GetOrthonormalBasis(zone, localPosition, &up, &north, &east);
 
-  udDouble4x4 m = udDouble4x4::create(-north.x, -north.y, -north.z, 0,
-                                       east.x,   east.y,   east.z,  0,
-                                       up.x,     up.y,     up.z,    0,
-                                       0,        0,        0,       1);
+    udDouble4x4 m = udDouble4x4::create(-north.x, -north.y, -north.z, 0,
+                                         east.x,   east.y,   east.z,  0,
+                                         up.x,     up.y,     up.z,    0,
+                                         0,        0,        0,       1);
 
-  return m.extractQuaternion();
+    q = m.extractQuaternion();
+  }
+  return q;
 }
 
 udDouble3 vcGIS_GetWorldLocalUp(const udGeoZone &zone, udDouble3 localCoords)

--- a/src/vcGIS.h
+++ b/src/vcGIS.h
@@ -18,7 +18,7 @@ bool vcGIS_SlippyToLocal(const udGeoZone &zone, udDouble3 *pLocalCoords, const u
 
 // Helpers
 void vcGIS_GetOrthonormalBasis(const udGeoZone &zone, udDouble3 localPosition, udDouble3 *pUp, udDouble3 *pNorth, udDouble3 *pEast);
-udDoubleQuat vcGIS_GetQuaternion(const udGeoZone &zone, udDouble3 localPosition); // Get rotational transform from cartesian space to the world position
+udDoubleQuat vcGIS_GetQuaternion(const udGeoZone &zone, udDouble3 localPosition); // Get rotational transform from cartesian space to the world position, where z = up, y = north, x = east in cartesian space
 udDouble3 vcGIS_GetWorldLocalUp(const udGeoZone &zone, udDouble3 localCoords); // Returns which direction is "up" at a given coordinate
 udDouble3 vcGIS_GetWorldLocalNorth(const udGeoZone &zone, udDouble3 localCoords); // Returns which direction is "north"
 udDouble2 vcGIS_QuaternionToHeadingPitch(const udGeoZone &zone, udDouble3 localPosition, udDoubleQuat orientation); // Returns HPR from a Quaternion at a specific location

--- a/vcTesting/src/vcGISTests.cpp
+++ b/vcTesting/src/vcGISTests.cpp
@@ -123,3 +123,17 @@ TEST(vcGIS, LocalAxis)
     EXPECT_TRUE(udEqualApprox(udDouble3::create(0, -1, 0), q.apply({ 0, 0, 1 })));
   }
 }
+
+TEST(vcGIS, NonGeolocatedRotationTests)
+{
+  udGeoZone lZone = {};
+
+  udDouble3 localPosition = udGeoZone_LatLongToCartesian(lZone, {1.0, 2.0, 3.0});
+
+  udGeoZone_SetFromSRID(&lZone, 0); // Non geolocated
+
+  udDoubleQuat q = vcGIS_GetQuaternion(lZone, localPosition);
+  EXPECT_TRUE(udEqualApprox(udDouble3::create(1, 0, 0), q.apply({1, 0, 0})));
+  EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 1, 0), q.apply({0, 1, 0})));
+  EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 0, 1), q.apply({0, 0, 1})));
+}

--- a/vcTesting/src/vcGISTests.cpp
+++ b/vcTesting/src/vcGISTests.cpp
@@ -124,16 +124,125 @@ TEST(vcGIS, LocalAxis)
   }
 }
 
-TEST(vcGIS, NonGeolocatedRotationTests)
+TEST(vcGIS, LocalVectors)
+{
+  udGeoZone zone = {};
+  udDouble3 localPosition = {0.0, 0.0, 0.0};
+
+  // Non geolocated
+  udGeoZone_SetFromSRID(&zone, 0);
+  EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 1, 0), vcGIS_GetWorldLocalNorth(zone, localPosition)));
+  EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 0, 1), vcGIS_GetWorldLocalUp(zone, localPosition)));
+
+  // ECEF
+  udGeoZone_SetFromSRID(&zone, 4978);
+  localPosition = udGeoZone_LatLongToCartesian(zone, {0.0, 0.0, 6371000.0});
+  EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 0, 1), vcGIS_GetWorldLocalNorth(zone, localPosition)));
+  EXPECT_TRUE(udEqualApprox(udDouble3::create(1, 0, 0), vcGIS_GetWorldLocalUp(zone, localPosition)));
+
+  // Long Lat
+  udGeoZone_SetFromSRID(&zone, 84);
+  localPosition = udGeoZone_CartesianToLatLong(zone, {10.0, 20.0, 30.0}, true);
+  EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 1, 0), vcGIS_GetWorldLocalNorth(zone, localPosition)));
+  EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 0, 1), vcGIS_GetWorldLocalUp(zone, localPosition)));
+
+  // Lat long
+  udGeoZone_SetFromSRID(&zone, 4326);
+  localPosition = udGeoZone_CartesianToLatLong(zone, {10.0, 20.0, 30.0});
+  EXPECT_TRUE(udEqualApprox(udDouble3::create(1, 0, 0), vcGIS_GetWorldLocalNorth(zone, localPosition)));
+  EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 0, 1), vcGIS_GetWorldLocalUp(zone, localPosition)));
+  
+  // Transverse Mercator
+  udGeoZone_SetFromSRID(&zone, 32701);
+  localPosition = udGeoZone_CartesianToLatLong(zone, {10.0, 20.0, 30.0}, true);
+  EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 1, 0), vcGIS_GetWorldLocalNorth(zone, localPosition)));
+  EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 0, 1), vcGIS_GetWorldLocalUp(zone, localPosition)));
+
+  // Lambert Conformal Conic 2SP
+  udGeoZone_SetFromSRID(&zone, 2230);
+  localPosition = udGeoZone_CartesianToLatLong(zone, {10.0, 20.0, 30.0}, true);
+  EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 1, 0), vcGIS_GetWorldLocalNorth(zone, localPosition)));
+  EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 0, 1), vcGIS_GetWorldLocalUp(zone, localPosition)));
+
+  // Web Mercator
+  udGeoZone_SetFromSRID(&zone, 3857);
+  localPosition = udGeoZone_CartesianToLatLong(zone, {10.0, 20.0, 30.0}, true);
+  EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 1, 0), vcGIS_GetWorldLocalNorth(zone, localPosition)));
+  EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 0, 1), vcGIS_GetWorldLocalUp(zone, localPosition)));
+}
+
+TEST(vcGIS, RotationTests)
 {
   udGeoZone lZone = {};
+  udDouble3 localPosition = {};
+  udDoubleQuat q = {};
 
-  udDouble3 localPosition = udGeoZone_LatLongToCartesian(lZone, {1.0, 2.0, 3.0});
+  // Non geolocated
+  {
+    udGeoZone_SetFromSRID(&lZone, 0);
 
-  udGeoZone_SetFromSRID(&lZone, 0); // Non geolocated
+    localPosition = {1.0, 2.0, 3.0};
+    q = vcGIS_GetQuaternion(lZone, localPosition);
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(1, 0, 0), q.apply({1, 0, 0})));
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 1, 0), q.apply({0, 1, 0})));
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 0, 1), q.apply({0, 0, 1})));
+  }
 
-  udDoubleQuat q = vcGIS_GetQuaternion(lZone, localPosition);
-  EXPECT_TRUE(udEqualApprox(udDouble3::create(1, 0, 0), q.apply({1, 0, 0})));
-  EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 1, 0), q.apply({0, 1, 0})));
-  EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 0, 1), q.apply({0, 0, 1})));
+  // Lat Long
+  {
+    udGeoZone_SetFromSRID(&lZone, 4326);
+
+    localPosition = {0.0, 0.0, 0.0};;
+    q = vcGIS_GetQuaternion(lZone, localPosition);
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(0, -1, 0), q.apply({1, 0, 0})));
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(1, 0, 0), q.apply({0, 1, 0})));
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 0, 1), q.apply({0, 0, 1})));
+
+    localPosition = {0.0, 90.0, 0.0};
+    q = vcGIS_GetQuaternion(lZone, localPosition);
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(0, -1, 0), q.apply({1, 0, 0})));
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(1, 0, 0), q.apply({0, 1, 0})));
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 0, 1), q.apply({0, 0, 1})));
+
+    localPosition = {0.0, 180.0, 0.0};
+    q = vcGIS_GetQuaternion(lZone, localPosition);
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(0, -1, 0), q.apply({1, 0, 0})));
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(1, 0, 0), q.apply({0, 1, 0})));
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 0, 1), q.apply({0, 0, 1})));
+
+    localPosition = {0.0, -90.0, 6371000.0};
+    q = vcGIS_GetQuaternion(lZone, localPosition);
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(0, -1, 0), q.apply({1, 0, 0})));
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(1, 0, 0), q.apply({0, 1, 0})));
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 0, 1), q.apply({0, 0, 1})));
+  }
+
+  // Long Lat
+  {
+    udGeoZone_SetFromSRID(&lZone, 84);
+
+    localPosition = {0.0, 0.0, 0.0};;
+    q = vcGIS_GetQuaternion(lZone, localPosition);
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(1, 0, 0), q.apply({1, 0, 0})));
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 1, 0), q.apply({0, 1, 0})));
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 0, 1), q.apply({0, 0, 1})));
+
+    localPosition = {90.0, 0.0, 0.0};
+    q = vcGIS_GetQuaternion(lZone, localPosition);
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(1, 0, 0), q.apply({1, 0, 0})));
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 1, 0), q.apply({0, 1, 0})));
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 0, 1), q.apply({0, 0, 1})));
+
+    localPosition = {180.0, 0.0, 0.0};
+    q = vcGIS_GetQuaternion(lZone, localPosition);
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(1, 0, 0), q.apply({1, 0, 0})));
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 1, 0), q.apply({0, 1, 0})));
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 0, 1), q.apply({0, 0, 1})));
+
+    localPosition = {-90.0, 0.0, 0.0};
+    q = vcGIS_GetQuaternion(lZone, localPosition);
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(1, 0, 0), q.apply({1, 0, 0})));
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 1, 0), q.apply({0, 1, 0})));
+    EXPECT_TRUE(udEqualApprox(udDouble3::create(0, 0, 1), q.apply({0, 0, 1})));
+  }
 }


### PR DESCRIPTION
`vcGIS_GetQuaternion()` now returns the unit quaternion for all projections but ECEF. Indeed this function was specifically written for just ECEF.