### PR TITLE
Added 2 splitters

### DIFF
--- a/src/imgui_ex/vcImGuiSimpleWidgets.cpp
+++ b/src/imgui_ex/vcImGuiSimpleWidgets.cpp
@@ -255,3 +255,25 @@ bool vcIGSW_StickyIntSlider(const char* label, int* v, int v_min, int v_max, int
   }
   return false;
 }
+
+void vcIGSW_verticalSplitter(const char* label, const udFloat2& size, const int currentColumnIndex, float currentColumnWidth, float leftColumnWidth)
+{
+  ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0, 0));
+  ImGui::SameLine();
+  ImGui::InvisibleButton(label, ImVec2(size.x, size.y));
+  if (ImGui::IsItemHovered())
+  {
+    ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
+  }
+  if (ImGui::IsItemActive())
+  {
+    ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
+    float _currentColumnWidth = (float)udMax(10.0, currentColumnWidth - ImGui::GetIO().MouseDelta.x);
+    float _leftColumnWidth = (float)udMax(5.0, leftColumnWidth + ImGui::GetIO().MouseDelta.x);
+    ImGui::SetColumnWidth(currentColumnIndex - 1, _leftColumnWidth);
+    ImGui::SetColumnWidth(currentColumnIndex, _currentColumnWidth);
+  }
+  ImGui::SameLine();
+  ImGui::PopStyleVar();
+}
+

--- a/src/imgui_ex/vcImGuiSimpleWidgets.h
+++ b/src/imgui_ex/vcImGuiSimpleWidgets.h
@@ -31,4 +31,6 @@ bool vcIGSW_IsItemHovered(ImGuiHoveredFlags flags = 0, float timer = 0.5f); // T
 
 void vcIGSW_ShowLoadStatusIndicator(vcSceneLoadStatus loadStatus, const char *pToolTip = nullptr);
 
+void vcIGSW_verticalSplitter(const char* label, const udFloat2& size, const int currentColumnIndex, float currentColumnWidth, float leftColumnWidth);
+
 #endif // vcImGuiSimpleWidgets_h__

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2469,24 +2469,9 @@ void vcMain_RenderSceneWindow(vcState *pProgramState)
 
       if (viewportIndex > 0)
       {
-        ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0, 0));
-        ImGui::SameLine();
-        uint8_t spliterSize = pProgramState->settings.window.touchscreenFriendly ? 6 : 3;
-        ImGui::InvisibleButton(udTempStr("###viewportSpliter%d", viewportIndex), ImVec2((float)spliterSize, (float)viewportResolution.y));
-        if (ImGui::IsItemHovered())
-        {
-          ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
-        }
-        if (ImGui::IsItemActive())
-        {
-          ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
-          float currentColumnWidth = (float)udMax(10.0, ImGui::GetColumnWidth(viewportIndex) - ImGui::GetIO().MouseDelta.x);
-          float leftColumnWidth = (float)udMax(5.0, ImGui::GetColumnWidth(viewportIndex - 1) + ImGui::GetIO().MouseDelta.x);
-          ImGui::SetColumnWidth(viewportIndex-1, leftColumnWidth);
-          ImGui::SetColumnWidth(viewportIndex, (float)currentColumnWidth);
-        }
-        ImGui::SameLine();
-        ImGui::PopStyleVar();
+        //uint8_t splitterSize = pProgramState->settings.window.touchscreenFriendly ? 6 : 3;
+        udFloat2 splitterSize = udFloat2::create(pProgramState->settings.window.touchscreenFriendly ? 6.0f : 3.0f, (float)viewportResolution.y);
+        vcIGSW_verticalSplitter(udTempStr("###viewportSpliter%d", viewportIndex), splitterSize, viewportIndex, ImGui::GetColumnWidth(viewportIndex), ImGui::GetColumnWidth(viewportIndex - 1));
       }
 
       if (ImGui::BeginChild(udTempStr("###sceneViewport%d", viewportIndex), ImVec2((float)viewportResolution.x, (float)viewportResolution.y), false))
