### PR TITLE
Avoid 0 scale in the scene explorer.

### DIFF
--- a/src/scene/vcModel.cpp
+++ b/src/scene/vcModel.cpp
@@ -441,8 +441,7 @@ void vcModel::HandleSceneExplorerUI(vcState *pProgramState, size_t * /*pItemID*/
   if (ImGui::IsItemDeactivatedAfterEdit())
   {
     repackMatrix = true;
-    if (scale.x == 0.0f)
-      scale.x = 1e-7; // Simple Hack to avoid 0 scale
+    scale.x = udMax(scale.x, 1e-7);
   }
 
   if (repackMatrix)

--- a/src/scene/vcModel.cpp
+++ b/src/scene/vcModel.cpp
@@ -439,7 +439,11 @@ void vcModel::HandleSceneExplorerUI(vcState *pProgramState, size_t * /*pItemID*/
   ImGui::InputScalarN(vcString::Get("sceneModelScale"), ImGuiDataType_Double, &scale.x, 1);
 
   if (ImGui::IsItemDeactivatedAfterEdit())
+  {
     repackMatrix = true;
+    if (scale.x == 0.0f)
+      scale.x = 1e-7; // Simple Hack to avoid 0 scale
+  }
 
   if (repackMatrix)
   {


### PR DESCRIPTION
Added a test on the model scale, if set to 0 the value is set to 1e-7 so that its square is 1e-14 which is still in the Double type limit.
Fixes [AB#2044](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2044)