### PR TITLE
Globe rendering and map tile optimizations

### DIFF
--- a/src/gl/metal/shaders/desktop/tileVertexShader.metal
+++ b/src/gl/metal/shaders/desktop/tileVertexShader.metal
@@ -15,13 +15,13 @@ struct type_u_EveryObject
 {
     float4x4 u_projection;
     float4x4 u_view;
-    float4 u_eyePositions[9];
+    float4 u_eyePositions[4];
     float4 u_colour;
     float4 u_objectInfo;
     float4 u_uvOffsetScale;
     float4 u_demUVOffsetScale;
-    float4 u_worldNormals[9];
-    float4 u_worldBitangents[9];
+    float4 u_worldNormals[4];
+    float4 u_worldBitangents[4];
 };
 
 constant float2 _60 = {};
@@ -46,37 +46,39 @@ struct main0_in
 vertex main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], constant type_u_EveryObject& u_EveryObject [[buffer(1)]], texture2d<float> demTexture [[texture(0)]], sampler demSampler [[sampler(0)]])
 {
     main0_out out = {};
-    float2 _65 = in.in_var_POSITION.xy * 2.0;
+    float2 _65 = in.in_var_POSITION.xy * 1.0;
     float _67 = _65.x;
     float _68 = floor(_67);
     float _69 = _65.y;
     float _70 = floor(_69);
-    float _72 = fast::min(2.0, _68 + 1.0);
-    float _77 = _70 * 3.0;
+    float _72 = fast::min(1.0, _68 + 1.0);
+    float _77 = _70 * 2.0;
     int _79 = int(_77 + _68);
     int _83 = int(_77 + _72);
-    float _86 = fast::min(2.0, _70 + 1.0) * 3.0;
+    float _86 = fast::min(1.0, _70 + 1.0) * 2.0;
     int _88 = int(_86 + _68);
     int _92 = int(_86 + _72);
     float4 _95 = float4(_67 - _68);
     float4 _98 = float4(_69 - _70);
     float4 _100 = normalize(mix(mix(u_EveryObject.u_worldNormals[_79], u_EveryObject.u_worldNormals[_83], _95), mix(u_EveryObject.u_worldNormals[_88], u_EveryObject.u_worldNormals[_92], _95), _98));
+    float3 _101 = _100.xyz;
+    float4 _113 = mix(mix(u_EveryObject.u_eyePositions[_79], u_EveryObject.u_eyePositions[_83], _95), mix(u_EveryObject.u_eyePositions[_88], u_EveryObject.u_eyePositions[_92], _95), _98);
     float2 _126 = u_EveryObject.u_demUVOffsetScale.xy + (u_EveryObject.u_demUVOffsetScale.zw * in.in_var_POSITION.xy);
     float4 _130 = demTexture.sample(demSampler, _126, level(0.0));
-    float4 _146 = u_EveryObject.u_projection * (mix(mix(u_EveryObject.u_eyePositions[_79], u_EveryObject.u_eyePositions[_83], _95), mix(u_EveryObject.u_eyePositions[_88], u_EveryObject.u_eyePositions[_92], _95), _98) + ((u_EveryObject.u_view * float4(_100.xyz, 0.0)) * ((((_130.x * 255.0) + (_130.y * 65280.0)) - 32768.0) + (in.in_var_POSITION.z * u_EveryObject.u_objectInfo.y))));
-    float _157 = _146.w;
-    float _163 = ((log2(fast::max(9.9999999747524270787835121154785e-07, 1.0 + _157)) * ((u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear) / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0))) + u_cameraPlaneParams.u_clipZNear) * _157;
-    float4 _164 = _146;
-    _164.z = _163;
-    float2 _176 = _60;
-    _176.x = u_EveryObject.u_objectInfo.x;
-    out.gl_Position = _164;
+    float4 _164 = u_EveryObject.u_projection * (float4(mix(_113.xyz, (u_EveryObject.u_view * float4(_101 * _113.w, 1.0)).xyz, float3(u_EveryObject.u_objectInfo.z)), 1.0) + ((u_EveryObject.u_view * float4(_100.xyz, 0.0)) * ((((_130.x * 255.0) + (_130.y * 65280.0)) - 32768.0) + (in.in_var_POSITION.z * (u_EveryObject.u_objectInfo.y * 0.5)))));
+    float _175 = _164.w;
+    float _181 = ((log2(fast::max(9.9999999747524270787835121154785e-07, 1.0 + _175)) * ((u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear) / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0))) + u_cameraPlaneParams.u_clipZNear) * _175;
+    float4 _182 = _164;
+    _182.z = _181;
+    float2 _194 = _60;
+    _194.x = u_EveryObject.u_objectInfo.x;
+    out.gl_Position = _182;
     out.out_var_COLOR0 = u_EveryObject.u_colour;
     out.out_var_TEXCOORD0 = u_EveryObject.u_uvOffsetScale.xy + (u_EveryObject.u_uvOffsetScale.zw * in.in_var_POSITION.xy);
-    out.out_var_TEXCOORD1 = float2(_163, _157);
-    out.out_var_TEXCOORD2 = _176;
+    out.out_var_TEXCOORD1 = float2(_181, _175);
+    out.out_var_TEXCOORD2 = _194;
     out.out_var_TEXCOORD3 = _126;
