### PR TITLE
Deactivate Filter Tool when a Gizmo is toggled

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1237,6 +1237,7 @@ void vcMain_ToggleViewport(vcState *pProgramState)
 
 void vcMain_ToggleGizmoOperation(vcState *pProgramState, vcGizmoOperation op)
 {
+  pProgramState->activeTool = vcActiveTool_Select;
   for (int viewportIndex = 0; viewportIndex < pProgramState->settings.activeViewportCount; ++viewportIndex)
   {
     vcViewport *pViewport = &pProgramState->pViewports[viewportIndex];


### PR DESCRIPTION
no bug have been reported on this but the behaviour is a bit weird.
This allow the user to click on the Gizmo tools after creating a filter without having to select the Select tool before.
Currently, if the user toggle a Gizmo after creating a filter without changing to the Select tool a new filter is created every time he clicks on the Gizmo.