### PR TITLE
Flythrough First Frame Constrain Max Time

### DIFF
--- a/src/scene/vcFlythrough.cpp
+++ b/src/scene/vcFlythrough.cpp
@@ -166,7 +166,7 @@ void vcFlythrough::HandleSceneExplorerUI(vcState *pProgramState, size_t *pItemID
     ImGui::PushID(udTempStr("ftpt_%zu", (*pItemID)));
 
     double minTime = (i == 0 ? 0 : m_flightPoints[i-1].time);
-    double maxTime = (i == 0 ? 0 : (i == m_flightPoints.length - 1 ? m_flightPoints[i].time + 10.0 : m_flightPoints[i + 1].time));
+    double maxTime = (i == m_flightPoints.length - 1 ? m_flightPoints[i].time + 10.0 : m_flightPoints[i + 1].time);
 
     if (ImGui::DragScalar("T", ImGuiDataType_Double, &m_flightPoints[i].time, 0.1f, &minTime, &maxTime))
     {

--- a/src/scene/vcFlythrough.cpp
+++ b/src/scene/vcFlythrough.cpp
@@ -165,11 +165,15 @@ void vcFlythrough::HandleSceneExplorerUI(vcState *pProgramState, size_t *pItemID
   {
     ImGui::PushID(udTempStr("ftpt_%zu", (*pItemID)));
 
-    double minTime = (i == 0 ? 0 : m_flightPoints[i-1].time);
-    double maxTime = (i == m_flightPoints.length - 1 ? m_flightPoints[i].time + 10.0 : m_flightPoints[i + 1].time);
+    double minTime = (i == 0 ? 0 : m_flightPoints[i - 1].time);
+    double maxTime = (i == 0 ? 0 : (i == m_flightPoints.length - 1 ? m_flightPoints[i].time + 10.0 : m_flightPoints[i + 1].time));
 
-    if (ImGui::DragScalar("T", ImGuiDataType_Double, &m_flightPoints[i].time, 0.1f, &minTime, &maxTime))
+    if (ImGui::DragScalar("T", ImGuiDataType_Double, &m_flightPoints[i].time, 0.1f, &minTime, &maxTime, 0, ImGuiSliderFlags_ClampOnInput))
     {
+      // ImGui::DragScalar doesn't clamp when min/max are the same value
+      if (minTime == maxTime)
+        m_flightPoints[i].time = minTime;
+
       if (i == m_flightPoints.length - 1)
         m_timeLength = m_flightPoints[i].time;
     }


### PR DESCRIPTION
- Fixed bug in calculating First frame max time
- Fixes [AB#2223](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2223)