### PR TITLE
Added some unicode support to the 12dxml loader

### DIFF
--- a/builds/assets/lang/enAU.json
+++ b/builds/assets/lang/enAU.json
@@ -518,6 +518,8 @@
   "sceneExplorerProjectReadOnlyTitle": "Read Only!",
   "sceneExplorerProjectReadOnlyMessage": "The project you tried to modify is marked read only. You do not have permission to make changes.",
   "sceneExplorerUnsupportedFilesTitle": "Unsupported Files",
+  "sceneExplorerUnsupportedEncodingTitle": "File has an unsupported unicode format",
+  "sceneExplorerUnsupportedEncodingText": "The file you tried to load has an unrecognised encoding. Save the file using the encoding 'UTF-8' and try again.",
   "sceneExplorerUnsupportedFilesMessage": "The files you tried to add are currently unsupported by the application.",
   "sceneExplorerClearAllButton": "Clear All",
   "sceneExplorerErrorOpen": "Could not open the resource, perhaps it is missing or you don't have permission to access it",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -511,7 +511,8 @@ void vcMain_MainLoop(vcState *pProgramState)
           vcProject_CreateBlankScene(pProgramState, "12DXML Import", vcPSZ_StandardGeoJSON);
           vcModals_CloseModal(pProgramState, vcMT_Welcome);
 
-          vc12DXML_Load(pProgramState, pNextLoad);
+          if (vc12DXML_Load(pProgramState, pNextLoad) == udR_Unsupported)
+            vcModals_OpenModal(pProgramState, vcMT_UnsupportedEncoding);
         }
 #if VC_HASCONVERT
         else if (convertDrop) // Everything else depends on where it was dropped

--- a/src/parsers/vc12DXML.h
+++ b/src/parsers/vc12DXML.h
@@ -3,6 +3,6 @@
 
 #include "vcState.h"
 
-void vc12DXML_Load(vcState *pProgramState, const char *pFilename);
+udResult vc12DXML_Load(vcState *pProgramState, const char *pFilename);
 
 #endif // vc12DXML_h__

--- a/src/parsers/vc12DXMLLoad.cpp
+++ b/src/parsers/vc12DXMLLoad.cpp
@@ -98,8 +98,8 @@ epilogue:
 
 //----------------------------------------------------------------------------
 // 12dxml file parsing
