### PR TITLE
Disabled play button when no flythrough recorded

### DIFF
--- a/src/scene/vcFlythrough.cpp
+++ b/src/scene/vcFlythrough.cpp
@@ -260,7 +260,7 @@ void vcFlythrough::HandleSceneEmbeddedUI(vcState *pProgramState)
   }
   else
   {
-    if (ImGui::Button(vcString::Get("flythroughPlay")))
+    if (ImGui::ButtonEx(vcString::Get("flythroughPlay"), ImVec2(0, 0), (m_flightPoints.length == 0 ? (ImGuiButtonFlags_)ImGuiButtonFlags_Disabled : ImGuiButtonFlags_None)))
     {
       pProgramState->pViewports[0].cameraInput.pAttachedToSceneItem = this;
       m_state = vcFTS_Playing;


### PR DESCRIPTION
Fixes [AB#2179](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2179)