### PR TITLE
Jproust/zup yup

### DIFF
--- a/builds/assets/lang/enAU.json
+++ b/builds/assets/lang/enAU.json
@@ -774,5 +774,6 @@
   "shareStatusPublic": "This project is in a public group and can be opened by anyone on the server.",
   "shareStatusShared": "This project can be opened by anyone on the server using the share code or browser link.",
   "shareStatusNotShared": "This project can only be opened by people in the same group.",
-  "_last": "Last item so no one forgets the comma on the line above"
+  "_last": "Last item so no one forgets the comma on the line above",
+  "yUp": "Y up"
 }

--- a/builds/assets/lang/enAU.json
+++ b/builds/assets/lang/enAU.json
@@ -774,6 +774,6 @@
   "shareStatusPublic": "This project is in a public group and can be opened by anyone on the server.",
   "shareStatusShared": "This project can be opened by anyone on the server using the share code or browser link.",
   "shareStatusNotShared": "This project can only be opened by people in the same group.",
-  "_last": "Last item so no one forgets the comma on the line above",
-  "yUp": "Y up"
+  "yUp": "Y up",
+  "_last": "Last item so no one forgets the comma on the line above"
 }

--- a/src/scene/vcPolyModelNode.cpp
+++ b/src/scene/vcPolyModelNode.cpp
@@ -10,7 +10,6 @@
 #include "imgui.h"
 #include "imgui_ex/vcImGuiSimpleWidgets.h"
 
-
 struct vcPolygonModelLoadInfo
 {
   vcState *pProgramState;
@@ -73,7 +72,6 @@ void vcPolyModelNode::OnNodeUpdate(vcState *pProgramState)
   }
 
   vcProject_GetNodeMetadata(m_pNode, "ignoreTint", &m_ignoreTint, false);
-
   vcProject_GetNodeMetadata(m_pNode, "yUp", &m_flipAxis, false);
 
   if (m_pNode->geomCount != 0)
@@ -187,7 +185,6 @@ void vcPolyModelNode::HandleSceneExplorerUI(vcState *pProgramState, size_t *pIte
       orientation = udDoubleQuat::create(UD_DEG2RAD(eulerRotation));
       repackMatrix = true;
     }
-
 
     if (repackMatrix)
     {

--- a/src/scene/vcPolyModelNode.cpp
+++ b/src/scene/vcPolyModelNode.cpp
@@ -10,6 +10,7 @@
 #include "imgui.h"
 #include "imgui_ex/vcImGuiSimpleWidgets.h"
 
+
 struct vcPolygonModelLoadInfo
 {
   vcState *pProgramState;
@@ -39,6 +40,7 @@ vcPolyModelNode::vcPolyModelNode(vcProject *pProject, udProjectNode *pNode, vcSt
   m_cullFace = vcGLSCM_Back;
   m_ignoreTint = false;
   m_loadStatus = vcSLS_Pending;
+  m_flipAxis = false;
 
   vcPolygonModelLoadInfo *pLoadInfo = udAllocType(vcPolygonModelLoadInfo, 1, udAF_Zero);
   if (pLoadInfo != nullptr)
@@ -71,6 +73,8 @@ void vcPolyModelNode::OnNodeUpdate(vcState *pProgramState)
   }
 
   vcProject_GetNodeMetadata(m_pNode, "ignoreTint", &m_ignoreTint, false);
+
+  vcProject_GetNodeMetadata(m_pNode, "yUp", &m_flipAxis, false);
 
   if (m_pNode->geomCount != 0)
   {
@@ -174,6 +178,16 @@ void vcPolyModelNode::HandleSceneExplorerUI(vcState *pProgramState, size_t *pIte
     ImGui::InputScalarN(vcString::Get("sceneModelScale"), ImGuiDataType_Double, &scale.x, 3);
     if (ImGui::IsItemDeactivatedAfterEdit())
       repackMatrix = true;
+
+    if (ImGui::Checkbox(udTempStr("%s##%zu", vcString::Get("yUp"), *pItemID), &m_flipAxis))
+    {
+      udProjectNode_SetMetadataBool(m_pNode, "yUp", m_flipAxis);
+      eulerRotation.y = m_flipAxis ? 90.0 : 0.0;
+      eulerRotation.z = 0.0;
+      orientation = udDoubleQuat::create(UD_DEG2RAD(eulerRotation));
+      repackMatrix = true;
+    }
+
 
     if (repackMatrix)
     {

--- a/src/scene/vcPolyModelNode.h
+++ b/src/scene/vcPolyModelNode.h
@@ -32,6 +32,7 @@ private:
 
   vcGLStateCullMode m_cullFace;
   bool m_ignoreTint;
+  bool m_flipAxis;
 };
 
 #endif //vcPolyModelNode_h__


### PR DESCRIPTION
Added a "Y up" checkbox in the scene explorer for PolyModels to rotate the model so that the Y axis is up (instead of Z axis by default)
Fixes [AB#1912](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1912)