### PR TITLE
Adding deltaTime to time length when inserting new flight points

### DIFF
--- a/src/scene/vcFlythrough.cpp
+++ b/src/scene/vcFlythrough.cpp
@@ -114,7 +114,7 @@ void vcFlythrough::AddToScene(vcState *pProgramState, vcRenderData *pRenderData)
       for (size_t i = offset + 1; i < m_flightPoints.length; ++i)
         m_flightPoints[i].time += pProgramState->deltaTime;
 
-      m_timeLength += pProgramState->deltaTime;
+      m_timeLength = m_flightPoints[m_flightPoints.length - 1].time;
     }
   }
 

--- a/src/scene/vcFlythrough.cpp
+++ b/src/scene/vcFlythrough.cpp
@@ -113,6 +113,8 @@ void vcFlythrough::AddToScene(vcState *pProgramState, vcRenderData *pRenderData)
 
       for (size_t i = offset + 1; i < m_flightPoints.length; ++i)
         m_flightPoints[i].time += pProgramState->deltaTime;
+
+      m_timeLength += pProgramState->deltaTime;
     }
   }
 


### PR DESCRIPTION
Fixes [AB#2227](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2227)