### PR TITLE
Added basic 12dxml support

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,6 +55,7 @@
 #include "tools/vcSceneTool.h"
 
 #include "parsers/vcUDP.h"
+#include "parsers/vc12DXML.h"
 
 #include "udFile.h"
 #include "udStringUtil.h"
@@ -465,6 +466,13 @@ void vcMain_MainLoop(vcState *pProgramState)
           vcModals_CloseModal(pProgramState, vcMT_Welcome);
 
           vcUDP_Load(pProgramState, pNextLoad);
+        }
+        else if (udStrEquali(pExt, ".12dxml"))
+        {
+          vcProject_CreateBlankScene(pProgramState, "12DXML Import", vcPSZ_StandardGeoJSON);
+          vcModals_CloseModal(pProgramState, vcMT_Welcome);
+
+          vc12DXML_Load(pProgramState, pNextLoad);
         }
 #if VC_HASCONVERT
         else if (convertDrop) // Everything else depends on where it was dropped

--- a/src/parsers/vc12DXML.h
+++ b/src/parsers/vc12DXML.h
@@ -5,4 +5,4 @@
 
 void vc12DXML_Load(vcState *pProgramState, const char *pFilename);
 
-#endif // !vcUDP_h__
+#endif // vc12DXML_h__

--- a/src/parsers/vc12DXML.h
+++ b/src/parsers/vc12DXML.h
@@ -1,0 +1,8 @@
+#ifndef vc12DXML_h__
+#define vc12DXML_h__
+
+#include "vcState.h"
+
+void vc12DXML_Load(vcState *pProgramState, const char *pFilename);
+
+#endif // !vcUDP_h__

--- a/src/parsers/vc12DXMLLoad.cpp
+++ b/src/parsers/vc12DXMLLoad.cpp
@@ -15,9 +15,9 @@
 *                not be obeyed!
 */
 
-#define LOG_ERROR(...)
-#define LOG_WARNING(...)
-#define LOG_INFO(...)
+#define LOG_ERROR(...) {}
+#define LOG_WARNING(...) {}
+#define LOG_INFO(...) {}
 
 // TODO support 'light' and 'dark' variants of all colours
 // TODO support capitalisation

