### PR TITLE
X & Y axis of a Scale Gizmo of a Cylinder filter now share the same value

### DIFF
--- a/src/scene/vcQueryNode.cpp
+++ b/src/scene/vcQueryNode.cpp
@@ -135,6 +135,12 @@ void vcQueryNode::ApplyDelta(vcState *pProgramState, const udDouble4x4 &delta)
   m_ypr = matrix.extractYPR();
   m_center = matrix.axis.t.toVector3();
   m_extents = udDouble3::create(udMag3(matrix.axis.x), udMag3(matrix.axis.y), udMag3(matrix.axis.z));
+
+  // Hack: a cylinder only scale on the x axis
+  if (m_shape == vcQNFS_Cylinder && delta.axis.y[1] == 1.0f)
+    m_extents.x = m_extents.y;
+  else if (m_shape == vcQNFS_Cylinder)// avoid jump in scale when swapping between the X & Y axis
+    m_extents.y = m_extents.x;
   
   vcProject_UpdateNodeGeometryFromCartesian(m_pProject, m_pNode, pProgramState->geozone, udPGT_Point, &m_center, 1);
 


### PR DESCRIPTION
Fixes [AB#2061](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2061)