@@ -3019,24 +3004,8 @@ void vcMain_RenderWindow(vcState *pProgramState)
 
         if (!pProgramState->settings.presentation.sceneExplorerCollapsed)
         {
-          ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0, 0));
-          ImGui::SameLine();
-          uint8_t spliterSize = pProgramState->settings.window.touchscreenFriendly ? 6 : 3;
-          ImGui::InvisibleButton(udTempStr("###sceneExplorerSpliterRight"), ImVec2((float)spliterSize, ImGui::GetWindowHeight()));
-          if (ImGui::IsItemHovered())
-          {
-            ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
-          }
-          if (ImGui::IsItemActive())
-          {
-            ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
-            float currentColumnWidth = (float)udMax(10.0, size.x - ImGui::GetColumnWidth(0) - ImGui::GetIO().MouseDelta.x);
-            float leftColumnWidth = (float)udMax(5.0, size.x - currentColumnWidth);
-            ImGui::SetColumnWidth(0, leftColumnWidth);
-            ImGui::SetColumnWidth(1, currentColumnWidth);
-          }
-          ImGui::SameLine();
-          ImGui::PopStyleVar();
+          udFloat2 splitterSize = udFloat2::create(pProgramState->settings.window.touchscreenFriendly ? 6.0f : 3.0f, ImGui::GetWindowHeight());
+          vcIGSW_verticalSplitter(udTempStr("###sceneExplorerSpliterRight"), splitterSize, 1, size.x - ImGui::GetColumnWidth(0), size.x - ImGui::GetColumnWidth(1));
         }
         if (ImGui::BeginChild(udTempStr("%s###sceneExplorerDock", vcString::Get("sceneExplorerTitle"))))
           vcMain_ShowSceneExplorerWindow(pProgramState);
@@ -3056,29 +3025,13 @@ void vcMain_RenderWindow(vcState *pProgramState)
 
         if (!pProgramState->settings.presentation.sceneExplorerCollapsed)
         {
-          ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0, 0));
-          ImGui::SameLine();
-          uint8_t spliterSize = pProgramState->settings.window.touchscreenFriendly ? 6 : 3;
-          ImGui::InvisibleButton(udTempStr("###sceneExplorerSpliterLeft"), ImVec2((float)spliterSize, ImGui::GetWindowHeight()));
-          if (ImGui::IsItemHovered())
-          {
-            ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
-          }
-          if (ImGui::IsItemActive())
-          {
-            ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
-            float currentColumnWidth = (float)udMax(10.0, size.x - ImGui::GetColumnWidth(0) - ImGui::GetIO().MouseDelta.x);
-            float leftColumnWidth = (float)udMax(5.0, size.x - currentColumnWidth);// ImGui::GetColumnWidth(1) + ImGui::GetIO().MouseDelta.x);
-            ImGui::SetColumnWidth(0, leftColumnWidth);
-            ImGui::SetColumnWidth(1, currentColumnWidth);
-          }
-          ImGui::SameLine();
-          ImGui::PopStyleVar();
+          udFloat2 splitterSize = udFloat2::create(pProgramState->settings.window.touchscreenFriendly ? 6.0f : 3.0f, ImGui::GetWindowHeight());
+          vcIGSW_verticalSplitter(udTempStr("###sceneExplorerSpliterLeft"), splitterSize, 1, size.x - ImGui::GetColumnWidth(0), size.x - ImGui::GetColumnWidth(1));
         }
         if (ImGui::GetColumnWidth(0) != sceneExplorerSize && !pProgramState->settings.presentation.sceneExplorerCollapsed)
           pProgramState->settings.presentation.sceneExplorerSize = (int)ImGui::GetColumnWidth(0);
 
