### PR TITLE
Input info modal will now only display if the user has used the mouse

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -297,6 +297,19 @@ void vcMain_MainLoop(vcState *pProgramState)
     if (event.type == SDL_KEYDOWN)
       pProgramState->currentKey = vcHotkey::GetMod(event.key.keysym.scancode);
 
+    if (!pProgramState->hasUsedMouse)
+    {
+      if ((event.type == SDL_MOUSEBUTTONDOWN || event.type == SDL_MOUSEBUTTONUP) && event.button.which != SDL_TOUCH_MOUSEID)
+        pProgramState->hasUsedMouse = true;
+
+      // When SDL_WarpMouseInWindow or SDL_WarpMouseGlobal is called on startup, it triggers this event with no motion
+      if (event.type == SDL_MOUSEMOTION && event.motion.which != SDL_TOUCH_MOUSEID && (event.motion.x != 0 || event.motion.xrel != 0 || event.motion.y != 0 || event.motion.yrel != 0))
+        pProgramState->hasUsedMouse = true;
+
+      if (event.type == SDL_MOUSEWHEEL && event.wheel.which != SDL_TOUCH_MOUSEID)
+        pProgramState->hasUsedMouse = true;
+    }
+
     if (!ImGui_ImplSDL2_ProcessEvent(&event))
     {
       if (event.type == SDL_WINDOWEVENT)

--- a/src/vcModals.cpp
+++ b/src/vcModals.cpp
@@ -1762,7 +1762,7 @@ void vcModals_DrawModals(vcState *pProgramState)
   vcModals_DrawChangePassword(pProgramState);
   vcModals_DrawConvert(pProgramState);
 
-  if (gShowInputControlsNextHack && !pProgramState->modalOpen)
+  if (gShowInputControlsNextHack && !pProgramState->modalOpen && pProgramState->hasUsedMouse)
   {
     gShowInputControlsNextHack = false;
     vcModals_OpenModal(pProgramState, vcMT_ShowInputInfo);

--- a/src/vcState.h
+++ b/src/vcState.h
@@ -108,6 +108,7 @@ struct vcState
   SDL_Window *pWindow;
   vcFramebuffer *pDefaultFramebuffer;
 
+  bool hasUsedMouse;
   bool openSettings;
   int activeSetting;
 


### PR DESCRIPTION
Fixes [AB#1991](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1991)