### PR TITLE
Added a 'geoverse style map mode' for the 2nd viewport

### DIFF
--- a/builds/assets/lang/enAU.json
+++ b/builds/assets/lang/enAU.json
@@ -401,7 +401,7 @@
   "menuBarWaitingForRenderLicense": "Waiting for Render license...",
   "menuBarNoRenderLicense": "No Render licenses are available for this user",
   "menuBarInactive": "Inactive",
-  "orthographicCameraViewport": "Orthographic Second Camera (Geoverse style)",
+  "orthographicCameraViewport": "Map Mode",
   "selectedItemInfoPanelitemsSelected": "items selected",
   "popupMenuCopy": "Copy",
   "popupMenuPaste": "Paste",

--- a/builds/assets/lang/enAU.json
+++ b/builds/assets/lang/enAU.json
@@ -401,6 +401,7 @@
   "menuBarWaitingForRenderLicense": "Waiting for Render license...",
   "menuBarNoRenderLicense": "No Render licenses are available for this user",
   "menuBarInactive": "Inactive",
+  "orthographicCameraViewport": "Orthographic Second Camera (Geoverse style)",
   "selectedItemInfoPanelitemsSelected": "items selected",
   "popupMenuCopy": "Copy",
   "popupMenuPaste": "Paste",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1504,7 +1504,7 @@ void vcRenderSceneUI(vcState *pProgramState, const ImVec2 &windowPos, const ImVe
 
       // TODO: Putting this here for now
       if (pProgramState->settings.activeViewportCount > 1)
-        ImGui::Checkbox(udTempStr("%s##orthographicCameraViewport", vcString::Get("orthographicCameraViewport")), &pProgramState->settings.viewports[1].mapMode);
+        ImGui::Checkbox(udTempStr("%s##secondViewportMapMode", vcString::Get("secondViewportMapMode")), &pProgramState->settings.viewports[1].mapMode);
     }
 
     ImGui::End();

--- a/src/scene/vcFolder.cpp
+++ b/src/scene/vcFolder.cpp
@@ -307,8 +307,8 @@ void vcFolder::HandleSceneExplorerUI(vcState *pProgramState, size_t *pItemID)
         if (pSceneItem->m_pPreferredProjection != nullptr && pSceneItem->m_pPreferredProjection->srid != 0 && ImGui::Selectable(vcString::Get("sceneExplorerUseProjection")))
         {
           bool success = false;
-          for (int viewportIndex = 0; viewportIndex < pProgramState->activeViewportCount; ++viewportIndex)
-            success = vcGIS_ChangeSpace(&pProgramState->geozone, *pSceneItem->m_pPreferredProjection, &pProgramState->pViewports[viewportIndex].camera.position, viewportIndex + 1 == pProgramState->activeViewportCount) || success;
+          for (int viewportIndex = 0; viewportIndex < pProgramState->settings.activeViewportCount; ++viewportIndex)
+            success = vcGIS_ChangeSpace(&pProgramState->geozone, *pSceneItem->m_pPreferredProjection, &pProgramState->pViewports[viewportIndex].camera.position, viewportIndex + 1 == pProgramState->settings.activeViewportCount) || success;
 
           if (success)
             pProgramState->activeProject.pFolder->ChangeProjection(*pSceneItem->m_pPreferredProjection);

--- a/src/scene/vcMedia.cpp
+++ b/src/scene/vcMedia.cpp
@@ -217,7 +217,7 @@ void vcMedia::AddToScene(vcState *pProgramState, vcRenderData *pRenderData)
 
       double worldScale = 1.0;
       if (m_image.size == vcIS_Native)
-        worldScale = (double)imageSize.x / pProgramState->pActiveViewport->resolution.x;
+        worldScale = (double)imageSize.x / pProgramState->settings.viewports[pProgramState->activeViewportIndex].resolution.x;
       else
         worldScale = vcISToWorldSize[m_image.size];
 
@@ -351,7 +351,7 @@ void vcMedia::Cleanup(vcState * /*pProgramState*/)
 
 void vcMedia::SetCameraPosition(vcState *pProgramState)
 {
-  for (int viewportIndex = 0; viewportIndex < pProgramState->activeViewportCount; ++viewportIndex)
+  for (int viewportIndex = 0; viewportIndex < pProgramState->settings.activeViewportCount; ++viewportIndex)
     pProgramState->pViewports[viewportIndex].camera.position = m_image.position;
 }
 

--- a/src/scene/vcPOI.cpp
+++ b/src/scene/vcPOI.cpp
@@ -1043,7 +1043,7 @@ void vcPOI::SetCameraPosition(vcState *pProgramState)
   if (!m_attachment.pModel)
     newPosition = m_pLabelInfo->worldPosition;
 
-  for (int viewportIndex = 0; viewportIndex < pProgramState->activeViewportCount; ++viewportIndex)
+  for (int viewportIndex = 0; viewportIndex < pProgramState->settings.activeViewportCount; ++viewportIndex)
     pProgramState->pViewports[viewportIndex].camera.position = newPosition;
 
 }