-        if (ImGui::BeginChild(udTempStr("%s###sceneDock", vcString::Get("sceneTitle"))))//, ImVec2(ImGui::GetColumnWidth(), ImGui::GetWindowHeight()), false))
+        if (ImGui::BeginChild(udTempStr("%s###sceneDock", vcString::Get("sceneTitle"))))
           vcMain_RenderSceneWindow(pProgramState);
         ImGui::EndChild();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2397,7 +2397,7 @@ void vcMain_RenderSceneWindow(vcState *pProgramState)
 
   {
     ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0, 0));
-    ImGui::Columns(pProgramState->settings.activeViewportCount);
+    ImGui::Columns(pProgramState->settings.activeViewportCount, nullptr, false);
     ImGui::PopStyleVar(); // Item Spacing
 
     // At the moment some functionality is restricted to certain viewports
@@ -2467,7 +2467,29 @@ void vcMain_RenderSceneWindow(vcState *pProgramState)
       pProgramState->pActiveViewport->pickingSuccess = false;
       vcRender_BeginFrame(pProgramState->pActiveViewport->pRenderContext, renderData);
 
-      if (ImGui::BeginChild(udTempStr("###sceneViewport%d", viewportIndex)))
+      if (viewportIndex > 0)
+      {
+        ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0, 0));
+        ImGui::SameLine();
+        uint8_t spliterSize = pProgramState->settings.window.touchscreenFriendly ? 6 : 3;
+        ImGui::InvisibleButton(udTempStr("###viewportSpliter%d", viewportIndex), ImVec2((float)spliterSize, (float)viewportResolution.y));
+        if (ImGui::IsItemHovered())
+        {
+          ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
+        }
+        if (ImGui::IsItemActive())
+        {
+          ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
+          float currentColumnWidth = (float)udMax(10.0, ImGui::GetColumnWidth(viewportIndex) - ImGui::GetIO().MouseDelta.x);
+          float leftColumnWidth = (float)udMax(5.0, ImGui::GetColumnWidth(viewportIndex - 1) + ImGui::GetIO().MouseDelta.x);
+          ImGui::SetColumnWidth(viewportIndex-1, leftColumnWidth);
+          ImGui::SetColumnWidth(viewportIndex, (float)currentColumnWidth);
+        }
+        ImGui::SameLine();
+        ImGui::PopStyleVar();
+      }
+
+      if (ImGui::BeginChild(udTempStr("###sceneViewport%d", viewportIndex), ImVec2((float)viewportResolution.x, (float)viewportResolution.y), false))
       {
         // Actual rendering to this texture is deferred
         ImGui::Image(renderData.pSceneTexture, ImVec2((float)viewportResolution.x, (float)viewportResolution.y), ImVec2(0, 0), ImVec2(renderData.sceneScaling.x, renderData.sceneScaling.y));
@@ -2968,7 +2990,7 @@ void vcMain_RenderWindow(vcState *pProgramState)
       }
 
       ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0, 0));
-      ImGui::Columns(2, nullptr, !pProgramState->settings.presentation.sceneExplorerCollapsed);
+      ImGui::Columns(2, nullptr, false);
       ImGui::PopStyleVar(); // Item Spacing
 
       if (!pProgramState->settings.presentation.columnSizeCorrect)
@@ -2995,6 +3017,27 @@ void vcMain_RenderWindow(vcState *pProgramState)
         ImGui::NextColumn();
         ImGui::PopStyleVar(); // Item Spacing
 
