### PR TITLE
Discarding the first (blank) image

### DIFF
--- a/src/scene/vcFlythrough.cpp
+++ b/src/scene/vcFlythrough.cpp
@@ -58,7 +58,7 @@ void vcFlythrough::AddToScene(vcState *pProgramState, vcRenderData * /*pRenderDa
   {
     if (pProgramState->screenshot.pImage != nullptr)
     {
-      if (m_exportInfo.currentFrame >= 0)
+      if (m_exportInfo.currentFrame > 0)
       {
         if (vcTexture_SaveImage(pProgramState->screenshot.pImage, vcRender_GetSceneFramebuffer(pProgramState->pActiveViewport->pRenderContext), udTempStr("%s/%05d.png", m_exportPath, m_exportInfo.currentFrame)) != udR_Success)
         {


### PR DESCRIPTION
Fixes [AB#2175](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2175)

NOTE: This nature bug has changed since it was logged. There is no longer any `_Temp` directory; there is no default path, the user must enter a path. Also all output images seem to be ok, except for the first, which is indeed blank. 

This PR doesn't fix the root cause, but simply discards the first output image. While I dig down and try to find out why this render is failing, I thought I might throw this 'fix' to you guys. If it's accepted I'll take that as it's good enough, otherwise happy if it's rejected.