--- a/src/scene/vcSceneItem.cpp
+++ b/src/scene/vcSceneItem.cpp
@@ -68,7 +68,7 @@ void vcSceneItem::HandleToolUI(vcState * /*pProgramState*/)
 
 void vcSceneItem::SetCameraPosition(vcState *pProgramState)
 {
-  for (int viewportIndex = 0; viewportIndex < pProgramState->activeViewportCount; ++viewportIndex)
+  for (int viewportIndex = 0; viewportIndex < pProgramState->settings.activeViewportCount; ++viewportIndex)
     pProgramState->pViewports[viewportIndex].camera.position = GetWorldSpacePivot();
 }
 

--- a/src/scene/vcViewpoint.cpp
+++ b/src/scene/vcViewpoint.cpp
@@ -134,6 +134,7 @@ void vcViewpoint::SetCameraPosition(vcState *pProgramState)
   }
 
   for (int viewportIndex = 0; viewportIndex < pProgramState->activeViewportCount; ++viewportIndex)
+  for (int viewportIndex = 0; viewportIndex < pProgramState->settings.activeViewportCount; ++viewportIndex)
   {
     pProgramState->pViewports[viewportIndex].camera.position = m_CameraPosition;
     pProgramState->pViewports[viewportIndex].camera.headingPitch = m_CameraHeadingPitch;

--- a/src/scene/vcViewpoint.cpp
+++ b/src/scene/vcViewpoint.cpp
@@ -133,7 +133,6 @@ void vcViewpoint::SetCameraPosition(vcState *pProgramState)
       pProgramState->settings.camera.keepAboveSurface = false;
   }
 
