### PR TITLE
Fixed an issue where screenshot viewing (opengl) was upside down

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2411,7 +2411,7 @@ void vcMain_RenderSceneWindow(vcState *pProgramState)
       if (ImGui::BeginChild(udTempStr("###sceneViewport%d", viewportIndex)))
       {
         // Actual rendering to this texture is deferred
-        ImGui::Image(renderData.pSceneTexture, ImVec2((float)pProgramState->settings.viewports[viewportIndex].resolution.x, (float)pProgramState->settings.viewports[viewportIndex].resolution.y), ImVec2(0, 0), ImVec2(renderData.sceneScaling.x, renderData.sceneScaling.y));
+        ImGui::Image(renderData.pSceneTexture, ImVec2((float)viewportResolution.x, (float)viewportResolution.y), ImVec2(0, 0), ImVec2(renderData.sceneScaling.x, renderData.sceneScaling.y));
       }
       ImGui::EndChild();
 

--- a/src/vcModals.cpp
+++ b/src/vcModals.cpp
@@ -1386,12 +1386,7 @@ void vcModals_DrawImageViewer(vcState *pProgramState)
       ImVec2 window = ImGui::GetWindowSize();
       ImVec2 windowPos = ImGui::GetWindowPos();
 
-#if GRAPHICS_API_OPENGL
-      ImVec2 uvs[2] = { {0,1}, {1,0} };
-#else
-      ImVec2 uvs[2] = { {0,0}, {1,1} };
-#endif
-      
+      ImVec2 uvs[2] = { {0,0}, {1,1} };    
       ImGui::Image(pProgramState->image.pImage, ImVec2((float)pProgramState->image.width, (float)pProgramState->image.height), uvs[0], uvs[1]);
 
       if (ImGui::IsWindowHovered())


### PR DESCRIPTION
Fixed an issue where while a screenshot was in progress, the viewport display would show the incorrect image.
Fixes [AB#1237](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1237)