-    out.out_var_TEXCOORD4 = _100.xyz;
+    out.out_var_TEXCOORD4 = _101;
     out.out_var_TEXCOORD5 = normalize(mix(mix(u_EveryObject.u_worldBitangents[_79], u_EveryObject.u_worldBitangents[_83], _95), mix(u_EveryObject.u_worldBitangents[_88], u_EveryObject.u_worldBitangents[_92], _95), _98)).xyz;
     return out;
 }

--- a/src/gl/metal/shaders/mobile/tileVertexShader.metal
+++ b/src/gl/metal/shaders/mobile/tileVertexShader.metal
@@ -15,13 +15,13 @@ struct type_u_EveryObject
 {
     float4x4 u_projection;
     float4x4 u_view;
-    float4 u_eyePositions[9];
+    float4 u_eyePositions[4];
     float4 u_colour;
     float4 u_objectInfo;
     float4 u_uvOffsetScale;
     float4 u_demUVOffsetScale;
-    float4 u_worldNormals[9];
-    float4 u_worldBitangents[9];
+    float4 u_worldNormals[4];
+    float4 u_worldBitangents[4];
 };
 
 constant float2 _60 = {};
@@ -46,37 +46,39 @@ struct main0_in
 vertex main0_out main0(main0_in in [[stage_in]], constant type_u_cameraPlaneParams& u_cameraPlaneParams [[buffer(0)]], constant type_u_EveryObject& u_EveryObject [[buffer(1)]], texture2d<float> demTexture [[texture(0)]], sampler demSampler [[sampler(0)]])
 {
     main0_out out = {};
-    float2 _65 = in.in_var_POSITION.xy * 2.0;
+    float2 _65 = in.in_var_POSITION.xy * 1.0;
     float _67 = _65.x;
     float _68 = floor(_67);
     float _69 = _65.y;
     float _70 = floor(_69);
-    float _72 = fast::min(2.0, _68 + 1.0);
-    float _77 = _70 * 3.0;
+    float _72 = fast::min(1.0, _68 + 1.0);
+    float _77 = _70 * 2.0;
     int _79 = int(_77 + _68);
     int _83 = int(_77 + _72);
-    float _86 = fast::min(2.0, _70 + 1.0) * 3.0;
+    float _86 = fast::min(1.0, _70 + 1.0) * 2.0;
     int _88 = int(_86 + _68);
     int _92 = int(_86 + _72);
     float4 _95 = float4(_67 - _68);
     float4 _98 = float4(_69 - _70);
     float4 _100 = normalize(mix(mix(u_EveryObject.u_worldNormals[_79], u_EveryObject.u_worldNormals[_83], _95), mix(u_EveryObject.u_worldNormals[_88], u_EveryObject.u_worldNormals[_92], _95), _98));
+    float3 _101 = _100.xyz;
+    float4 _113 = mix(mix(u_EveryObject.u_eyePositions[_79], u_EveryObject.u_eyePositions[_83], _95), mix(u_EveryObject.u_eyePositions[_88], u_EveryObject.u_eyePositions[_92], _95), _98);
     float2 _126 = u_EveryObject.u_demUVOffsetScale.xy + (u_EveryObject.u_demUVOffsetScale.zw * in.in_var_POSITION.xy);
     float4 _130 = demTexture.sample(demSampler, _126, level(0.0));
-    float4 _146 = u_EveryObject.u_projection * (mix(mix(u_EveryObject.u_eyePositions[_79], u_EveryObject.u_eyePositions[_83], _95), mix(u_EveryObject.u_eyePositions[_88], u_EveryObject.u_eyePositions[_92], _95), _98) + ((u_EveryObject.u_view * float4(_100.xyz, 0.0)) * ((((_130.x * 255.0) + (_130.y * 65280.0)) - 32768.0) + (in.in_var_POSITION.z * u_EveryObject.u_objectInfo.y))));
-    float _157 = _146.w;
-    float _163 = ((log2(fast::max(9.9999999747524270787835121154785e-07, 1.0 + _157)) * ((u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear) / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0))) + u_cameraPlaneParams.u_clipZNear) * _157;
-    float4 _164 = _146;
-    _164.z = _163;
-    float2 _176 = _60;
-    _176.x = u_EveryObject.u_objectInfo.x;
-    out.gl_Position = _164;
+    float4 _164 = u_EveryObject.u_projection * (float4(mix(_113.xyz, (u_EveryObject.u_view * float4(_101 * _113.w, 1.0)).xyz, float3(u_EveryObject.u_objectInfo.z)), 1.0) + ((u_EveryObject.u_view * float4(_100.xyz, 0.0)) * ((((_130.x * 255.0) + (_130.y * 65280.0)) - 32768.0) + (in.in_var_POSITION.z * (u_EveryObject.u_objectInfo.y * 0.5)))));
+    float _175 = _164.w;
+    float _181 = ((log2(fast::max(9.9999999747524270787835121154785e-07, 1.0 + _175)) * ((u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear) / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0))) + u_cameraPlaneParams.u_clipZNear) * _175;
+    float4 _182 = _164;
+    _182.z = _181;
+    float2 _194 = _60;
+    _194.x = u_EveryObject.u_objectInfo.x;
+    out.gl_Position = _182;
     out.out_var_COLOR0 = u_EveryObject.u_colour;
     out.out_var_TEXCOORD0 = u_EveryObject.u_uvOffsetScale.xy + (u_EveryObject.u_uvOffsetScale.zw * in.in_var_POSITION.xy);