--- a/src/parsers/vc12DXMLLoad.cpp
+++ b/src/parsers/vc12DXMLLoad.cpp
@@ -164,8 +164,8 @@ udResult vc12DXML_SuperString::Build(udJSON const *pNode, vc12DXML_ProjectGlobal
 {
   udResult result;
   const udJSON *pItem = nullptr;
-  bool has_z = false;
-  double z = 0.0;
+  //bool has_z = false;
+  //double z = 0.0;
 
   UD_ERROR_IF(pNode == nullptr, udR_InvalidParameter_);
 
@@ -175,14 +175,14 @@ udResult vc12DXML_SuperString::Build(udJSON const *pNode, vc12DXML_ProjectGlobal
   // From the spec:
   //   - There is exactly 0 or 1 <z> tag per string.
   //   - Its position is irrelevant, it is global to the string
-  pItem = &pNode->Get("z");
-  UD_ERROR_IF(pItem->IsArray(), udR_InvalidConfiguration);
-
-  if (!pItem->IsVoid())
-  {
-    has_z = true;
-    z = pItem->AsDouble();
-  }
+  //pItem = &pNode->Get("z");
+  //UD_ERROR_IF(pItem->IsArray(), udR_InvalidConfiguration);
+  //
+  //if (!pItem->IsVoid())
+  //{
+  //  has_z = true;
+  //  z = pItem->AsDouble();
+  //}
 
   SetGlobals(pNode, globals);
 

--- a/src/parsers/vc12DXMLLoad.cpp
+++ b/src/parsers/vc12DXMLLoad.cpp
@@ -1,0 +1,423 @@
+#include "vc12DXML.h"
+#include "vc12dxmlCommon.h"
+#include "udStringUtil.h"
+#include "udFile.h"
+
+/*
+*  Notes:
+*  I am unsure if commands such as <null></null> and <colour></colour> can be placed anywhere in the xml
+*  or must be called from inside a string. The spec is difficult to interpret. I have opted for the
+*  following rule regarding commands
+*     - Commands (null and colour at least) can only be called from within a string and should
+*       only be called once. Position is irrelevant. The command will set the global value,
+*       and will affect all subsequent strings.
+*       WARNING: If udJSON does not preserve order when building arrays of objects, the spec will
+*                not be obeyed!
+*/
+
+#define LOG_ERROR(...)
+#define LOG_WARNING(...)
+#define LOG_INFO(...)
+
+// TODO support 'light' and 'dark' variants of all colours
+// TODO support capitalisation
+static uint32_t vc12DXML_ToColour(const char *pStr)
+{
+  struct ColourPair
+  {
+    const char *pStr;
+    uint32_t val;
+  };
+
+  static const ColourPair Colours[] =
+  {
+    {"red",     0xFFFF0000},
+    {"green",   0xFF00FF00},
+    {"blue",    0xFF0000FF},
+    {"yellow",  0xFFFFFF00},
+    {"cyan",    0xFF00FFFF},
+    {"magenta", 0xFFFF00FF},
+    {"black",   0xFF000000},
+    {"white",   0xFFFFFFFF},
+  };
+
+  for (size_t i = 0; i < udLengthOf(Colours); ++i)
+  {
+    if (udStrcmp(pStr, Colours[i].pStr) == 0)
+      return Colours[i].val;
+  }
+
+  return 0xFFFF00FF;
+}
+
+static size_t vc12DXML_StrSplit(char *pStr, const char *pDelims, char **ppSubstrings, size_t subStrCount)
+{
+  if (subStrCount == 0)
+    return 0;
+
+  bool newString = false;
+  size_t subInd = 1;
+  size_t strLen = udStrlen(pStr);
+  ppSubstrings[0] = pStr;
+
+  for (size_t i = 0; i < strLen; ++i)
+  {
+    if (subInd == subStrCount)
+      break;
+
+    bool delimFound = false;
+    for (size_t j = 0; j < udStrlen(pDelims); ++j)
+    {
+      if (pStr[i] == pDelims[j])
+      {
+        pStr[i] = 0;
+        newString = true;
+        delimFound = true;
+        break;
+      }
+    }
+
+    if (delimFound)
+      continue;
+
+    if (newString)
+    {
+      ppSubstrings[subInd] = &pStr[i];
+      ++subInd;
+      newString = false;
+    }
+  }
+  return subInd;
+}
+
+static void SetGlobals(udJSON const *pNode, vc12DXML_ProjectGlobals &globals)
+{
+  const udJSON *pItem = nullptr;
+
+  pItem = &pNode->Get("null");
+  if (!pItem->IsVoid())
+    globals.nullValue = pItem->AsDouble();
+
+  pItem = &pNode->Get("colour");
+  if (!pItem->IsVoid())
+    globals.colour = vc12DXML_ToColour(pItem->AsString());
+}
+
+static void vc12DXML_Ammend_data_3d(udJSON const *pNode, std::vector<udDouble3> &pointList, vc12DXML_ProjectGlobals &globals)
+{
+  if (pNode->IsArray())
+  {
+    for (size_t i = 0; i < pNode->AsArray()->length; ++i)
+      vc12DXML_Ammend_data_3d(pNode->AsArray()->GetElement(i), pointList, globals);
+  }
+  else
+  {
+    char str[128] = {};
+    char *tokens[3] = {};
+    udDouble3 point = {};
+    udStrcpy(str, pNode->AsString());
+    if (vc12DXML_StrSplit(str, " ", tokens, 3) != 3)
+    {
+      LOG_WARNING("Malformed data_3d vertex item");
+    }
+    else
+    {
+      for (int p = 0; p < 3; ++p)
+      {
+        if (udStrcmp(tokens[p], "null") == 0)
+          point[p] = globals.nullValue;
+        else
+          point[p] = udStrAtof64(tokens[p]);
+      }
+      pointList.push_back(point);
+    }
+  }
+}
+
+vc12DXML_ProjectGlobals::vc12DXML_ProjectGlobals()
+  : nullValue(-999.0)                 // Default defined in the spec
+  , colour(vc12DXML_ToColour("red"))  // Default defined in the spec
+{
+
+}
+
+vc12DXML_Item::~vc12DXML_Item()
+{
+
+}
+
+vc12DXML_SuperString::vc12DXML_SuperString()
+  : m_pName(nullptr)
+  , m_isClosed(false)
+  , m_weight(1.0)
+  , m_colour(0xFFFF00FF)
+{
+
+}
+
+vc12DXML_SuperString::~vc12DXML_SuperString()
+{
+  udFree(m_pName);
+}
+
+udResult vc12DXML_SuperString::Build(udJSON const *pNode, vc12DXML_ProjectGlobals &globals)
+{
+  udResult result;
+  const udJSON *pItem = nullptr;
+  bool has_z = false;
+  double z = 0.0;
+
+  UD_ERROR_IF(pNode == nullptr, udR_InvalidParameter_);
+
+  // TODO Some values can and MUST be pulled out before others.
+  // <z> for example MUST be pulled out of the super_string block before reading any
+  // 3d/2d data, regardless of where <z> sits in the file in relation to the data.
+  // From the spec:
+  //   - There is exactly 0 or 1 <z> tag per string.
+  //   - Its position is irrelevant, it is global to the string
+  pItem = &pNode->Get("z");
+  UD_ERROR_IF(pItem->IsArray(), udR_InvalidConfiguration);
+
+  if (!pItem->IsVoid())
+  {
+    has_z = true;
+    z = pItem->AsDouble();
+  }
+
+  SetGlobals(pNode, globals);
+
+  pItem = &pNode->Get("name");
+  if (!pItem->IsVoid())
+  {
+    udFree(m_pName);
+    m_pName = udStrdup(pItem->AsString());
+  }
+
+  pItem = &pNode->Get("closed");
+  if (!pItem->IsVoid())
+    m_isClosed = pItem->AsBool();
+
+  pItem = &pNode->Get("colour");
+  if (!pItem->IsVoid())
+    m_colour = vc12DXML_ToColour(pItem->AsString());
+  else
+    m_colour = globals.colour;
+
+  pItem = &pNode->Get("weight");
+  if (!pItem->IsVoid())
+    m_weight = pItem->AsDouble();
+
+  pItem = &pNode->Get("data_3d");
+  if (!pItem->IsVoid())
+    vc12DXML_Ammend_data_3d(&pItem->Get("p"), m_points, globals);
+
+  result = udR_Success;
+epilogue:
+  return result;
+}
+
+void vc12DXML_SuperString::Print(FILE *pOut, int indent) const
+{
+  fprintf(pOut, "\n%*cSUPERSTRING", indent, ' ');
+  fprintf(pOut, "\n%*cname: %s", indent + 2, ' ', m_pName);
+  fprintf(pOut, "\n%*cclosed: %s", indent + 2, ' ', m_isClosed ? "true" : "false");
+  fprintf(pOut, "\n%*cweight: %f", indent + 2, ' ', m_weight);
+  fprintf(pOut, "\n%*cPOINTS:", indent + 2, ' ');
+  fprintf(pOut, "\n%*c%zu points:", indent + 4, ' ', m_points.size());
+  //for (const auto &point : m_points)
+  //  fprintf(pOut, "\n%*c%f %f %f", indent + 4, ' ', point[0], point[1], point[2]);
+}
+
+
+vc12DXML_Model::vc12DXML_Model()
+  : m_pName(nullptr)
+{
+
+}
+
+vc12DXML_Model::~vc12DXML_Model()
+{
+  for (auto pItem : m_elements)
+    delete pItem;
+
+  udFree(m_pName);
+}
+
+udResult vc12DXML_Model::BuildChildren(udJSON const *pNode, vc12DXML_ProjectGlobals &globals)
+{
+  udResult result;
+  const udJSON *pItem = nullptr;
+  UD_ERROR_IF(pNode == nullptr, udR_InvalidParameter_);
+
+  pItem = &pNode->Get("string_super");
+  if (!pItem->IsVoid())
+  {
+    if (pItem->IsArray())
+    {
+      for (size_t i = 0; i < pItem->ArrayLength(); ++i)
+      {
+        vc12DXML_SuperString *pSS = new vc12DXML_SuperString();
+        udResult res = pSS->Build(pItem->AsArray()->GetElement(i), globals);
+        if (res == udR_Success)
+          m_elements.push_back(pSS);
+        else
+          LOG_ERROR("Failed to load super string.");
+      }
+    }
+    else
+    {
+      vc12DXML_SuperString *pSS = new vc12DXML_SuperString();
+      udResult res = pSS->Build(pItem, globals);
+      if (res == udR_Success)
+        m_elements.push_back(pSS);
+      else
+        LOG_ERROR("Failed to load super string.");
+    }
+  }
+
+  result = udR_Success;
+epilogue:
+  return result;
+}
+
+udResult vc12DXML_Model::Build(udJSON const *pNode, vc12DXML_ProjectGlobals &globals)
+{
+  udResult result;
+  const udJSON *pItem = nullptr;
+  UD_ERROR_IF(pNode == nullptr, udR_InvalidParameter_);
+
+  // As per the spec, 'name' MUST be defined for models. But we don't check the format, just assume is correct.
+  pItem = &pNode->Get("name");
+  if (!pItem->IsVoid())
+  {
+    udFree(m_pName);
+    m_pName = udStrdup(pItem->AsString());
+  }
+
+  pItem = &pNode->Get("children");
+  if (!pItem->IsVoid())
+    UD_ERROR_CHECK(BuildChildren(pItem, globals));
+
+  result = udR_Success;
+epilogue:
+  return result;
+};
+
+void vc12DXML_Model::Print(FILE *pOut, int indent) const
+{
+  fprintf(pOut, "\n%*cMODEL", indent, ' ');
+  fprintf(pOut, "\n%*cname: %s", indent + 2, ' ', m_pName);
+  for (const auto pEle : m_elements)
+    pEle->Print(pOut, indent + 4);
+}
+
+vc12DXML_Project::vc12DXML_Project()
+  : m_pName(nullptr)
+{
+
+}
+
+vc12DXML_Project::~vc12DXML_Project()
+{
+  for (auto pItem : m_models)
+    delete pItem;
+
+  udFree(m_pName);
+}
+
+void vc12DXML_Project::SetName(const char *pName)
+{
+  udFree(m_pName);
+  m_pName = udStrdup(pName);
+}
+
+udResult vc12DXML_Project::BeginBuild(udJSON const *pNode)
+{
+  return Build(pNode, m_globals);
+}
+
+udResult vc12DXML_Project::Build(udJSON const *pNode, vc12DXML_ProjectGlobals &globals)
+{
+  udResult result;
+  const udJSON *pRoot = nullptr;
+  const udJSON *pItem = nullptr;
+
+  UD_ERROR_IF(pNode == nullptr, udR_InvalidParameter_);
+
+  pRoot = &pNode->Get("xml12d");
+
+  // Models
+  pItem = &pRoot->Get("model");
+  if (!pItem->IsVoid())
+  {
+    if (pItem->IsArray())
+    {
+      for (size_t i = 0; i < pItem->ArrayLength(); ++i)
+      {
+        vc12DXML_Model *pModel = new vc12DXML_Model();
+        udResult res = pModel->Build(pItem->AsArray()->GetElement(i), globals);
+        if (res == udR_Success)
+          m_models.push_back(pModel);
+        else
+          LOG_ERROR("Failed to load model.");
+      }
+    }
+    else
+    {
+      vc12DXML_Model *pModel = new vc12DXML_Model();
+      udResult res = pModel->Build(pItem, globals);
+      if (res == udR_Success)
+        m_models.push_back(pModel);
+      else
+        LOG_ERROR("Failed to load model.");
+    }
+  }
+
+  result = udR_Success;
+epilogue:
+  return result;
+}
+
+void vc12DXML_Project::Print(FILE *pOut, int indent) const
+{
+  fprintf(pOut, "%*cPROJECT", indent, ' ');
+  fprintf(pOut, "\n%*cname: %s", indent + 2, ' ', m_pName);
+  for (const auto pModel : m_models)
+    pModel->Print(pOut, indent + 4);
+}
+
+udResult vc12DXML_LoadProject(vc12DXML_Project &project, const char *pFilePath)
+{
+  udResult result;
+  udJSON xml;
+  const char *pFileContents = nullptr;
+  udJSON models;
+  udFilename fileName;
+  char projectName[256] = {};
+
+  UD_ERROR_NULL(pFilePath, udR_InvalidParameter_);
+
+  fileName.SetFromFullPath(pFilePath);
+  fileName.ExtractFilenameOnly(projectName, 256);
+  project.SetName(projectName);
+
+  UD_ERROR_CHECK(udFile_Load(pFilePath, (void **)&pFileContents));
+  UD_ERROR_CHECK(xml.Parse(pFileContents));
+
+  UD_ERROR_CHECK(project.BeginBuild(&xml));
+
+epilogue:
+  udFree(pFileContents);
+  return result;
+}
+
+void vc12DXML_Load(vcState *pProgramState, const char *pFilename)
+{
+  vc12DXML_Project project;
+  udResult result = vc12DXML_LoadProject(project, pFilename);
+  if (result == udR_Success)
+  {
+    udProjectNode *pParentNode = pProgramState->sceneExplorer.clickedItem.pItem != nullptr ? pProgramState->sceneExplorer.clickedItem.pItem : pProgramState->activeProject.pRoot;
+    project.AddToProject(pProgramState, pParentNode);
+  }
+}

--- a/src/parsers/vc12DXMLLoad.cpp
+++ b/src/parsers/vc12DXMLLoad.cpp
@@ -397,7 +397,7 @@ udResult vc12DXML_LoadProject(vc12DXML_Project &project, const char *pFilePath)
 
   UD_ERROR_NULL(pFilePath, udR_InvalidParameter_);
 
-  fileName.SetFromFullPath(pFilePath);
+  fileName.SetFromFullPath("%s", pFilePath);
   fileName.ExtractFilenameOnly(projectName, 256);
   project.SetName(projectName);
 

--- a/src/parsers/vc12dxmlApply.cpp
+++ b/src/parsers/vc12dxmlApply.cpp
@@ -1,0 +1,48 @@
+#include "vc12dxmlCommon.h"
+#include "vcState.h"
+
+void vc12DXML_SuperString::AddToProject(vcState *pProgramState, udProjectNode *pParent)
+{
+  if (m_pName == nullptr || m_points.size() == 0)
+    return;
+
+  udProjectNode *pNode = nullptr;
+  if (m_points.size() == 1)
+  {
+    udProjectNode_Create(pProgramState->activeProject.pProject, &pNode, pParent, "POI", m_pName, nullptr, nullptr);
+    vcProject_UpdateNodeGeometryFromCartesian(&pProgramState->activeProject, pNode, pProgramState->geozone, udPGT_Point, &m_points[0], 1);
+  }
+  else
+  {
+    udProjectNode_Create(pProgramState->activeProject.pProject, &pNode, pParent, "POI", m_pName, nullptr, nullptr);
+    if (m_isClosed)
+      vcProject_UpdateNodeGeometryFromCartesian(&pProgramState->activeProject, pNode, pProgramState->geozone, udPGT_Polygon, &m_points[0], (int)m_points.size());
+    else
+      vcProject_UpdateNodeGeometryFromCartesian(&pProgramState->activeProject, pNode, pProgramState->geozone, udPGT_MultiPoint, &m_points[0], (int)m_points.size());
+  }
+
+  udProjectNode_SetMetadataDouble(pNode, "lineWidth", m_weight);
+  udProjectNode_SetMetadataUint(pNode, "lineColourPrimary", m_colour);
+  udProjectNode_SetMetadataUint(pNode, "lineColourSecondary", m_colour);
+  udProjectNode_SetMetadataString(pNode, "textSize", "Medium");
+}
+
+void vc12DXML_Model::AddToProject(vcState *pProgramState, udProjectNode *pParent)
+{
+  udProjectNode *pNode = nullptr;
+  udProjectNode_Create(pProgramState->activeProject.pProject, &pNode, pParent, "Folder", m_pName, nullptr, nullptr);
+
+  for (auto pEle : m_elements)
+    pEle->AddToProject(pProgramState, pNode);
+}
+
+void vc12DXML_Project::AddToProject(vcState *pProgramState, udProjectNode *pParent)
+{
+  // TODO Can a 12dxml file be geolocated? For now, set as non-geolocated.
+  udGeoZone zone;
+  if (udGeoZone_SetFromSRID(&zone, 0) == udR_Success)
+    pProgramState->geozone = zone;
+
+  for (const auto &model : m_models)
+    model->AddToProject(pProgramState, pParent);
+}

--- a/src/parsers/vc12dxmlCommon.h
+++ b/src/parsers/vc12dxmlCommon.h
@@ -36,7 +36,7 @@ public:
   ~vc12DXML_SuperString();
   udResult Build(udJSON const *pNode, vc12DXML_ProjectGlobals &globals) override;
   void Print(FILE *pOut, int indent) const override;
-  void AddToProject(vcState *pProgramState, udProjectNode *pParent);
+  void AddToProject(vcState *pProgramState, udProjectNode *pParent) override;
 private:
 
   char *m_pName;
@@ -55,7 +55,7 @@ public:
   udResult BuildChildren(udJSON const *pNode, vc12DXML_ProjectGlobals &globals);
   udResult Build(udJSON const *pNode, vc12DXML_ProjectGlobals &globals) override;
   void Print(FILE *pOut, int indent) const override;
-  void AddToProject(vcState *pProgramState, udProjectNode *pParent);
+  void AddToProject(vcState *pProgramState, udProjectNode *pParent) override;
 
 private:
 

--- a/src/parsers/vc12dxmlCommon.h
+++ b/src/parsers/vc12dxmlCommon.h
@@ -1,0 +1,85 @@
+#ifndef vc12dxmlCommon_h__
+#define vc12dxmlCommon_h__
+
+#include <stdint.h>
+#include <vector>
+#include <cstdio>
+#include "udJSON.h"
+
+struct vcState;
+struct udProjectNode;
+
+class vc12DXML_ProjectGlobals
+{
+public:
+
+  vc12DXML_ProjectGlobals();
+
+  double nullValue;
+  uint32_t colour;
+};
+
+class vc12DXML_Item
+{
+public:
+  virtual ~vc12DXML_Item();
+  virtual udResult Build(udJSON const *, vc12DXML_ProjectGlobals &) = 0;
+  virtual void AddToProject(vcState *pProgramState, udProjectNode *pParent) = 0;
+  virtual void Print(FILE *, int indent) const = 0;
+};
+
+class vc12DXML_SuperString : public vc12DXML_Item
+{
+public:
+
+  vc12DXML_SuperString();
+  ~vc12DXML_SuperString();
+  udResult Build(udJSON const *pNode, vc12DXML_ProjectGlobals &globals) override;
+  void Print(FILE *pOut, int indent) const override;
+  void AddToProject(vcState *pProgramState, udProjectNode *pParent);
+private:
+
+  char *m_pName;
+  bool m_isClosed;
+  double m_weight;
+  uint32_t m_colour;
+  std::vector<udDouble3> m_points;
+};
+
+class vc12DXML_Model : public vc12DXML_Item
+{
+public:
+
+  vc12DXML_Model();
+  ~vc12DXML_Model();
+  udResult BuildChildren(udJSON const *pNode, vc12DXML_ProjectGlobals &globals);
+  udResult Build(udJSON const *pNode, vc12DXML_ProjectGlobals &globals) override;
+  void Print(FILE *pOut, int indent) const override;
+  void AddToProject(vcState *pProgramState, udProjectNode *pParent);
+
+private:
+
+  char *m_pName;
+  std::vector<vc12DXML_Item *> m_elements;
+};
+
+class vc12DXML_Project : public vc12DXML_Item
+{
+public:
+
+  vc12DXML_Project();
+  ~vc12DXML_Project();
+  void SetName(const char *pName);
+  udResult BeginBuild(udJSON const *pNode);
+  udResult Build(udJSON const *pNode, vc12DXML_ProjectGlobals &globals) override;
+  void Print(FILE *pOut, int indent = 0) const override;
+  void AddToProject(vcState *pProgramState, udProjectNode *pParent) override;
+
+private:
+
+  char *m_pName;
+  vc12DXML_ProjectGlobals m_globals; // Every 12dxml file has a set of globals that can change while parsing
+  std::vector<vc12DXML_Item *> m_models;
+};
+
+#endif

--- a/src/parsers/vc12dxmlCommon.h
+++ b/src/parsers/vc12dxmlCommon.h
@@ -3,7 +3,6 @@
 
 #include <stdint.h>
 #include <vector>
-#include <cstdio>
 #include "udJSON.h"
 
 struct vcState;
@@ -25,7 +24,6 @@ public:
   virtual ~vc12DXML_Item();
   virtual udResult Build(udJSON const *, vc12DXML_ProjectGlobals &) = 0;
   virtual void AddToProject(vcState *pProgramState, udProjectNode *pParent) = 0;
-  virtual void Print(FILE *, int indent) const = 0;
 };
 
 class vc12DXML_SuperString : public vc12DXML_Item
@@ -35,7 +33,6 @@ public:
   vc12DXML_SuperString();
   ~vc12DXML_SuperString();
   udResult Build(udJSON const *pNode, vc12DXML_ProjectGlobals &globals) override;
-  void Print(FILE *pOut, int indent) const override;
   void AddToProject(vcState *pProgramState, udProjectNode *pParent) override;
 private:
 
@@ -54,7 +51,6 @@ public:
   ~vc12DXML_Model();
   udResult BuildChildren(udJSON const *pNode, vc12DXML_ProjectGlobals &globals);
   udResult Build(udJSON const *pNode, vc12DXML_ProjectGlobals &globals) override;
-  void Print(FILE *pOut, int indent) const override;
   void AddToProject(vcState *pProgramState, udProjectNode *pParent) override;
 
 private:
@@ -72,7 +68,6 @@ public:
   void SetName(const char *pName);
   udResult BeginBuild(udJSON const *pNode);
   udResult Build(udJSON const *pNode, vc12DXML_ProjectGlobals &globals) override;
-  void Print(FILE *pOut, int indent = 0) const override;
   void AddToProject(vcState *pProgramState, udProjectNode *pParent) override;
 
 private:
@@ -82,4 +77,4 @@ private:
   std::vector<vc12DXML_Item *> m_models;
 };
 
-#endif
+#endif // vc12dxmlCommon_h__

--- a/vcTesting/src/vcMathTests.cpp
+++ b/vcTesting/src/vcMathTests.cpp
@@ -443,3 +443,61 @@ TEST(vcMath, ProjectedArea)
     EXPECT_NEAR(udProjectedArea(plane, points, 4), 16.0, EPSILON_DOUBLE);
   }
 }
