### PR TITLE
GIS zone changes now change all viewport cameras

### DIFF
--- a/src/scene/vcFolder.cpp
+++ b/src/scene/vcFolder.cpp
@@ -306,13 +306,13 @@ void vcFolder::HandleSceneExplorerUI(vcState *pProgramState, size_t *pItemID)
 
         if (pSceneItem->m_pPreferredProjection != nullptr && pSceneItem->m_pPreferredProjection->srid != 0 && ImGui::Selectable(vcString::Get("sceneExplorerUseProjection")))
         {
+          bool success = false;
           for (int viewportIndex = 0; viewportIndex < pProgramState->activeViewportCount; ++viewportIndex)
-          {
-            if (vcGIS_ChangeSpace(&pProgramState->geozone, *pSceneItem->m_pPreferredProjection, &pProgramState->pViewports[viewportIndex].camera.position))
-            {
-              pProgramState->activeProject.pFolder->ChangeProjection(*pSceneItem->m_pPreferredProjection);
-            }
-          }
+            success = vcGIS_ChangeSpace(&pProgramState->geozone, *pSceneItem->m_pPreferredProjection, &pProgramState->pViewports[viewportIndex].camera.position, viewportIndex + 1 == pProgramState->activeViewportCount) || success;
+
+          if (success)
+            pProgramState->activeProject.pFolder->ChangeProjection(*pSceneItem->m_pPreferredProjection);
+
         }
 
         if (pNode->itemtype != udPNT_Folder && pSceneItem->GetWorldSpacePivot() != udDouble3::zero() && ImGui::Selectable(vcString::Get("sceneExplorerMoveTo")))

--- a/src/vcGIS.cpp
+++ b/src/vcGIS.cpp
@@ -10,12 +10,13 @@ bool vcGIS_AcceptableSRID(int32_t sridCode)
   return (udGeoZone_SetFromSRID(&zone, sridCode) == udR_Success);
 }
 
-bool vcGIS_ChangeSpace(udGeoZone *pZone, const udGeoZone &newZone, udDouble3 *pCameraPosition /*= nullptr*/)
+bool vcGIS_ChangeSpace(udGeoZone *pZone, const udGeoZone &newZone, udDouble3 *pCameraPosition /*= nullptr*/, bool changeZone /*= true*/)
 {
   if (pCameraPosition != nullptr)
     *pCameraPosition = udGeoZone_TransformPoint(*pCameraPosition, *pZone, newZone);
 
-  *pZone = newZone;
+  if (changeZone)
+    *pZone = newZone;
 
   return true;
 }

--- a/src/vcGIS.h
+++ b/src/vcGIS.h
@@ -7,7 +7,7 @@
 bool vcGIS_AcceptableSRID(int32_t sridCode);
 
 // Changes pSpace from its current zone to the new zone, pCameraPosition if set gets moved to the new zone
-bool vcGIS_ChangeSpace(udGeoZone *pGeozone, const udGeoZone &newZone, udDouble3 *pCameraPosition = nullptr);
+bool vcGIS_ChangeSpace(udGeoZone *pGeozone, const udGeoZone &newZone, udDouble3 *pCameraPosition = nullptr, bool changeZone = true);
 
 bool vcGIS_LatLongToSlippy(udInt2 *pSlippyCoords, udDouble3 latLong, int zoomLevel);
 bool vcGIS_LatLongToSlippy(udDouble2 *pSlippyCoords, udDouble3 latLong, int zoomLevel);

--- a/src/vcSettingsUI.cpp
+++ b/src/vcSettingsUI.cpp
@@ -718,7 +718,10 @@ void vcSettingsUI_BasicMapSettings(vcState *pProgramState, bool alwaysShowOption
         {
           udGeoZone zone = {};
           udGeoZone_SetFromSRID(&zone, newSRID);
-          vcGIS_ChangeSpace(&pProgramState->geozone, zone, &pProgramState->pActiveViewport->camera.position);
+
+          for (int viewportIndex = 0; viewportIndex < pProgramState->activeViewportCount; ++viewportIndex)
+            vcGIS_ChangeSpace(&pProgramState->geozone, zone, &pProgramState->pViewports[viewportIndex].camera.position, viewportIndex + 1 == pProgramState->activeViewportCount);
+
           pProgramState->activeProject.pFolder->ChangeProjection(zone);
         }
       }


### PR DESCRIPTION
Fixed an issue with scene context menu, when opening on a failed pick.

Fixes [AB#2051](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2051)
Fixes [AB#2034](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2034)