-    out.out_var_TEXCOORD1 = float2(_163, _157);
-    out.out_var_TEXCOORD2 = _176;
+    out.out_var_TEXCOORD1 = float2(_181, _175);
+    out.out_var_TEXCOORD2 = _194;
     out.out_var_TEXCOORD3 = _126;
-    out.out_var_TEXCOORD4 = _100.xyz;
+    out.out_var_TEXCOORD4 = _101;
     out.out_var_TEXCOORD5 = normalize(mix(mix(u_EveryObject.u_worldBitangents[_79], u_EveryObject.u_worldBitangents[_83], _95), mix(u_EveryObject.u_worldBitangents[_88], u_EveryObject.u_worldBitangents[_92], _95), _98)).xyz;
     return out;
 }

--- a/src/gl/opengl/shaders/desktop/tileVertexShader.vert
+++ b/src/gl/opengl/shaders/desktop/tileVertexShader.vert
@@ -18,13 +18,13 @@ layout(std140) uniform type_u_EveryObject
 {
     layout(row_major) mat4 u_projection;
     layout(row_major) mat4 u_view;
-    vec4 u_eyePositions[9];
+    vec4 u_eyePositions[4];
     vec4 u_colour;
     vec4 u_objectInfo;
     vec4 u_uvOffsetScale;
     vec4 u_demUVOffsetScale;
-    vec4 u_worldNormals[9];
-    vec4 u_worldBitangents[9];
+    vec4 u_worldNormals[4];
+    vec4 u_worldBitangents[4];
 } u_EveryObject;
 
 uniform sampler2D SPIRV_Cross_CombineddemTexturedemSampler;
@@ -42,37 +42,39 @@ vec2 _60;
 
 void main()
 {
-    vec2 _65 = in_var_POSITION.xy * 2.0;
+    vec2 _65 = in_var_POSITION.xy * 1.0;
     float _67 = _65.x;
     float _68 = floor(_67);
     float _69 = _65.y;
     float _70 = floor(_69);
-    float _72 = min(2.0, _68 + 1.0);
-    float _77 = _70 * 3.0;
+    float _72 = min(1.0, _68 + 1.0);
+    float _77 = _70 * 2.0;
     int _79 = int(_77 + _68);
     int _83 = int(_77 + _72);
-    float _86 = min(2.0, _70 + 1.0) * 3.0;
+    float _86 = min(1.0, _70 + 1.0) * 2.0;
     int _88 = int(_86 + _68);
     int _92 = int(_86 + _72);
     vec4 _95 = vec4(_67 - _68);
     vec4 _98 = vec4(_69 - _70);
     vec4 _100 = normalize(mix(mix(u_EveryObject.u_worldNormals[_79], u_EveryObject.u_worldNormals[_83], _95), mix(u_EveryObject.u_worldNormals[_88], u_EveryObject.u_worldNormals[_92], _95), _98));
+    vec3 _101 = _100.xyz;
+    vec4 _113 = mix(mix(u_EveryObject.u_eyePositions[_79], u_EveryObject.u_eyePositions[_83], _95), mix(u_EveryObject.u_eyePositions[_88], u_EveryObject.u_eyePositions[_92], _95), _98);
     vec2 _126 = u_EveryObject.u_demUVOffsetScale.xy + (u_EveryObject.u_demUVOffsetScale.zw * in_var_POSITION.xy);
     vec4 _130 = textureLod(SPIRV_Cross_CombineddemTexturedemSampler, _126, 0.0);
-    vec4 _146 = (mix(mix(u_EveryObject.u_eyePositions[_79], u_EveryObject.u_eyePositions[_83], _95), mix(u_EveryObject.u_eyePositions[_88], u_EveryObject.u_eyePositions[_92], _95), _98) + ((vec4(_100.xyz, 0.0) * u_EveryObject.u_view) * ((((_130.x * 255.0) + (_130.y * 65280.0)) - 32768.0) + (in_var_POSITION.z * u_EveryObject.u_objectInfo.y)))) * u_EveryObject.u_projection;
-    float _157 = _146.w;
-    float _163 = ((log2(max(9.9999999747524270787835121154785e-07, 1.0 + _157)) * ((u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear) / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0))) + u_cameraPlaneParams.u_clipZNear) * _157;
-    vec4 _164 = _146;
-    _164.z = _163;
-    vec2 _176 = _60;
-    _176.x = u_EveryObject.u_objectInfo.x;
-    gl_Position = _164;
+    vec4 _164 = (vec4(mix(_113.xyz, (vec4(_101 * _113.w, 1.0) * u_EveryObject.u_view).xyz, vec3(u_EveryObject.u_objectInfo.z)), 1.0) + ((vec4(_100.xyz, 0.0) * u_EveryObject.u_view) * ((((_130.x * 255.0) + (_130.y * 65280.0)) - 32768.0) + (in_var_POSITION.z * (u_EveryObject.u_objectInfo.y * 0.5))))) * u_EveryObject.u_projection;
+    float _175 = _164.w;
+    float _181 = ((log2(max(9.9999999747524270787835121154785e-07, 1.0 + _175)) * ((u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear) / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0))) + u_cameraPlaneParams.u_clipZNear) * _175;
+    vec4 _182 = _164;
+    _182.z = _181;
+    vec2 _194 = _60;
+    _194.x = u_EveryObject.u_objectInfo.x;
+    gl_Position = _182;
     out_var_COLOR0 = u_EveryObject.u_colour;
     out_var_TEXCOORD0 = u_EveryObject.u_uvOffsetScale.xy + (u_EveryObject.u_uvOffsetScale.zw * in_var_POSITION.xy);
