### PR TITLE
Changed SceneExplorer SphereFilter Size to use a UnputScalarN

### DIFF
--- a/src/scene/vcQueryNode.cpp
+++ b/src/scene/vcQueryNode.cpp
@@ -172,7 +172,7 @@ void vcQueryNode::HandleSceneExplorerUI(vcState *pProgramState, size_t *pItemID)
   }
   else // Is a sphere
   {
-    ImGui::InputDouble(udTempStr("%s##FilterExtents%zu", vcString::Get("sceneFilterExtents"), *pItemID), &m_extents.x);
+    ImGui::InputScalarN(udTempStr("%s##FilterExtents%zu", vcString::Get("sceneFilterExtents"), *pItemID), ImGuiDataType_Double, &m_extents.x, 1);
     changed |= ImGui::IsItemDeactivatedAfterEdit();
   }
 


### PR DESCRIPTION
InputDouble let the user use scientific numbers that can be above the Double type limit. 
Fixes AB#2055