### PR TITLE
SDL2 message boxes now use default colour scheme instead

### DIFF
--- a/src/vcConvert.cpp
+++ b/src/vcConvert.cpp
@@ -84,20 +84,6 @@ uint32_t vcConvert_Thread(void *pVoidState)
           { SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT, 1, "Yes" },
         };
 
-        SDL_MessageBoxColorScheme colorScheme = {
-          { /* .colors (.r, .g, .b) */
-            /* [SDL_MESSAGEBOX_COLOR_BACKGROUND] */
-            { 255, 0, 0 },
-            /* [SDL_MESSAGEBOX_COLOR_TEXT] */
-            { 0, 255, 0 },
-            /* [SDL_MESSAGEBOX_COLOR_BUTTON_BORDER] */
-            { 255, 255, 0 },
-            /* [SDL_MESSAGEBOX_COLOR_BUTTON_BACKGROUND] */
-            { 0, 0, 255 },
-            /* [SDL_MESSAGEBOX_COLOR_BUTTON_SELECTED] */
-            { 255, 0, 255 }
-          }
-        };
         pFileExistsMsg = vcStringFormat(vcString::Get("convertFileExistsMessage"), pItem->pConvertInfo->pOutputName);
         SDL_MessageBoxData messageboxdata = {
           SDL_MESSAGEBOX_INFORMATION, /* .flags */
@@ -106,7 +92,7 @@ uint32_t vcConvert_Thread(void *pVoidState)
           pFileExistsMsg, /* .message */
           SDL_arraysize(buttons), /* .numbuttons */
           buttons, /* .buttons */
-          &colorScheme /* .colorScheme */
+          nullptr /* .colorScheme */
         };
 
         // Skip this item if the user declines to override

--- a/src/vcModals.cpp
+++ b/src/vcModals.cpp
@@ -64,15 +64,6 @@ bool vcModals_OverwriteExistingFile(vcState *pProgramState, const char *pFilenam
       { SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT, 0, vcString::Get("popupConfirmNo") },
       { SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT, 1, vcString::Get("popupConfirmYes") },
     };
-    SDL_MessageBoxColorScheme colorScheme = {
-      {
-        { 255, 0, 0 },
-        { 0, 255, 0 },
-        { 255, 255, 0 },
-        { 0, 0, 255 },
-        { 255, 0, 255 }
-      }
-    };
     pFileExistsMsg = vcStringFormat(vcString::Get("convertFileExistsMessage"), pFilename);
     SDL_MessageBoxData messageboxdata = {
       SDL_MESSAGEBOX_INFORMATION,
@@ -81,7 +72,7 @@ bool vcModals_OverwriteExistingFile(vcState *pProgramState, const char *pFilenam
       pFileExistsMsg,
       SDL_arraysize(buttons),
       buttons,
-      &colorScheme
+      nullptr
     };
     int buttonid = 0;
     if (SDL_ShowMessageBox(&messageboxdata, &buttonid) != 0 || buttonid == 0)
@@ -108,16 +99,6 @@ bool vcModals_AllowDestructiveAction(vcState *pProgramState, const char *pTitle,
     { SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT, 1, vcString::Get("popupConfirmYes") },
   };
 
-  SDL_MessageBoxColorScheme colorScheme = {
-    {
-      { 255, 0, 0 },
-      { 0, 255, 0 },
-      { 255, 255, 0 },
-      { 0, 0, 255 },
-      { 255, 0, 255 }
-    }
-  };
-
   SDL_MessageBoxData messageboxdata = {
     SDL_MESSAGEBOX_WARNING,
     pProgramState->pWindow,
@@ -125,7 +106,7 @@ bool vcModals_AllowDestructiveAction(vcState *pProgramState, const char *pTitle,
     pMessage,
     SDL_arraysize(buttons),
     buttons,
-    &colorScheme
+    nullptr
   };
 
   int buttonid = 0;


### PR DESCRIPTION
Fixes [AB#1994](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1994)