-    out_var_TEXCOORD1 = vec2(_163, _157);
-    out_var_TEXCOORD2 = _176;
+    out_var_TEXCOORD1 = vec2(_181, _175);
+    out_var_TEXCOORD2 = _194;
     out_var_TEXCOORD3 = _126;
-    out_var_TEXCOORD4 = _100.xyz;
+    out_var_TEXCOORD4 = _101;
     out_var_TEXCOORD5 = normalize(mix(mix(u_EveryObject.u_worldBitangents[_79], u_EveryObject.u_worldBitangents[_83], _95), mix(u_EveryObject.u_worldBitangents[_88], u_EveryObject.u_worldBitangents[_92], _95), _98)).xyz;
 }
 

--- a/src/gl/opengl/shaders/mobile/tileVertexShader.vert
+++ b/src/gl/opengl/shaders/mobile/tileVertexShader.vert
@@ -12,13 +12,13 @@ layout(std140) uniform type_u_EveryObject
 {
     layout(row_major) mat4 u_projection;
     layout(row_major) mat4 u_view;
-    vec4 u_eyePositions[9];
+    vec4 u_eyePositions[4];
     vec4 u_colour;
     vec4 u_objectInfo;
     vec4 u_uvOffsetScale;
     vec4 u_demUVOffsetScale;
-    vec4 u_worldNormals[9];
-    vec4 u_worldBitangents[9];
+    vec4 u_worldNormals[4];
+    vec4 u_worldBitangents[4];
 } u_EveryObject;
 
 uniform highp sampler2D SPIRV_Cross_CombineddemTexturedemSampler;
@@ -36,37 +36,39 @@ vec2 _60;
 
 void main()
 {
-    vec2 _65 = in_var_POSITION.xy * 2.0;
+    vec2 _65 = in_var_POSITION.xy * 1.0;
     float _67 = _65.x;
     float _68 = floor(_67);
     float _69 = _65.y;
     float _70 = floor(_69);
-    float _72 = min(2.0, _68 + 1.0);
-    float _77 = _70 * 3.0;
+    float _72 = min(1.0, _68 + 1.0);
+    float _77 = _70 * 2.0;
     int _79 = int(_77 + _68);
     int _83 = int(_77 + _72);
-    float _86 = min(2.0, _70 + 1.0) * 3.0;
+    float _86 = min(1.0, _70 + 1.0) * 2.0;
     int _88 = int(_86 + _68);
     int _92 = int(_86 + _72);
     vec4 _95 = vec4(_67 - _68);
     vec4 _98 = vec4(_69 - _70);
     vec4 _100 = normalize(mix(mix(u_EveryObject.u_worldNormals[_79], u_EveryObject.u_worldNormals[_83], _95), mix(u_EveryObject.u_worldNormals[_88], u_EveryObject.u_worldNormals[_92], _95), _98));
+    vec3 _101 = _100.xyz;
+    vec4 _113 = mix(mix(u_EveryObject.u_eyePositions[_79], u_EveryObject.u_eyePositions[_83], _95), mix(u_EveryObject.u_eyePositions[_88], u_EveryObject.u_eyePositions[_92], _95), _98);
     vec2 _126 = u_EveryObject.u_demUVOffsetScale.xy + (u_EveryObject.u_demUVOffsetScale.zw * in_var_POSITION.xy);
     vec4 _130 = textureLod(SPIRV_Cross_CombineddemTexturedemSampler, _126, 0.0);
-    vec4 _146 = (mix(mix(u_EveryObject.u_eyePositions[_79], u_EveryObject.u_eyePositions[_83], _95), mix(u_EveryObject.u_eyePositions[_88], u_EveryObject.u_eyePositions[_92], _95), _98) + ((vec4(_100.xyz, 0.0) * u_EveryObject.u_view) * ((((_130.x * 255.0) + (_130.y * 65280.0)) - 32768.0) + (in_var_POSITION.z * u_EveryObject.u_objectInfo.y)))) * u_EveryObject.u_projection;
-    float _157 = _146.w;
-    float _163 = ((log2(max(9.9999999747524270787835121154785e-07, 1.0 + _157)) * ((u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear) / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0))) + u_cameraPlaneParams.u_clipZNear) * _157;
-    vec4 _164 = _146;
-    _164.z = _163;
-    vec2 _176 = _60;
-    _176.x = u_EveryObject.u_objectInfo.x;
-    gl_Position = _164;
+    vec4 _164 = (vec4(mix(_113.xyz, (vec4(_101 * _113.w, 1.0) * u_EveryObject.u_view).xyz, vec3(u_EveryObject.u_objectInfo.z)), 1.0) + ((vec4(_100.xyz, 0.0) * u_EveryObject.u_view) * ((((_130.x * 255.0) + (_130.y * 65280.0)) - 32768.0) + (in_var_POSITION.z * (u_EveryObject.u_objectInfo.y * 0.5))))) * u_EveryObject.u_projection;
+    float _175 = _164.w;
+    float _181 = ((log2(max(9.9999999747524270787835121154785e-07, 1.0 + _175)) * ((u_cameraPlaneParams.u_clipZFar - u_cameraPlaneParams.u_clipZNear) / log2(u_cameraPlaneParams.s_CameraFarPlane + 1.0))) + u_cameraPlaneParams.u_clipZNear) * _175;
+    vec4 _182 = _164;
+    _182.z = _181;
+    vec2 _194 = _60;
+    _194.x = u_EveryObject.u_objectInfo.x;
+    gl_Position = _182;
     varying_COLOR0 = u_EveryObject.u_colour;
     varying_TEXCOORD0 = u_EveryObject.u_uvOffsetScale.xy + (u_EveryObject.u_uvOffsetScale.zw * in_var_POSITION.xy);
