### PR TITLE
Single viewport platforms no longer require focus to update mouse position

### DIFF
--- a/src/imgui_ex/imgui_impl_sdl.cpp
+++ b/src/imgui_ex/imgui_impl_sdl.cpp
@@ -433,8 +433,7 @@ static void ImGui_ImplSDL2_UpdateMousePosAndButtons()
     SDL_CaptureMouse(any_mouse_button_down ? SDL_TRUE : SDL_FALSE);
 #else
     // SDL 2.0.3 and before: single-viewport only
-    if (SDL_GetWindowFlags(g_Window) & SDL_WINDOW_INPUT_FOCUS)
-        io.MousePos = ImVec2(mouse_x_local / g_Scaling, mouse_y_local / g_Scaling);
+    io.MousePos = ImVec2(mouse_x_local / g_Scaling, mouse_y_local / g_Scaling);
 #endif
 }
 


### PR DESCRIPTION
Fixes [AB#1238](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1238)