### PR TITLE
Hide Custom Server in Map Settings Popup

### DIFF
--- a/src/vcSettingsUI.cpp
+++ b/src/vcSettingsUI.cpp
@@ -761,6 +761,7 @@ void vcSettingsUI_BasicMapSettings(vcState *pProgramState, bool alwaysShowOption
           float window_visible_x2 = ImGui::GetWindowPos().x + ImGui::GetWindowContentRegionMax().x;
 
           bool customServerSpecified = pProgramState->settings.maptiles.layers[mapLayer].customServer.tileServerAddress[0] != '\0';
+          bool customServerSelected = udStrEqual(pProgramState->settings.maptiles.layers[mapLayer].mapType, "custom");
 
           for (size_t i = 0; i < udLengthOf(s_mapTiles); i++)
           {
@@ -774,7 +775,7 @@ void vcSettingsUI_BasicMapSettings(vcState *pProgramState, bool alwaysShowOption
               s_mapTiles[i].pPreviewTexture = pProgramState->pWhiteTexture;
             }
 
-            if (!alwaysShowOptions || !udStrEqual(s_mapTiles[i].pModeStr, "custom") || customServerSpecified)
+            if (!udStrEqual(s_mapTiles[i].pModeStr, "custom") || customServerSelected || customServerSpecified || !alwaysShowOptions)
             {
               if (pop)
                 ImGui::PushStyleColor(ImGuiCol_Button, ImGui::GetStyleColorVec4(ImGuiCol_ButtonActive));
@@ -813,7 +814,7 @@ void vcSettingsUI_BasicMapSettings(vcState *pProgramState, bool alwaysShowOption
 
           if (pProgramState->settings.maptiles.mapEnabled)
           {
-            if (udStrEqual(pProgramState->settings.maptiles.layers[mapLayer].mapType, "custom") && customServerSpecified)
+            if (customServerSelected)
             {
               ImGui::Indent();
 
@@ -832,7 +833,6 @@ void vcSettingsUI_BasicMapSettings(vcState *pProgramState, bool alwaysShowOption
               }
 
               ImGui::Unindent();
-
             }
             if (ImGui::SliderFloat(udTempStr("%s##%d", vcString::Get("settingsMapsMapHeight"), mapLayer), &pProgramState->settings.maptiles.layers[mapLayer].mapHeight, vcSL_MapHeightMin, vcSL_MapHeightMax, "%.3fm", 2.f))
               pProgramState->settings.maptiles.layers[mapLayer].mapHeight = udClamp(pProgramState->settings.maptiles.layers[mapLayer].mapHeight, -vcSL_GlobalLimitf, vcSL_GlobalLimitf);

--- a/src/vcSettingsUI.cpp
+++ b/src/vcSettingsUI.cpp
@@ -784,7 +784,7 @@ void vcSettingsUI_BasicMapSettings(vcState *pProgramState, bool alwaysShowOption
               {
                 udStrcpy(pProgramState->settings.maptiles.layers[mapLayer].mapType, s_mapTiles[i].pModeStr);
                 vcSettings_ApplyMapChange(&pProgramState->settings, mapLayer);
-                for (int viewportIndex = 0; viewportIndex < pProgramState->activeViewportCount; ++viewportIndex)
+                for (int viewportIndex = 0; viewportIndex < pProgramState->settings.activeViewportCount; ++viewportIndex)
                   vcRender_ClearTiles(pProgramState->pViewports[viewportIndex].pRenderContext);
               }
 

--- a/src/vcSettingsUI.cpp
+++ b/src/vcSettingsUI.cpp
@@ -760,48 +760,52 @@ void vcSettingsUI_BasicMapSettings(vcState *pProgramState, bool alwaysShowOption
           ImVec2 button_sz(92, 92);
           float window_visible_x2 = ImGui::GetWindowPos().x + ImGui::GetWindowContentRegionMax().x;
 
+          bool customServerSpecified = pProgramState->settings.maptiles.layers[mapLayer].customServer.tileServerAddress[0] != '\0';
+
           for (size_t i = 0; i < udLengthOf(s_mapTiles); i++)
           {
             ImGui::PushID((int)i);
 
             bool pop = udStrEqual(pProgramState->settings.maptiles.layers[mapLayer].mapType, s_mapTiles[i].pModeStr);
-
-            if (pop)
-              ImGui::PushStyleColor(ImGuiCol_Button, ImGui::GetStyleColorVec4(ImGuiCol_ButtonActive));
-
+            
             if (s_mapTiles[i].pPreviewTexture == nullptr)
             {
               vcTexture_AsyncCreateFromFilename(&s_mapTiles[i].pPreviewTexture, pProgramState->pWorkerPool, udTempStr("asset://assets/textures/mapservers/%s.png", s_mapTiles[i].pModeStr), vcTFM_Linear);
               s_mapTiles[i].pPreviewTexture = pProgramState->pWhiteTexture;
             }
 
-            if (ImGui::ImageButton(s_mapTiles[i].pPreviewTexture, button_sz))
+            if (!alwaysShowOptions || !udStrEqual(s_mapTiles[i].pModeStr, "custom") || customServerSpecified)
             {
-              udStrcpy(pProgramState->settings.maptiles.layers[mapLayer].mapType, s_mapTiles[i].pModeStr);
-              vcSettings_ApplyMapChange(&pProgramState->settings, mapLayer);
-              for (int viewportIndex = 0; viewportIndex < pProgramState->settings.activeViewportCount; ++viewportIndex)
-                vcRender_ClearTiles(pProgramState->pViewports[viewportIndex].pRenderContext);
+              if (pop)
+                ImGui::PushStyleColor(ImGuiCol_Button, ImGui::GetStyleColorVec4(ImGuiCol_ButtonActive));
+
+              if (ImGui::ImageButton(s_mapTiles[i].pPreviewTexture, button_sz))
+              {
+                udStrcpy(pProgramState->settings.maptiles.layers[mapLayer].mapType, s_mapTiles[i].pModeStr);
+                vcSettings_ApplyMapChange(&pProgramState->settings, mapLayer);
+                for (int viewportIndex = 0; viewportIndex < pProgramState->activeViewportCount; ++viewportIndex)
+                  vcRender_ClearTiles(pProgramState->pViewports[viewportIndex].pRenderContext);
+              }
+
+              if (pop)
+                ImGui::PopStyleColor();
+
+              if (ImGui::IsItemHovered())
+              {
+                ImGui::BeginTooltip();
+                if (udStrEqual(s_mapTiles[i].pMode, "Custom"))
+                  ImGui::TextUnformatted(vcString::Get("settingsMapTypeCustom"));
+                else
+                  ImGui::TextUnformatted(s_mapTiles[i].pMode);
+                ImGui::EndTooltip();
+              }
+
+              float last_button_x2 = ImGui::GetItemRectMax().x;
+              float next_button_x2 = last_button_x2 + style.ItemSpacing.x + button_sz.x; // Expected position if next button was on same line
+
+              if (i + 1 < udLengthOf(s_mapTiles) && next_button_x2 < window_visible_x2)
+                ImGui::SameLine();
             }
-
-            if (pop)
-              ImGui::PopStyleColor();
-
-            if (ImGui::IsItemHovered())
-            {
-              ImGui::BeginTooltip();
-              if (udStrEqual(s_mapTiles[i].pMode, "Custom"))
-                ImGui::TextUnformatted(vcString::Get("settingsMapTypeCustom"));
-              else
-                ImGui::TextUnformatted(s_mapTiles[i].pMode);
-              ImGui::EndTooltip();
-            }
-
-            float last_button_x2 = ImGui::GetItemRectMax().x;
-            float next_button_x2 = last_button_x2 + style.ItemSpacing.x + button_sz.x; // Expected position if next button was on same line
-
-            if (i + 1 < udLengthOf(s_mapTiles) && next_button_x2 < window_visible_x2)
-              ImGui::SameLine();
-
             ImGui::PopID();
           }
 
@@ -809,7 +813,7 @@ void vcSettingsUI_BasicMapSettings(vcState *pProgramState, bool alwaysShowOption
 
           if (pProgramState->settings.maptiles.mapEnabled)
           {
-            if (udStrEqual(pProgramState->settings.maptiles.layers[mapLayer].mapType, "custom"))
+            if (udStrEqual(pProgramState->settings.maptiles.layers[mapLayer].mapType, "custom") && customServerSpecified)
             {
               ImGui::Indent();
 


### PR DESCRIPTION
- Implemented hiding of custom server in settings popup if it isn't the selected map server AND it's address is empty
- This check occurs for each layer
- Fixes [AB#1936](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1936)