### PR TITLE
Nulling attached scene item when item deleted and project cleared

### DIFF
--- a/src/scene/vcFolder.cpp
+++ b/src/scene/vcFolder.cpp
@@ -356,9 +356,6 @@ void vcFolder::HandleSceneExplorerUI(vcState *pProgramState, size_t *pItemID)
 
         if (ImGui::Selectable(vcString::Get("sceneExplorerRemoveItem")))
         {
-          if ((vcSceneItem*)(pNode->pUserData) == pProgramState->pActiveViewport->cameraInput.pAttachedToSceneItem)
-            pProgramState->pActiveViewport->cameraInput.pAttachedToSceneItem = nullptr;
-
           ImGui::EndPopup();
 
           if (pSceneItem->m_expanded)

--- a/src/vcProject.cpp
+++ b/src/vcProject.cpp
@@ -436,6 +436,7 @@ void vcProject_Deinit(vcState *pProgramData, vcProject *pProject)
 
   pProgramData->activeTool = vcActiveTool_Select;
   pProgramData->activeProject.pSlideshowViewpoint = nullptr;
+  pProgramData->pActiveViewport->cameraInput.pAttachedToSceneItem = nullptr;
   udFree(pProject->pRelativeBase);
   vcProject_RecursiveDestroyUserData(pProgramData, pProject->pRoot);
   udProject_Release(&pProject->pProject);
@@ -562,6 +563,9 @@ void vcProject_RemoveItem(vcState *pProgramState, udProjectNode *pParent, udProj
 
   if (pNode == pProgramState->activeProject.pSlideshowViewpoint)
     pProgramState->activeProject.pSlideshowViewpoint = nullptr;
+
+  if (pNode->pUserData == pProgramState->pActiveViewport->cameraInput.pAttachedToSceneItem)
+    pProgramState->pActiveViewport->cameraInput.pAttachedToSceneItem = nullptr;
 
   vcSceneItem *pItem = pNode == nullptr ? nullptr : (vcSceneItem*)pNode->pUserData;
 


### PR DESCRIPTION
Fixes [AB#2197](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2197)

Also now setting `pAttachedToSceneItem` every time a node is destroyed