### PR TITLE
Waiting another frame before starting to export

### DIFF
--- a/src/scene/vcFlythrough.cpp
+++ b/src/scene/vcFlythrough.cpp
@@ -306,7 +306,7 @@ void vcFlythrough::HandleSceneEmbeddedUI(vcState *pProgramState)
     {
       m_state = vcFTS_Exporting;
       pProgramState->screenshot.pImage = nullptr;
-      m_exportInfo.currentFrame = -1;
+      m_exportInfo.currentFrame = -2;
       pProgramState->pViewports[0].cameraInput.pAttachedToSceneItem = this;
       pProgramState->exportVideo = true;
       pProgramState->exportVideoResolution = vcScreenshotResolutions[m_selectedResolutionIndex];


### PR DESCRIPTION
Fixes [AB#2175](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2175)

We need to wait another frame to allow correct setup. Also the nature of the bug has changed a bit, see the devopts item for details.