-//----------------------------------------------------------------------------static bool vc12DXML_IsGreyColour(const char *pStr, uint32_t *pOut)
-bool vc12DXML_IsGreyColour(const char *pStr, uint32_t *pOut)
+//----------------------------------------------------------------------------
+static bool vc12DXML_IsGreyColour(const char *pStr, uint32_t *pOut)
 {
   if (pStr == nullptr || pOut == nullptr)
     return false;

--- a/src/parsers/vc12DXMLLoad.cpp
+++ b/src/parsers/vc12DXMLLoad.cpp
@@ -19,7 +19,87 @@
 #define LOG_WARNING(...) {}
 #define LOG_INFO(...) {}
 
-static bool vc12DXML_IsGreyColour(const char *pStr, uint32_t *pOut)
+//----------------------------------------------------------------------------
+// Unicode format detection. 
+//----------------------------------------------------------------------------
+
+#define MAX_BOM_BYTES 8
+
+enum vcUnicodeEncoding
+{
+  vcUE_ANSI,
+  vcUE_UTF8,
+  vcUE_UTF8BOM,
+  vcUE_UCS2BEBOM,
+  vcUE_UCS2LEBOM,
+  vcUE_UTF16BEBOM,
+  vcUE_UTF16LEBOM,
+  vcUE_Unknown
+};
+
+struct BOMBytes
+{
+  uint32_t nBytes;
+  uint8_t bytes[MAX_BOM_BYTES];
+};
+
+static vcUnicodeEncoding vcUnicode_GetEncodingFromBOM(const BOMBytes &bom)
+{
+  static uint8_t UTF8BOM[3] = {0xEF, 0xBB, 0xBF};
+  static uint8_t UTF16LEBOM[2] = {0xFF, 0xFE};
+  static uint8_t UTF16BEBOM[2] = {0xFE, 0xFF};
+
+  if (bom.nBytes >= 3 && memcmp(bom.bytes, UTF8BOM, 3) == 0)
+    return vcUE_UTF8BOM;
+
+  if (bom.nBytes >= 2 && memcmp(bom.bytes, UTF16LEBOM, 2) == 0)
+    return vcUE_UTF16LEBOM;
+
+  if (bom.nBytes >= 2 && memcmp(bom.bytes, UTF16BEBOM, 2) == 0)
+    return vcUE_UTF16BEBOM;
+
+  // Treat USC2 as UTF16 as UCS2 is a subset of UTF16 with identical BOMs
+
+  return vcUE_Unknown;
+}
+
+udResult vcUnicode_DetermineFileEncoding(const char *pFilePath, vcUnicodeEncoding *pEncoding)
+{
+  udResult result;
+  udFile *pFile = nullptr;
+  int64_t fileLength = -1;
+  size_t bytesRead = 0;
+  BOMBytes bom = {};
+
+  UD_ERROR_NULL(pFilePath, udR_InvalidParameter_);
+  UD_ERROR_NULL(pEncoding, udR_InvalidParameter_);
+
+  UD_ERROR_CHECK(udFile_Open(&pFile, pFilePath, udFOF_Read, &fileLength));
+  UD_ERROR_CHECK(udFile_Read(pFile, bom.bytes, MAX_BOM_BYTES, 0, udFSW_SeekCur, &bytesRead));
+
+  bom.nBytes = uint32_t(bytesRead);
+
+  *pEncoding = vcUE_Unknown;
+
+  do
+  {
+    *pEncoding = vcUnicode_GetEncodingFromBOM(bom);
+    if (*pEncoding != vcUE_Unknown)
+      break;
+
+    // TODO From here we can try to probe the file to determine the encoding.
+
+  } while (false);
+
+  result = udR_Success;
+epilogue:
+  return result;
+}
+
+//----------------------------------------------------------------------------
+// 12dxml file parsing
+//----------------------------------------------------------------------------static bool vc12DXML_IsGreyColour(const char *pStr, uint32_t *pOut)
+bool vc12DXML_IsGreyColour(const char *pStr, uint32_t *pOut)
 {
   if (pStr == nullptr || pOut == nullptr)
     return false;
@@ -453,6 +533,14 @@ udResult vc12DXML_LoadProject(vc12DXML_Project &project, const char *pFilePath)
   udFilename fileName;
   char projectName[256] = {};
 
+  vcUnicodeEncoding encoding;
+
+  UD_ERROR_CHECK(vcUnicode_DetermineFileEncoding(pFilePath, &encoding));
+  UD_ERROR_IF(encoding == vcUE_UCS2LEBOM, udR_Unsupported);
+  UD_ERROR_IF(encoding == vcUE_UCS2BEBOM, udR_Unsupported);
+  UD_ERROR_IF(encoding == vcUE_UTF16LEBOM, udR_Unsupported);
+  UD_ERROR_IF(encoding == vcUE_UTF16BEBOM, udR_Unsupported);
+
   UD_ERROR_NULL(pFilePath, udR_InvalidParameter_);
 
   fileName.SetFromFullPath("%s", pFilePath);
@@ -460,7 +548,11 @@ udResult vc12DXML_LoadProject(vc12DXML_Project &project, const char *pFilePath)
   project.SetName(projectName);
 
   UD_ERROR_CHECK(udFile_Load(pFilePath, (void **)&pFileContents));
-  UD_ERROR_CHECK(xml.Parse(pFileContents));
+
+  if (encoding == vcUE_UTF8BOM)
+    UD_ERROR_CHECK(xml.Parse(pFileContents + 3));
+  else // Try to load as UTF8 or ANSI. Will fail here if anything else
+    UD_ERROR_CHECK(xml.Parse(pFileContents));
 
   UD_ERROR_CHECK(project.BeginBuild(&xml));
 
@@ -469,13 +561,19 @@ epilogue:
   return result;
 }
 
-void vc12DXML_Load(vcState *pProgramState, const char *pFilename)
+udResult vc12DXML_Load(vcState *pProgramState, const char *pFilename)
 {
+  udResult result;
   vc12DXML_Project project;
-  udResult result = vc12DXML_LoadProject(project, pFilename);
+
+  UD_ERROR_CHECK(vc12DXML_LoadProject(project, pFilename));
   if (result == udR_Success)
   {
     udProjectNode *pParentNode = pProgramState->sceneExplorer.clickedItem.pItem != nullptr ? pProgramState->sceneExplorer.clickedItem.pItem : pProgramState->activeProject.pRoot;
     project.AddToProject(pProgramState, pParentNode);
   }
+
+  result = udR_Success;
+epilogue:
+  return result;
 }

--- a/src/vcModals.cpp
+++ b/src/vcModals.cpp
@@ -1418,7 +1418,7 @@ void vcModals_DrawUnsupportedEncoding(vcState *pProgramState)
     else
       pProgramState->modalOpen = true;
 
-    ImGui::TextWrapped(vcString::Get("sceneExplorerUnsupportedEncodingText"));
+    ImGui::TextWrapped("%s", vcString::Get("sceneExplorerUnsupportedEncodingText"));
 
     // Close buttons
     if (ImGui::Button(vcString::Get("popupClose")) || vcHotkey::IsPressed(vcB_Cancel))

--- a/src/vcModals.cpp
+++ b/src/vcModals.cpp
@@ -1405,6 +1405,29 @@ void vcModals_DrawUnsupportedFiles(vcState *pProgramState)
   }
 }
 