+        if (!pProgramState->settings.presentation.sceneExplorerCollapsed)
+        {
+          ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0, 0));
+          ImGui::SameLine();
+          uint8_t spliterSize = pProgramState->settings.window.touchscreenFriendly ? 6 : 3;
+          ImGui::InvisibleButton(udTempStr("###sceneExplorerSpliterRight"), ImVec2((float)spliterSize, ImGui::GetWindowHeight()));
+          if (ImGui::IsItemHovered())
+          {
+            ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
+          }
+          if (ImGui::IsItemActive())
+          {
+            ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
+            float currentColumnWidth = (float)udMax(10.0, size.x - ImGui::GetColumnWidth(0) - ImGui::GetIO().MouseDelta.x);
+            float leftColumnWidth = (float)udMax(5.0, size.x - currentColumnWidth);
+            ImGui::SetColumnWidth(0, leftColumnWidth);
+            ImGui::SetColumnWidth(1, currentColumnWidth);
+          }
+          ImGui::SameLine();
+          ImGui::PopStyleVar();
+        }
         if (ImGui::BeginChild(udTempStr("%s###sceneExplorerDock", vcString::Get("sceneExplorerTitle"))))
           vcMain_ShowSceneExplorerWindow(pProgramState);
         ImGui::EndChild();
@@ -3002,8 +3045,6 @@ void vcMain_RenderWindow(vcState *pProgramState)
         break;
 
       case vcWL_SceneRight:
-        if (ImGui::GetColumnWidth(0) != sceneExplorerSize && !pProgramState->settings.presentation.sceneExplorerCollapsed)
-          pProgramState->settings.presentation.sceneExplorerSize = (int)ImGui::GetColumnWidth();
 
         if (ImGui::BeginChild(udTempStr("%s###sceneExplorerDock", vcString::Get("sceneExplorerTitle"))))
           vcMain_ShowSceneExplorerWindow(pProgramState);
@@ -3013,7 +3054,31 @@ void vcMain_RenderWindow(vcState *pProgramState)
         ImGui::NextColumn();
         ImGui::PopStyleVar(); // Item Spacing
 
-        if (ImGui::BeginChild(udTempStr("%s###sceneDock", vcString::Get("sceneTitle"))))
+        if (!pProgramState->settings.presentation.sceneExplorerCollapsed)
+        {
+          ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0, 0));
+          ImGui::SameLine();
+          uint8_t spliterSize = pProgramState->settings.window.touchscreenFriendly ? 6 : 3;
+          ImGui::InvisibleButton(udTempStr("###sceneExplorerSpliterLeft"), ImVec2((float)spliterSize, ImGui::GetWindowHeight()));
+          if (ImGui::IsItemHovered())
+          {
+            ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
+          }
+          if (ImGui::IsItemActive())
+          {
+            ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
+            float currentColumnWidth = (float)udMax(10.0, size.x - ImGui::GetColumnWidth(0) - ImGui::GetIO().MouseDelta.x);
+            float leftColumnWidth = (float)udMax(5.0, size.x - currentColumnWidth);// ImGui::GetColumnWidth(1) + ImGui::GetIO().MouseDelta.x);
+            ImGui::SetColumnWidth(0, leftColumnWidth);
+            ImGui::SetColumnWidth(1, currentColumnWidth);
+          }
+          ImGui::SameLine();
+          ImGui::PopStyleVar();
+        }
+        if (ImGui::GetColumnWidth(0) != sceneExplorerSize && !pProgramState->settings.presentation.sceneExplorerCollapsed)
+          pProgramState->settings.presentation.sceneExplorerSize = (int)ImGui::GetColumnWidth(0);
+
+        if (ImGui::BeginChild(udTempStr("%s###sceneDock", vcString::Get("sceneTitle"))))//, ImVec2(ImGui::GetColumnWidth(), ImGui::GetWindowHeight()), false))
           vcMain_RenderSceneWindow(pProgramState);
         ImGui::EndChild();
 


### PR DESCRIPTION
I have added a splitter function so that we can now set the size of the divider between each viewport and between the scene and scene explorer. Currently set to 3.0 and 6.0 when using Touch Friendly UI.
Fixes [AB#2017](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2017)
Fixes [AB#2092](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2092)
![Splitter](https://user-images.githubusercontent.com/17191283/92349219-c5e74a80-f118-11ea-8d4e-0e3b7f5d4d1d.gif)