-    varying_TEXCOORD1 = vec2(_163, _157);
-    varying_TEXCOORD2 = _176;
+    varying_TEXCOORD1 = vec2(_181, _175);
+    varying_TEXCOORD2 = _194;
     varying_TEXCOORD3 = _126;
-    varying_TEXCOORD4 = _100.xyz;
+    varying_TEXCOORD4 = _101;
     varying_TEXCOORD5 = normalize(mix(mix(u_EveryObject.u_worldBitangents[_79], u_EveryObject.u_worldBitangents[_83], _95), mix(u_EveryObject.u_worldBitangents[_88], u_EveryObject.u_worldBitangents[_92], _95), _98)).xyz;
 }
 

--- a/src/rendering/vcTileRenderer.cpp
+++ b/src/rendering/vcTileRenderer.cpp
@@ -1008,8 +1008,6 @@ void vcTileRenderer_UpdateTileDEMTexture(vcTileRenderer *pTileRenderer, vcQuadTr
     vcTileRenderer_RecursiveDownUpdateNodeAABB(&pTileRenderer->quadTree, nullptr, pNode);
     vcTileRenderer_RecursiveUpUpdateNodeAABB(&pTileRenderer->quadTree, pNode);
 
-    *pUploadBudgetRemainingMS -= udPerfCounterMilliseconds(uploadStartTime);
-
     pNode->demInfo.loadStatus.Set(vcNodeRenderInfo::vcTLS_Loaded);
 
     *pUploadBudgetRemainingMS -= udPerfCounterMilliseconds(uploadStartTime);
@@ -1446,7 +1444,7 @@ void vcTileRenderer_Render(vcTileRenderer *pTileRenderer, const udDouble4x4 &vie
       vcGLState_SetBlendMode(vcGLSBM_Interpolative);
       tileSkirtLength = 0.0f;
     }
-  
+
     pShader->everyObject.objectInfo = udFloat4::create(encodedObjectId, (pTileRenderer->cameraIsUnderMapSurface ? -1.0f : 1.0f) * tileSkirtLength, pTileRenderer->quadTree.geozone.projection == udGZPT_ECEF ? 1.0f : 0.0f, 0);
     pShader->everyObject.colour = udFloat4::create(1.f, 1.f, 1.f, pTileRenderer->pSettings->maptiles.layers[layer].transparency);
 

--- a/src/rendering/vcTileRenderer.cpp
+++ b/src/rendering/vcTileRenderer.cpp
@@ -34,7 +34,6 @@ udUUID demTileServerAddresUUID = {};
 
 enum
 {
-  TileVertexControlPointRes = 3, // Change with caution : 'vcQuadTreeNode::worldBounds[]' and GPU structs need to match
   TileVertexResolution = 31 + 2, // +2 for skirt
   TileIndexResolution = (TileVertexResolution - 1),
 };
@@ -86,13 +85,13 @@ struct vcTileShader
   {
     udFloat4x4 projectionMatrix;
     udFloat4x4 viewMatrix;
-    udFloat4 eyePositions[TileVertexControlPointRes * TileVertexControlPointRes];
+    udFloat4 eyePositions[vcQuadTreeNodeVertexResolution * vcQuadTreeNodeVertexResolution];
     udFloat4 colour;
     udFloat4 objectInfo; // objectId.x, tileSkirtLength
     udFloat4 uvOffsetScale;
     udFloat4 demUVOffsetScale;
-    udFloat4 worldNormals[TileVertexControlPointRes * TileVertexControlPointRes];
-    udFloat4 worldBitangents[TileVertexControlPointRes * TileVertexControlPointRes];
+    udFloat4 worldNormals[vcQuadTreeNodeVertexResolution * vcQuadTreeNodeVertexResolution];
+    udFloat4 worldBitangents[vcQuadTreeNodeVertexResolution * vcQuadTreeNodeVertexResolution];
   } everyObject;
 };
 
@@ -112,6 +111,13 @@ struct vcTileRenderer
 
   udDouble3 cameraPosition;
   bool cameraIsUnderMapSurface;
