### PR TITLE
Flythroughs can no longer be exported without recording first

### DIFF
--- a/src/scene/vcFlythrough.cpp
+++ b/src/scene/vcFlythrough.cpp
@@ -308,7 +308,7 @@ void vcFlythrough::HandleSceneEmbeddedUI(vcState *pProgramState)
 
     vcIGSW_FilePicker(pProgramState, vcString::Get("flythroughExportPath"), m_exportPath, udLengthOf(m_exportPath), nullptr, 0, vcFDT_SelectDirectory, nullptr);
     
-    if (ImGui::ButtonEx(vcString::Get("flythroughExport"), ImVec2(0, 0), (m_exportPath[0] == '\0' ? (ImGuiButtonFlags_)ImGuiButtonFlags_Disabled : ImGuiButtonFlags_None)))
+    if (ImGui::ButtonEx(vcString::Get("flythroughExport"), ImVec2(0, 0), (m_exportPath[0] == '\0' || m_flightPoints.length == 0 ? (ImGuiButtonFlags_)ImGuiButtonFlags_Disabled : ImGuiButtonFlags_None)))
     {
       m_state = vcFTS_Exporting;
       pProgramState->screenshot.pImage = nullptr;


### PR DESCRIPTION
Fixes [AB#2216](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2216)