-  for (int viewportIndex = 0; viewportIndex < pProgramState->activeViewportCount; ++viewportIndex)
   for (int viewportIndex = 0; viewportIndex < pProgramState->settings.activeViewportCount; ++viewportIndex)
   {
     pProgramState->pViewports[viewportIndex].camera.position = m_CameraPosition;

--- a/src/vcProject.cpp
+++ b/src/vcProject.cpp
@@ -36,7 +36,7 @@ void vcProject_InitScene(vcState *pProgramState, int srid)
   udGeoZone zone = {};
   vcGIS_ChangeSpace(&pProgramState->geozone, zone);
 
-  for (int viewportIndex = 0; viewportIndex < pProgramState->activeViewportCount; ++viewportIndex)
+  for (int viewportIndex = 0; viewportIndex < pProgramState->settings.activeViewportCount; ++viewportIndex)
   {
     pProgramState->pViewports[viewportIndex].camera.position = udDouble3::zero();
     pProgramState->pViewports[viewportIndex].camera.headingPitch = udDouble2::zero();
@@ -76,7 +76,7 @@ void vcProject_InitScene(vcState *pProgramState, int srid)
       int randomIndex = (int)(seed % length);
       double *pPlace = locations[randomIndex];
 
-      for (int viewportIndex = 0; viewportIndex < pProgramState->activeViewportCount; ++viewportIndex)
+      for (int viewportIndex = 0; viewportIndex < pProgramState->settings.activeViewportCount; ++viewportIndex)
       {
         pProgramState->pViewports[viewportIndex].camera.position = udDouble3::create(pPlace[0], pPlace[1], pPlace[2]);
         pProgramState->pViewports[viewportIndex].camera.headingPitch = { UD_DEG2RAD(pPlace[3]), UD_DEG2RAD(pPlace[4]) };
@@ -84,7 +84,7 @@ void vcProject_InitScene(vcState *pProgramState, int srid)
     }
     else
     {
-      for (int viewportIndex = 0; viewportIndex < pProgramState->activeViewportCount; ++viewportIndex)
+      for (int viewportIndex = 0; viewportIndex < pProgramState->settings.activeViewportCount; ++viewportIndex)
       {
         pProgramState->pViewports[viewportIndex].camera.position = udGeoZone_LatLongToCartesian(cameraZone, udDouble3::create((cameraZone.latLongBoundMin + cameraZone.latLongBoundMax) / 2.0, 10000.0));
         pProgramState->pViewports[viewportIndex].camera.headingPitch = { 0.0, UD_DEG2RAD(-80.0) };
@@ -186,7 +186,7 @@ bool vcProject_ExtractCameraRecursive(vcState *pProgramState, udProjectNode *pPa
       udProjectNode_GetMetadataDouble(pNode, "transform.heading", &headingPitch.x, 0.0);
       udProjectNode_GetMetadataDouble(pNode, "transform.pitch", &headingPitch.y, 0.0);
 
-      for (int viewportIndex = 0; viewportIndex < pProgramState->activeViewportCount; ++viewportIndex)
+      for (int viewportIndex = 0; viewportIndex < pProgramState->settings.activeViewportCount; ++viewportIndex)
       {
         pProgramState->pViewports[viewportIndex].camera.position = position;
         pProgramState->pViewports[viewportIndex].camera.headingPitch = headingPitch;
@@ -213,7 +213,7 @@ bool vcProject_ExtractCameraRecursive(vcState *pProgramState, udProjectNode *pPa
 // Try extract a valid viewpoint from the project, based on available nodes
 void vcProject_ExtractCamera(vcState *pProgramState)
 {
-  for (int viewportIndex = 0; viewportIndex < pProgramState->activeViewportCount; ++viewportIndex)
+  for (int viewportIndex = 0; viewportIndex < pProgramState->settings.activeViewportCount; ++viewportIndex)
   {
     pProgramState->pViewports[viewportIndex].camera.position = udDouble3::zero();
     pProgramState->pViewports[viewportIndex].camera.headingPitch = udDouble2::zero();

--- a/src/vcRender.cpp
+++ b/src/vcRender.cpp
@@ -1235,7 +1235,7 @@ void vcRender_RenderUI(vcState *pProgramState, vcRenderContext *pRenderContext, 
   }
 
   // Pins
-  vcPinRenderer_Render(pRenderContext->pPinRenderer, pProgramState->pActiveViewport->camera.matrices.viewProjection, pProgramState->pActiveViewport->resolution, renderData.labels);
+  vcPinRenderer_Render(pRenderContext->pPinRenderer, pProgramState->pActiveViewport->camera.matrices.viewProjection, pProgramState->settings.viewports[pProgramState->activeViewportIndex].resolution, renderData.labels);
 
   // Labels
   uint32_t labelIds = vcObjectId_SceneItems + (uint32_t)(renderData.polyModels.length + renderData.images.length);
@@ -1243,7 +1243,7 @@ void vcRender_RenderUI(vcState *pProgramState, vcRenderContext *pRenderContext, 
   for (uint32_t i = 0; i < renderData.labels.length; ++i)
   {
     float encodedLabelId = vcRender_EncodeModelId(labelIds + i);
-    vcLabelRenderer_Render(drawList, renderData.labels[i], encodedLabelId, pProgramState->pActiveViewport->camera.matrices.viewProjection, pProgramState->pActiveViewport->resolution);
+    vcLabelRenderer_Render(drawList, renderData.labels[i], encodedLabelId, pProgramState->pActiveViewport->camera.matrices.viewProjection, pProgramState->settings.viewports[pProgramState->activeViewportIndex].resolution);
   }
 
   vcGLState_ResetState();
@@ -1258,7 +1258,7 @@ void vcRender_TransparentPass(vcState *pProgramState, vcRenderContext *pRenderCo
   vcGLState_SetFaceMode(vcGLSFM_Solid, vcGLSCM_None);
   udDouble4 nearPlane = vcCamera_GetNearPlane(pProgramState->pActiveViewport->camera, pProgramState->settings.camera);
   for (size_t i = 0; i < renderData.lines.length; ++i)
-    vcLineRenderer_Render(pRenderContext->pLineRenderer, renderData.lines[i], pProgramState->pActiveViewport->camera.matrices.viewProjection, pProgramState->pActiveViewport->resolution, nearPlane);
+    vcLineRenderer_Render(pRenderContext->pLineRenderer, renderData.lines[i], pProgramState->pActiveViewport->camera.matrices.viewProjection, pProgramState->settings.viewports[pProgramState->activeViewportIndex].resolution, nearPlane);
 
   // Images
   {

--- a/src/vcSession.cpp
+++ b/src/vcSession.cpp
@@ -285,7 +285,7 @@ void vcSession_GetProfileInfoWT(void *pProgramStatePtr)
 
 void vcSession_ChangeSession(vcState *pProgramState)
 {
-  for (int viewportIndex = 0; viewportIndex < pProgramState->activeViewportCount; ++viewportIndex)
+  for (int viewportIndex = 0; viewportIndex < pProgramState->settings.activeViewportCount; ++viewportIndex)
     vcRender_SetVaultContext(pProgramState, pProgramState->pViewports[viewportIndex].pRenderContext);
   udContext_GetSessionInfo(pProgramState->pUDSDKContext, &pProgramState->sessionInfo);
 
@@ -398,7 +398,7 @@ void vcSession_Logout(vcState *pProgramState)
     vcSession_CleanupSession(pProgramState);
     pProgramState->profileInfo.Destroy();
 
-    for (int viewportIndex = 0; viewportIndex < pProgramState->activeViewportCount; ++viewportIndex)
+    for (int viewportIndex = 0; viewportIndex < pProgramState->settings.activeViewportCount; ++viewportIndex)
       vcRender_RemoveVaultContext(pProgramState->pViewports[viewportIndex].pRenderContext);
     udContext_Disconnect(&pProgramState->pUDSDKContext, pProgramState->forceLogout);
 

--- a/src/vcSettings.cpp
+++ b/src/vcSettings.cpp
@@ -638,7 +638,7 @@ bool vcSettings_Load(vcSettings *pSettings, bool forceReset /*= false*/, vcSetti
     for (int viewportIndex = 0; viewportIndex < vcMaxViewportCount; ++viewportIndex)
     {
       pSettings->viewports[viewportIndex].resolution.x = data.Get("viewports.viewport[%d].width", viewportIndex).AsInt(128);
-      pSettings->viewports[viewportIndex].resolution.y = data.Get("viewports.viewport[% d].height", viewportIndex).AsInt(128);
+      pSettings->viewports[viewportIndex].resolution.y = data.Get("viewports.viewport[%d].height", viewportIndex).AsInt(128);
       pSettings->viewports[viewportIndex].mapMode = data.Get("viewports.viewport[%d].mapMode", viewportIndex).AsBool(false);
     }
   }

--- a/src/vcSettings.cpp
+++ b/src/vcSettings.cpp
@@ -633,6 +633,14 @@ bool vcSettings_Load(vcSettings *pSettings, bool forceReset /*= false*/, vcSetti
         pSettings->projectsHistory.projects.PushBack({ isServerProject, udStrdup(pProjectName), udStrdup(pProjectPath) });
 
     }
+
+    pSettings->activeViewportCount = data.Get("viewports.activeCount").AsInt(1);
+    for (int viewportIndex = 0; viewportIndex < vcMaxViewportCount; ++viewportIndex)
+    {
+      pSettings->viewports[viewportIndex].resolution.x = data.Get("viewports.viewport[%d].width", viewportIndex).AsInt(128);
+      pSettings->viewports[viewportIndex].resolution.y = data.Get("viewports.viewport[% d].height", viewportIndex).AsInt(128);
+      pSettings->viewports[viewportIndex].mapMode = data.Get("viewports.viewport[%d].mapMode", viewportIndex).AsBool(false);
+    }
   }
 
   udFree(pSavedData);
@@ -947,6 +955,14 @@ bool vcSettings_Save(vcSettings *pSettings)
 
     temp.SetString(pProjectHistory->pPath);
     data.Set(&temp, "projectsHistory.path[]");
+  }
+
+  data.Set("viewports.activeCount = %d", pSettings->activeViewportCount);
+  for (int viewportIndex = 0; viewportIndex < vcMaxViewportCount; ++viewportIndex)
+  {
+    data.Set("viewports.viewport[%d].width = %d", viewportIndex, pSettings->viewports[viewportIndex].resolution.x);
+    data.Set("viewports.viewport[%d].height = %d", viewportIndex, pSettings->viewports[viewportIndex].resolution.y);
+    data.Set("viewports.viewport[%d].mapMode = %s", viewportIndex, pSettings->viewports[viewportIndex].mapMode ? "true" : "false");
   }
 
   // Save

--- a/src/vcSettings.h
+++ b/src/vcSettings.h
@@ -124,6 +124,11 @@ enum vcSkyboxType
   vcSkyboxType_Atmosphere,
 };
 
+enum
+{
+  vcMaxViewportCount = 2,
+};
+
 struct vcLanguageOption
 {
   // Arbitrary limits
@@ -351,6 +356,13 @@ struct vcSettings
   } postVisualization;
 
   vcCameraSettings camera;
+
+  struct vcViewportSettings
+  {
+    udUInt2 resolution;
+    bool mapMode; // geoverse-style orthographic camera
+  } viewports[vcMaxViewportCount];
+  int activeViewportCount;
 
   struct vcMapServer
   {

--- a/src/vcSettingsUI.cpp
+++ b/src/vcSettingsUI.cpp
@@ -719,8 +719,8 @@ void vcSettingsUI_BasicMapSettings(vcState *pProgramState, bool alwaysShowOption
           udGeoZone zone = {};
           udGeoZone_SetFromSRID(&zone, newSRID);
 
-          for (int viewportIndex = 0; viewportIndex < pProgramState->activeViewportCount; ++viewportIndex)
-            vcGIS_ChangeSpace(&pProgramState->geozone, zone, &pProgramState->pViewports[viewportIndex].camera.position, viewportIndex + 1 == pProgramState->activeViewportCount);
+          for (int viewportIndex = 0; viewportIndex < pProgramState->settings.activeViewportCount; ++viewportIndex)
+            vcGIS_ChangeSpace(&pProgramState->geozone, zone, &pProgramState->pViewports[viewportIndex].camera.position, viewportIndex + 1 == pProgramState->settings.activeViewportCount);
 
           pProgramState->activeProject.pFolder->ChangeProjection(zone);
         }
@@ -779,7 +779,7 @@ void vcSettingsUI_BasicMapSettings(vcState *pProgramState, bool alwaysShowOption
             {
               udStrcpy(pProgramState->settings.maptiles.layers[mapLayer].mapType, s_mapTiles[i].pModeStr);
               vcSettings_ApplyMapChange(&pProgramState->settings, mapLayer);
-              for (int viewportIndex = 0; viewportIndex < pProgramState->activeViewportCount; ++viewportIndex)
+              for (int viewportIndex = 0; viewportIndex < pProgramState->settings.activeViewportCount; ++viewportIndex)
                 vcRender_ClearTiles(pProgramState->pViewports[viewportIndex].pRenderContext);
             }
 
@@ -823,7 +823,7 @@ void vcSettingsUI_BasicMapSettings(vcState *pProgramState, bool alwaysShowOption
               if (changed)
               {
                 vcSettings_ApplyMapChange(&pProgramState->settings, mapLayer);
-                for (int viewportIndex = 0; viewportIndex < pProgramState->activeViewportCount; ++viewportIndex)
+                for (int viewportIndex = 0; viewportIndex < pProgramState->settings.activeViewportCount; ++viewportIndex)
                   vcRender_ClearTiles(pProgramState->pViewports[viewportIndex].pRenderContext);
               }
 

--- a/src/vcState.h
+++ b/src/vcState.h
@@ -100,7 +100,7 @@ struct vcViewport
   vcCamera camera;
   vcCameraInput cameraInput;
 
-  udUInt2 resolution;
+ // udUInt2 resolution; // TODO: Duplicated with settings
   vcRenderContext *pRenderContext;
 
   struct
@@ -173,11 +173,11 @@ struct vcState
 
   udUInt2 windowResolution;
 
-  int activeViewportCount;
   vcViewport *pViewports;
 
   // The systems only have a concept of a single active viewport, so maintain that
   vcViewport *pActiveViewport;
+  int activeViewportIndex;
   int focusedViewportIndex;
 
   udGeoZone geozone;

--- a/src/vcState.h
+++ b/src/vcState.h
@@ -100,7 +100,6 @@ struct vcViewport
   vcCamera camera;
   vcCameraInput cameraInput;
 
- // udUInt2 resolution; // TODO: Duplicated with settings
   vcRenderContext *pRenderContext;
 
   struct


### PR DESCRIPTION
Some viewport settings are now serialized.
Euclideon watermark is now only rendered on the first viewport.
Moved the initial project blank scene creation to a more appropriate place in program start up.