+void vcModals_DrawUnsupportedEncoding(vcState *pProgramState)
+{
+  if (pProgramState->openModals & (1 << vcMT_UnsupportedEncoding))
+    ImGui::OpenPopup(vcString::Get("sceneExplorerUnsupportedEncodingTitle"));
+
+  ImGui::SetNextWindowSize(ImVec2(300, 100), ImGuiCond_Appearing);
+  if (ImGui::BeginPopupModal(vcString::Get("sceneExplorerUnsupportedEncodingTitle"), nullptr, ImGuiWindowFlags_NoResize | ImGuiWindowFlags_AlwaysAutoResize))
+  {
+    if (pProgramState->closeModals & (1 << vcMT_UnsupportedEncoding))
+      ImGui::CloseCurrentPopup();
+    else
+      pProgramState->modalOpen = true;
+
+    ImGui::TextWrapped(vcString::Get("sceneExplorerUnsupportedEncodingText"));
+
+    // Close buttons
+    if (ImGui::Button(vcString::Get("popupClose")) || vcHotkey::IsPressed(vcB_Cancel))
+      ImGui::CloseCurrentPopup();
+
+    ImGui::EndPopup();
+  }
+}
+
 void vcModals_DrawImageViewer(vcState *pProgramState)
 {
   if (pProgramState->openModals & (1 << vcMT_ImageViewer))
@@ -1790,6 +1813,7 @@ void vcModals_DrawModals(vcState *pProgramState)
   vcModals_DrawProjectInfo(pProgramState);
   vcModals_DrawImageViewer(pProgramState);
   vcModals_DrawUnsupportedFiles(pProgramState);
+  vcModals_DrawUnsupportedEncoding(pProgramState);
   vcModals_DrawProfile(pProgramState);
   vcModals_DrawChangePassword(pProgramState);
   vcModals_DrawConvert(pProgramState);

--- a/src/vcModals.h
+++ b/src/vcModals.h
@@ -16,6 +16,7 @@ enum vcModalTypes
   vcMT_ProjectReadOnly,
   vcMT_ProjectInfo,
   vcMT_UnsupportedFile,
+  vcMT_UnsupportedEncoding,
   vcMT_Profile,
   vcMT_Convert,
   vcMT_ChangePassword,


### PR DESCRIPTION
Fixes [AB#489](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/489)

This final PR should be enough to check off 12dxml support for this sprint.