### PR TITLE
Added a prompt if folder contains same Flythrough images

### DIFF
--- a/builds/assets/lang/enAU.json
+++ b/builds/assets/lang/enAU.json
@@ -333,6 +333,7 @@
   "flythroughCopyPosition": "Copy current position to this frame",
   "flythroughAddAfter": "Add new frame after this frame",
   "flythroughRemoveAt": "Remove this frame",
+  "flythroughExportAlreadyExists": "A Flythrough already exists in this location.\nWould you like to overwrite existing Flythrough?\nIf so some older files may remain.",
   "menuSystem": "System",
   "menuExperimentalFeatures": "Experimental Features",
   "menuWindows": "Windows",

--- a/src/scene/vcFlythrough.cpp
+++ b/src/scene/vcFlythrough.cpp
@@ -12,6 +12,7 @@
 #include "imgui.h"
 #include "imgui_ex/vcImGuiSimpleWidgets.h"
 #include "imgui_internal.h"
+#include "vcModals.h"
 
 static const int vcFlythroughExportFPS[] = { 12, 24, 30, 60, 120 };
 const char *vcFlythroughExportFormats[] =
@@ -61,7 +62,7 @@ void vcFlythrough::AddToScene(vcState *pProgramState, vcRenderData *pRenderData)
     {
       if (m_exportInfo.currentFrame >= 0)
       {
-        if (vcTexture_SaveImage(pProgramState->screenshot.pImage, vcRender_GetSceneFramebuffer(pProgramState->pActiveViewport->pRenderContext), udTempStr("%s/%05d.png", m_exportPath, m_exportInfo.currentFrame)) != udR_Success)
+        if (vcTexture_SaveImage(pProgramState->screenshot.pImage, vcRender_GetSceneFramebuffer(pProgramState->pActiveViewport->pRenderContext), udTempStr("%s/%05d.%s", m_exportPath, m_exportInfo.currentFrame, vcFlythroughExportFormats[m_selectedExportFormatIndex])) != udR_Success)
         {
           m_state = vcFTS_None;
           pProgramState->exportVideo = false;

--- a/src/scene/vcFlythrough.cpp
+++ b/src/scene/vcFlythrough.cpp
@@ -309,12 +309,15 @@ void vcFlythrough::HandleSceneEmbeddedUI(vcState *pProgramState)
 
     if (ImGui::ButtonEx(vcString::Get("flythroughExport"), ImVec2(0, 0), (m_exportPath[0] == '\0' || m_flightPoints.length == 0 ? (ImGuiButtonFlags_)ImGuiButtonFlags_Disabled : ImGuiButtonFlags_None)))
     {
-      m_state = vcFTS_Exporting;
-      pProgramState->screenshot.pImage = nullptr;
-      m_exportInfo.currentFrame = -2;
-      pProgramState->pViewports[0].cameraInput.pAttachedToSceneItem = this;
-      pProgramState->exportVideo = true;
-      pProgramState->exportVideoResolution = vcScreenshotResolutions[m_selectedResolutionIndex];
+      if (vcModals_OverwriteExistingFile(pProgramState, udTempStr("%s/%05d.%s", m_exportPath, 0, vcFlythroughExportFormats[m_selectedExportFormatIndex]), vcString::Get("flythroughExportAlreadyExists")))
+      {
+        m_state = vcFTS_Exporting;
+        pProgramState->screenshot.pImage = nullptr;
+        m_exportInfo.currentFrame = -2;
+        pProgramState->pViewports[0].cameraInput.pAttachedToSceneItem = this;
+        pProgramState->exportVideo = true;
+        pProgramState->exportVideoResolution = vcScreenshotResolutions[m_selectedResolutionIndex];
+      }
     }
     break;
   case vcFTS_Playing:

--- a/src/vcModals.cpp
+++ b/src/vcModals.cpp
@@ -57,7 +57,6 @@ void vcModals_DrawLoggedOut(vcState *pProgramState)
 bool vcModals_OverwriteExistingFile(vcState* pProgramState, const char* pFilename, const char* pFileExistingMsg)
 {
   bool result = true;
-  //const char *pFileExistsMsg = nullptr;
   if (udFileExists(pFilename) == udR_Success)
   {
     const SDL_MessageBoxButtonData buttons[] = {
@@ -78,7 +77,6 @@ bool vcModals_OverwriteExistingFile(vcState* pProgramState, const char* pFilenam
     int buttonid = 0;
     if (SDL_ShowMessageBox(&messageboxdata, &buttonid) != 0 || buttonid == 0)
       result = false;
-    //udFree(pFileExistingMsg);
   }
   return result;
 }

--- a/src/vcModals.cpp
+++ b/src/vcModals.cpp
@@ -54,22 +54,23 @@ void vcModals_DrawLoggedOut(vcState *pProgramState)
 }
 
 // Presents user with a message if the specified file exists, then returns false if user declines to overwrite the file
-bool vcModals_OverwriteExistingFile(vcState *pProgramState, const char *pFilename)
+bool vcModals_OverwriteExistingFile(vcState* pProgramState, const char* pFilename, const char* pFileExistingMsg)
 {
   bool result = true;
-  const char *pFileExistsMsg = nullptr;
+  //const char *pFileExistsMsg = nullptr;
   if (udFileExists(pFilename) == udR_Success)
   {
     const SDL_MessageBoxButtonData buttons[] = {
       { SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT, 0, vcString::Get("popupConfirmNo") },
       { SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT, 1, vcString::Get("popupConfirmYes") },
     };
-    pFileExistsMsg = vcStringFormat(vcString::Get("convertFileExistsMessage"), pFilename);
+    if (pFileExistingMsg == nullptr)
+      pFileExistingMsg = vcStringFormat(vcString::Get("convertFileExistsMessage"), pFilename);
     SDL_MessageBoxData messageboxdata = {
       SDL_MESSAGEBOX_INFORMATION,
       pProgramState->pWindow,
       vcString::Get("convertFileExistsTitle"),
-      pFileExistsMsg,
+      pFileExistingMsg,
       SDL_arraysize(buttons),
       buttons,
       nullptr
@@ -77,7 +78,7 @@ bool vcModals_OverwriteExistingFile(vcState *pProgramState, const char *pFilenam
     int buttonid = 0;
     if (SDL_ShowMessageBox(&messageboxdata, &buttonid) != 0 || buttonid == 0)
       result = false;
-    udFree(pFileExistsMsg);
+    //udFree(pFileExistingMsg);
   }
   return result;
 }

--- a/src/vcModals.cpp
+++ b/src/vcModals.cpp
@@ -54,7 +54,7 @@ void vcModals_DrawLoggedOut(vcState *pProgramState)
 }
 
 // Presents user with a message if the specified file exists, then returns false if user declines to overwrite the file
-bool vcModals_OverwriteExistingFile(vcState* pProgramState, const char* pFilename, const char* pFileExistingMsg)
+bool vcModals_OverwriteExistingFile(vcState *pProgramState, const char *pFilename, const char *pFileExistingMsg)
 {
   bool result = true;
   if (udFileExists(pFilename) == udR_Success)

--- a/src/vcModals.h
+++ b/src/vcModals.h
@@ -32,7 +32,7 @@ void vcModals_CloseModal(vcState *pProgramState, vcModalTypes type);
 void vcModals_DrawModals(vcState *pProgramState);
 
 // Returns true if its safe to write- if exists the user is asked if it can be overriden
-bool vcModals_OverwriteExistingFile(vcState *pProgramState, const char *pFilename, const char* pFileExistingMsg = nullptr);
+bool vcModals_OverwriteExistingFile(vcState *pProgramState, const char *pFilename, const char *pFileExistingMsg = nullptr);
 
 // Returns true if user accepts action
 bool vcModals_AllowDestructiveAction(vcState *pProgramState, const char *pTitle, const char *pMessage);

--- a/src/vcModals.h
+++ b/src/vcModals.h
@@ -32,7 +32,7 @@ void vcModals_CloseModal(vcState *pProgramState, vcModalTypes type);
 void vcModals_DrawModals(vcState *pProgramState);
 
 // Returns true if its safe to write- if exists the user is asked if it can be overriden
-bool vcModals_OverwriteExistingFile(vcState *pProgramState, const char *pFilename);
+bool vcModals_OverwriteExistingFile(vcState *pProgramState, const char *pFilename, const char* pFileExistingMsg = nullptr);
 
 // Returns true if user accepts action
 bool vcModals_AllowDestructiveAction(vcState *pProgramState, const char *pTitle, const char *pMessage);


### PR DESCRIPTION
Expanded vcModals_OverwriteExistingFile to specify a string for the message displayed
Also fixed the saved texture to use the extension specified.
Fixes [AB#2225](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2225)
Fixes [AB#2213](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2213)