### PR TITLE
Changed where the tool updates

### DIFF
--- a/src/scene/tools/vcMeasureHeight.cpp
+++ b/src/scene/tools/vcMeasureHeight.cpp
@@ -66,6 +66,6 @@ void vcMeasureHeight::PreviewPicking(vcState *pProgramState, vcRenderData & /*re
       pProgramState->activeTool = vcActiveTool_Select;
 
     vcVerticalMeasureTool *pTool = (vcVerticalMeasureTool *)pProgramState->sceneExplorer.clickedItem.pItem->pUserData;
-    pTool->Preview(pProgramState->pActiveViewport->worldMousePosCartesian);
+    pTool->Preview(pProgramState, pProgramState->pActiveViewport->worldMousePosCartesian);
   }
 }

--- a/src/scene/vcVerticalMeasureTool.cpp
+++ b/src/scene/vcVerticalMeasureTool.cpp
@@ -48,9 +48,10 @@ vcVerticalMeasureTool::~vcVerticalMeasureTool()
 {
 }
 
-void vcVerticalMeasureTool::Preview(const udDouble3 &position)
+void vcVerticalMeasureTool::Preview(vcState *pProgramState, const udDouble3 &position)
 {
   m_points[2] = position;
+  vcProject_UpdateNodeGeometryFromCartesian(m_pProject, m_pNode, pProgramState->geozone, udPGT_LineString, m_points, 3);
 }
 
 void vcVerticalMeasureTool::EndMeasure(vcState *pProgramState, const udDouble3 &position)
@@ -59,6 +60,7 @@ void vcVerticalMeasureTool::EndMeasure(vcState *pProgramState, const udDouble3 &
   m_done = true;
   pProgramState->activeTool = vcActiveTool::vcActiveTool_Select;
   udProjectNode_SetMetadataBool(m_pNode, "measureEnd", m_done);
+  vcProject_UpdateNodeGeometryFromCartesian(m_pProject, m_pNode, pProgramState->geozone, udPGT_LineString, m_points, 3);
 }
 
 void vcVerticalMeasureTool::OnNodeUpdate(vcState *pProgramState)
@@ -155,7 +157,6 @@ void vcVerticalMeasureTool::AddToScene(vcState *pProgramState, vcRenderData *pRe
     m_labelList[1].pSceneItem = this;
     pRenderData->labels.PushBack(&m_labelList[1]);
 
-    vcProject_UpdateNodeGeometryFromCartesian(m_pProject, m_pNode, pProgramState->geozone, udPGT_LineString, m_points, 3);
     vcLineRenderer_UpdatePoints(m_pLineInstance, m_points, 3, vcIGSW_BGRAToImGui(m_lineColour), m_lineWidth, false);
     pRenderData->lines.PushBack(m_pLineInstance);
   }

--- a/src/scene/vcVerticalMeasureTool.h
+++ b/src/scene/vcVerticalMeasureTool.h
@@ -18,7 +18,7 @@ public:
   vcVerticalMeasureTool(vcProject *pProject, udProjectNode *pNode, vcState *pProgramState);
   virtual ~vcVerticalMeasureTool();
 
-  void Preview(const udDouble3 &position);
+  void Preview(vcState *pProgramState, const udDouble3 &position);
   void EndMeasure(vcState *pProgramState, const udDouble3 &position);
 
   virtual void OnNodeUpdate(vcState *pProgramState);


### PR DESCRIPTION
Fixes [AB#1741](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1741)

Ok, from what I could gather, saving and loading data to and from the project node each frame (in `ApplyToScene()`) was introducing floating point drift. I don't think there should be a need to save out every frame anyway. I changed this to only save out when the preview point has changed, and when preview has finished, in addition to `ApplyDelta()` and `OnNodeUpdate()`

This has been tested changing GeoZones.