+
+TEST(vcMath, SlerpVectors)
+{
+  double invR2 = 0.70710678118654752440084436210485;
+  double sin60 = 0.86602540378443864676372317075294;
+  double sin30 = 0.5;
+  double cos60 = 0.5;
+  double cos30 = 0.86602540378443864676372317075294;
+
+  // Vectors parallel
+  EXPECT_EQ(udDot(udSlerp({-1.0, 0.0, 0.0}, {1.0, 0.0, 0.0}, 0.5), {1.0, 0.0, 0.0}), 0.0);
+
+  EXPECT_EQ(udSlerp({1.0, 0.0, 0.0}, {1.0, 0.0, 0.0}, 0.0, false), udDouble3::create(1.0, 0.0, 0.0));
+  EXPECT_EQ(udSlerp({1.0, 0.0, 0.0}, {1.0, 0.0, 0.0}, 0.25, false), udDouble3::create(1.0, 0.0, 0.0));
+  EXPECT_EQ(udSlerp({1.0, 0.0, 0.0}, {1.0, 0.0, 0.0}, 0.5, false), udDouble3::create(1.0, 0.0, 0.0));
+  EXPECT_EQ(udSlerp({1.0, 0.0, 0.0}, {1.0, 0.0, 0.0}, 0.70, false), udDouble3::create(1.0, 0.0, 0.0));
+
+  // theta <= pi/2
+  EXPECT_VEC_NEAR(udSlerp({0.0, 1.0, 0.0}, {1.0, 0.0, 0.0}, 0.5, false), udDouble3::create(invR2, invR2, 0.0));
+  EXPECT_VEC_NEAR(udSlerp({1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, 0.5, false), udDouble3::create(invR2, invR2, 0.0));
+
+  EXPECT_VEC_NEAR(udSlerp({1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, 0.5, false), udDouble3::create(invR2, -invR2, 0.0));
+  EXPECT_VEC_NEAR(udSlerp({0.0, -1.0, 0.0}, {1.0, 0.0, 0.0}, 0.5, false), udDouble3::create(invR2, -invR2, 0.0));
+
+  EXPECT_VEC_NEAR(udSlerp({0.0, -1.0, 0.0}, {-1.0, 0.0, 0.0}, 0.5, false), udDouble3::create(-invR2, -invR2, 0.0));
+  EXPECT_VEC_NEAR(udSlerp({-1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, 0.5, false), udDouble3::create(-invR2, -invR2, 0.0));
+
+  EXPECT_VEC_NEAR(udSlerp({-1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, 0.5, false), udDouble3::create(-invR2, invR2, 0.0));
+  EXPECT_VEC_NEAR(udSlerp({0.0, 1.0, 0.0}, {-1.0, 0.0, 0.0}, 0.5, false), udDouble3::create(-invR2, invR2, 0.0));
+
+  EXPECT_VEC_NEAR(udSlerp({0.0, 1.0, 0.0}, {1.0, 0.0, 0.0}, 1.0 / 3.0, false), udDouble3::create(cos60, sin60, 0.0));
+  EXPECT_VEC_NEAR(udSlerp({0.0, 1.0, 0.0}, {1.0, 0.0, 0.0}, 2.0 / 3.0, false), udDouble3::create(cos30, sin30, 0.0));
+  EXPECT_VEC_NEAR(udSlerp({1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, 1.0 / 3.0, false), udDouble3::create(cos30, sin30, 0.0));
+  EXPECT_VEC_NEAR(udSlerp({1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, 2.0 / 3.0, false), udDouble3::create(cos60, sin60, 0.0));
+
+  EXPECT_VEC_NEAR(udSlerp({0.0, -1.0, 0.0}, {-1.0, 0.0, 0.0}, 1.0 / 3.0, false), udDouble3::create(-cos60, -sin60, 0.0));
+  EXPECT_VEC_NEAR(udSlerp({0.0, -1.0, 0.0}, {-1.0, 0.0, 0.0}, 2.0 / 3.0, false), udDouble3::create(-cos30, -sin30, 0.0));
+  EXPECT_VEC_NEAR(udSlerp({-1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, 1.0 / 3.0, false), udDouble3::create(-cos30, -sin30, 0.0));
+  EXPECT_VEC_NEAR(udSlerp({-1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, 2.0 / 3.0, false), udDouble3::create(-cos60, -sin60, 0.0));
+
+  // pi/2 <= theta <= pi
+  EXPECT_VEC_NEAR(udSlerp({1.0, 0.0, 0.0}, {-cos30, sin30, 0.0}, 0.6, false), udDouble3::create(0.0, 1.0, 0.0));
+  EXPECT_VEC_NEAR(udSlerp({1.0, 0.0, 0.0}, {-cos30, sin30, 0.0}, 0.8, false), udDouble3::create(-cos60, sin60, 0.0));
+
+  // theta >= pi
+  EXPECT_VEC_NEAR(udSlerp({1.0, 0.0, 0.0}, {cos30, -sin30, 0.0}, 1.0 / 11.0, true), udDouble3::create(cos30, sin30, 0.0));
+  EXPECT_VEC_NEAR(udSlerp({1.0, 0.0, 0.0}, {cos30, -sin30, 0.0}, 2.0 / 11.0, true), udDouble3::create(cos60, sin60, 0.0));
+  EXPECT_VEC_NEAR(udSlerp({1.0, 0.0, 0.0}, {cos30, -sin30, 0.0}, 3.0 / 11.0, true), udDouble3::create(0.0, 1.0, 0.0));
+  EXPECT_VEC_NEAR(udSlerp({1.0, 0.0, 0.0}, {cos30, -sin30, 0.0}, 4.0 / 11.0, true), udDouble3::create(-cos60, sin60, 0.0));
+  EXPECT_VEC_NEAR(udSlerp({1.0, 0.0, 0.0}, {cos30, -sin30, 0.0}, 5.0 / 11.0, true), udDouble3::create(-cos30, sin30, 0.0));
+  EXPECT_VEC_NEAR(udSlerp({1.0, 0.0, 0.0}, {cos30, -sin30, 0.0}, 6.0 / 11.0, true), udDouble3::create(-1.0, 0.0, 0.0));
+  EXPECT_VEC_NEAR(udSlerp({1.0, 0.0, 0.0}, {cos30, -sin30, 0.0}, 7.0 / 11.0, true), udDouble3::create(-cos30, -sin30, 0.0));
+  EXPECT_VEC_NEAR(udSlerp({1.0, 0.0, 0.0}, {cos30, -sin30, 0.0}, 8.0 / 11.0, true), udDouble3::create(-cos60, -sin60, 0.0));
+  EXPECT_VEC_NEAR(udSlerp({1.0, 0.0, 0.0}, {cos30, -sin30, 0.0}, 9.0 / 11.0, true), udDouble3::create(0.0, -1.0, 0.0));
+  EXPECT_VEC_NEAR(udSlerp({1.0, 0.0, 0.0}, {cos30, -sin30, 0.0}, 10.0 / 11.0, true), udDouble3::create(cos60, -sin60, 0.0));
+  EXPECT_VEC_NEAR(udSlerp({1.0, 0.0, 0.0}, {cos30, -sin30, 0.0}, 11.0 / 11.0, true), udDouble3::create(cos30, -sin30, 0.0));
+
+}


### PR DESCRIPTION
First block of work for [AB#489](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/489). This PR currently implements:
 - load UTF-8 encoded 12dxml file
 - loading 12dxml models (converts to folder in udStream)
 - loading 3D point and line data from 12dxml superstrings
 - `<null></null>` and `<colour></colour>` 'commands' from the xml
 - a few essential tags to display data (name, colours, weights, ...)

Not currently implemented
 - non UTF-8 encoded files
 - 2D and 3D varients of arcs, circles, transitions, offset transitions
 - different project structures (there are at least 2 different structures I have seen)

EDIT: The idea behind the `12dxml` loader being multiple files is to separate the 'loading' of the `12dxml` file from the creation of a udStream project. If we eventually want to support the full `12dxml` spec, both of these might become very large things, and it may be easier to handle if they were separate modules. Otherwise I'm happy to re-submit with everything in one file.