+
+  struct vcSortedNode
+  {
+    vcQuadTreeNode *pNode;
+    double distToCameraSqr;
+  };
+  udChunkedArray<vcSortedNode> renderLists[vcMaxTileLayerCount];
 
   // cache textures
   struct vcTileCache
@@ -320,7 +326,7 @@ void vcTileRenderer_GenerateDEMAndNormalMaps(vcQuadTreeNode *pNode, void *pRawDe
   pNode->normalInfo.data.height = pNode->demInfo.data.height;
 
   // Calculate the horizontal region distances covered by this node
-  udFloat2 tileWorldSize = udFloat2::create((float)udMag3(pNode->worldBounds[2] - pNode->worldBounds[0]), (float)udMag3(pNode->worldBounds[6] - pNode->worldBounds[0]));
+  udFloat2 tileWorldSize = udFloat2::create((float)udMag3(pNode->worldBounds[vcQuadTreeNodeVertexResolution - 1] - pNode->worldBounds[0]), (float)udMag3(pNode->worldBounds[vcQuadTreeNodeVertexResolution * (vcQuadTreeNodeVertexResolution - 1)] - pNode->worldBounds[0]));
 
   float stepSize = 1.0f + (pNode->slippyPosition.z >= 12 ? (pNode->slippyPosition.z - 11) : 0.0f); // TODO: At lower levels blocky artefacts appear, so 'smudge'
   udFloat2 stepOffset = udFloat2::create(stepSize / pNode->normalInfo.data.width, stepSize / pNode->normalInfo.data.height);
@@ -796,6 +802,9 @@ udResult vcTileRenderer_Create(vcTileRenderer **ppTileRenderer, udWorkerPool *pW
   pTileRenderer->cache.keepLoading = true;
   pTileRenderer->cache.tileLoadList.Init(256);
 
+  for (int i = 0; i < vcMaxTileLayerCount; ++i)
+    pTileRenderer->renderLists[i].Init(128);
+
   for (size_t i = 0; i < udLengthOf(pTileRenderer->cache.pThreads); ++i)
     UD_ERROR_CHECK(udThread_Create(&pTileRenderer->cache.pThreads[i], vcTileRenderer_LoadThread, pTileRenderer));
 
@@ -862,6 +871,9 @@ udResult vcTileRenderer_Destroy(vcTileRenderer **ppTileRenderer)
   vcTexture_Destroy(&pTileRenderer->pEmptyTileTexture);
   vcTexture_Destroy(&pTileRenderer->pEmptyDemTileTexture);
   vcTexture_Destroy(&pTileRenderer->pEmptyNormalTexture);
+
+  for (int i = 0; i < vcMaxTileLayerCount; ++i)
+    pTileRenderer->renderLists[i].Deinit();
 
   vcQuadTree_Destroy(&(*ppTileRenderer)->quadTree);
   udFree(*ppTileRenderer);
@@ -995,6 +1007,8 @@ void vcTileRenderer_UpdateTileDEMTexture(vcTileRenderer *pTileRenderer, vcQuadTr
     // conditonal update AABBs of tree (up and down)
     vcTileRenderer_RecursiveDownUpdateNodeAABB(&pTileRenderer->quadTree, nullptr, pNode);
     vcTileRenderer_RecursiveUpUpdateNodeAABB(&pTileRenderer->quadTree, pNode);
+
+    *pUploadBudgetRemainingMS -= udPerfCounterMilliseconds(uploadStartTime);
 
     pNode->demInfo.loadStatus.Set(vcNodeRenderInfo::vcTLS_Loaded);
 
@@ -1178,13 +1192,21 @@ void vcTileRenderer_DrawNode(vcTileRenderer *pTileRenderer, vcQuadTreeNode *pNod
     pNormalTexture = pTileRenderer->pEmptyNormalTexture;
   }
 
-  for (int t = 0; t < TileVertexControlPointRes * TileVertexControlPointRes; ++t)
+  for (int t = 0; t < vcQuadTreeNodeVertexResolution * vcQuadTreeNodeVertexResolution; ++t)
   {
     udDouble3 mapHeightOffset = pNode->worldNormals[t] * udDouble3::create(pTileRenderer->pSettings->maptiles.layers[layer].mapHeight);
-    udFloat4 eyeSpacePosition = udFloat4::create(view * udDouble4::create(pNode->worldBounds[t] + mapHeightOffset, 1.0));
-    pShader->everyObject.eyePositions[t] = eyeSpacePosition;
+    udDouble3 worldPos = pNode->worldBounds[t] + mapHeightOffset;
+    udDouble4 eyePosition = view * udDouble4::create(worldPos, 1.0);
+    udDouble3 normal = pNode->worldNormals[t];
+    if (pTileRenderer->quadTree.geozone.projection == udGZPT_ECEF)
+      normal = udNormalize(worldPos);
 
-    pShader->everyObject.worldNormals[t] = udFloat4::create(udFloat3::create(pNode->worldNormals[t]), 0.0f);
+    pShader->everyObject.eyePositions[t] = udFloat4::create(eyePosition);
+
+    // store the distance in the here (this will be used to generate the globe)
+    pShader->everyObject.eyePositions[t].w = (float)udMag3(worldPos);
+
+    pShader->everyObject.worldNormals[t] = udFloat4::create(udFloat3::create(normal), 0.0f);
     pShader->everyObject.worldBitangents[t] = udFloat4::create(udFloat3::create(pNode->worldBitangents[t]), 0.0f);
   }
 
@@ -1263,7 +1285,29 @@ void vcTileRenderer_DrapeDEM(vcQuadTreeNode *pChild, vcQuadTreeNode *pAncestor)
   }
 }
 
-void vcTileRenderer_RecursiveRenderNodes(vcTileRenderer *pTileRenderer, vcQuadTreeNode *pNode, vcTileShader *pShader, const udDouble4x4 &view, int layer, vcQuadTreeNode *pBestTexturedAncestor, vcQuadTreeNode *pBestDemAncestor)
+// Sorted by distance to camera
+void vcTileRenderer_InsertRenderListSorted(vcTileRenderer *pTileRenderer, vcQuadTreeNode *pNode, int layer)
+{
+  double distToCameraSqr = udMagSq3(pNode->tileCenter - pTileRenderer->cameraPosition);
+  vcTileRenderer::vcSortedNode queuedNode = { pNode, distToCameraSqr };
+
+  udChunkedArray<vcTileRenderer::vcSortedNode> *pRenderList = &pTileRenderer->renderLists[layer];
+
+  size_t insertIndex = 0;
+  for (; insertIndex < pRenderList->length; ++insertIndex)
+  {
+    if (distToCameraSqr < pRenderList->GetElement(insertIndex)->distToCameraSqr)
+    {
+      pRenderList->Insert(insertIndex, &queuedNode);
+      break;
+    }
+  }
+
+  if (insertIndex == pRenderList->length)
+    pRenderList->PushBack(queuedNode);
+}
+
+void vcTileRenderer_RecursiveBuildRenderList(vcTileRenderer *pTileRenderer, vcQuadTreeNode *pNode, int layer, vcQuadTreeNode *pBestTexturedAncestor, vcQuadTreeNode *pBestDemAncestor)
 {
   if (layer == 0)
   {
@@ -1271,7 +1315,6 @@ void vcTileRenderer_RecursiveRenderNodes(vcTileRenderer *pTileRenderer, vcQuadTr
 
     // recalculate visibility here
     pNode->visible = vcQuadTree_IsNodeVisible(&pTileRenderer->quadTree, pNode);
-    pTileRenderer->quadTree.metaData.visibleNodeCount++;
 
     pNode->demInfo.drawInfo.pTexture = nullptr;
     pNode->normalInfo.drawInfo.pTexture = nullptr;
@@ -1279,6 +1322,8 @@ void vcTileRenderer_RecursiveRenderNodes(vcTileRenderer *pTileRenderer, vcQuadTr
 
   if (!pNode->visible && pNode->slippyPosition.z >= vcQuadTree_MinimumDescendLayer)
     return;
+
+  pTileRenderer->quadTree.metaData.visibleNodeCount++;
 
   // Progressively get the closest ancestors available data for draping (if own data doesn't exist)
   pNode->pPayloads[layer].drawInfo.pTexture = nullptr;
@@ -1300,7 +1345,7 @@ void vcTileRenderer_RecursiveRenderNodes(vcTileRenderer *pTileRenderer, vcQuadTr
     for (int c = 0; c < 4; ++c)
     {
       vcQuadTreeNode *pChildNode = &pTileRenderer->quadTree.nodes.pPool[pNode->childBlockIndex + c];
-      vcTileRenderer_RecursiveRenderNodes(pTileRenderer, pChildNode, pShader, view, layer, pBestTexturedAncestor, pBestDemAncestor);
+      vcTileRenderer_RecursiveBuildRenderList(pTileRenderer, pChildNode, layer, pBestTexturedAncestor, pBestDemAncestor);
 
       pNode->completeRender = pNode->completeRender && pChildNode->completeRender;
     }
@@ -1314,18 +1359,29 @@ void vcTileRenderer_RecursiveRenderNodes(vcTileRenderer *pTileRenderer, vcQuadTr
   if (layer == 0)
     vcTileRenderer_DrapeDEM(pNode, pBestDemAncestor);
 
-  // Lookup mesh variant for rendering
-  size_t meshIndex = 0;
-  for (size_t mc = 0; mc < udLengthOf(MeshConfigurations); ++mc)
-  {
-    if (MeshConfigurations[mc] == pNode->neighbours)
-    {
-      meshIndex = mc;
-      break;
-    }
-  }
+  vcTileRenderer_InsertRenderListSorted(pTileRenderer, pNode, layer);
+}
 
-  vcTileRenderer_DrawNode(pTileRenderer, pNode, pShader, view, layer, pTileRenderer->pTileMeshes[meshIndex]);
+void vcTileRenderer_DrawRenderList(vcTileRenderer *pTileRenderer, vcTileShader *pShader, const udDouble4x4 &view, int layer)
+{
+  udChunkedArray<vcTileRenderer::vcSortedNode> *pRenderList = &pTileRenderer->renderLists[layer];
+  for (size_t i = 0; i < pRenderList->length; ++i)
+  {
+    vcQuadTreeNode *pNode = pRenderList->GetElement(i)->pNode;
+
+    // Lookup mesh variant for rendering
+    size_t meshIndex = 0;
+    for (size_t mc = 0; mc < udLengthOf(MeshConfigurations); ++mc)
+    {
+      if (MeshConfigurations[mc] == pNode->neighbours)
+      {
+        meshIndex = mc;
+        break;
+      }
+    }
+
+    vcTileRenderer_DrawNode(pTileRenderer, pNode, pShader, view, layer, pTileRenderer->pTileMeshes[meshIndex]);
+  }
 }
 
 void vcTileRenderer_Render(vcTileRenderer *pTileRenderer, const udDouble4x4 &view, const udDouble4x4 &proj, const bool cameraInsideGround, const float encodedObjectId)
@@ -1337,7 +1393,14 @@ void vcTileRenderer_Render(vcTileRenderer *pTileRenderer, const udDouble4x4 &vie
   pTileRenderer->quadTree.metaData.visibleNodeCount = 0;
   pTileRenderer->quadTree.metaData.nodeRenderCount = 0;
 
-  float tileSkirtLength = 3000000.0f; // TODO: Read actual planet radius
+  // Build render list
+  for (int layer = 0; layer < pTileRenderer->pSettings->maptiles.activeLayerCount; ++layer)
+  {
+    pTileRenderer->renderLists[layer].Clear();
+    vcTileRenderer_RecursiveBuildRenderList(pTileRenderer, pRootNode, layer, nullptr, nullptr);
+  }
+
+  float tileSkirtLength = 6378137.0f; // TODO: Read actual planet radius
 
   for (int layer = 0; layer < pTileRenderer->pSettings->maptiles.activeLayerCount; ++layer)
   {
@@ -1383,11 +1446,12 @@ void vcTileRenderer_Render(vcTileRenderer *pTileRenderer, const udDouble4x4 &vie
       vcGLState_SetBlendMode(vcGLSBM_Interpolative);
       tileSkirtLength = 0.0f;
     }
-
-    pShader->everyObject.objectInfo = udFloat4::create(encodedObjectId, (pTileRenderer->cameraIsUnderMapSurface ? -1.0f : 1.0f) * tileSkirtLength, 0, 0);
+  
+    pShader->everyObject.objectInfo = udFloat4::create(encodedObjectId, (pTileRenderer->cameraIsUnderMapSurface ? -1.0f : 1.0f) * tileSkirtLength, pTileRenderer->quadTree.geozone.projection == udGZPT_ECEF ? 1.0f : 0.0f, 0);
     pShader->everyObject.colour = udFloat4::create(1.f, 1.f, 1.f, pTileRenderer->pSettings->maptiles.layers[layer].transparency);
 
-    vcTileRenderer_RecursiveRenderNodes(pTileRenderer, pRootNode, pShader, view, layer, nullptr, nullptr);
+    // render nodes
+    vcTileRenderer_DrawRenderList(pTileRenderer, pShader, view, layer);
   }
 
   vcGLState_SetViewportDepthRange(0.0f, 1.0f);

--- a/src/vcQuadTree.h
+++ b/src/vcQuadTree.h
@@ -12,7 +12,11 @@ enum
 {
   // Always descend a certain absolute depth to ensure the resulting geometry
   // is somewhat the shape of the projection (e.g. ECEF).
-  vcQuadTree_MinimumDescendLayer = 2
+  vcQuadTree_MinimumDescendLayer = 3,
+
+  // TODO: This should move out from vcQuadTree, and into an independent 'payload' struct
+  // Change with caution : 'vcQuadTreeNode::worldBounds[]' and GPU structs need to match
+  vcQuadTreeNodeVertexResolution = 2,
 };
 
 struct vcTexture;
@@ -68,18 +72,18 @@ struct vcQuadTreeNode
   bool visible;
   volatile bool touched;
 
-  // if a node was rendered with missing information (only considers colour at the moment, includes any failed descendents)
+  // if a node was rendered without missing information (only considers colour at the moment, includes any failed descendents)
   bool completeRender;
 
   // cached
-  udDouble3 tileCenter, tileExtents;
-  udDouble3 worldBounds[9]; // 3x3 grid of cartesian points
+  udDouble3 tileCenter, tileExtents, tileNormal;
+  udDouble3 worldBounds[vcQuadTreeNodeVertexResolution * vcQuadTreeNodeVertexResolution]; // 3x3 grid of cartesian points
                             // [0, 1, 2,
                             //  3, 4, 5,
                             //  6, 7, 8]
 
-  udDouble3 worldNormals[9];
-  udDouble3 worldBitangents[9];
+  udDouble3 worldNormals[vcQuadTreeNodeVertexResolution * vcQuadTreeNodeVertexResolution];
+  udDouble3 worldBitangents[vcQuadTreeNodeVertexResolution * vcQuadTreeNodeVertexResolution];
 
   enum vcDemBoundsState
   {


### PR DESCRIPTION
Significantly increased the tessellation of the planet when globe rendering.
Tiles are now drawn front to back (significantly reduces fill rate)
Tiles 'facing away' from the camera are now culled.
Reduced the # of control point calculations per block down from 36 to 9.

Fixes [AB#1956](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1956)