### PR TITLE
ImGUI Font Texture Linear

### DIFF
--- a/src/imgui_ex/imgui_impl_gl.cpp
+++ b/src/imgui_ex/imgui_impl_gl.cpp
@@ -114,7 +114,7 @@ bool ImGuiGL_CreateFontsTexture()
 
   io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);   // Load as RGBA 32-bits for OpenGL3 demo because it is more likely to be compatible with user's existing shader.
 
-  vcTexture_Create(&g_pFontTexture, width, height, pixels);
+  vcTexture_Create(&g_pFontTexture, width, height, pixels, vcTextureFormat_RGBA8, vcTFM_Linear);
 
   // Store our identifier
   io.Fonts->TexID = g_pFontTexture;


### PR DESCRIPTION
- ImGUI Font texture using Linear instead of Nearest
- Fixes [AB#2192](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2192)