### PR TITLE
Positional input only when the enter key is pressed

### DIFF
--- a/src/scene/vcCrossSectionNode.cpp
+++ b/src/scene/vcCrossSectionNode.cpp
@@ -71,9 +71,18 @@ void vcCrossSectionNode::HandleSceneExplorerUI(vcState *pProgramState, size_t *p
 {
   bool changed = false;
 
-  if (ImGui::InputScalarN(udTempStr("%s##FilterPosition%zu", vcString::Get("sceneFilterPosition"), *pItemID), ImGuiDataType_Double, &m_position.x, 3))
+  udDouble3 positionTemp = m_position;
+  ImGui::InputScalarN(udTempStr("%s##FilterPosition%zu", vcString::Get("sceneFilterPosition"), *pItemID), ImGuiDataType_Double, &positionTemp.x, 3);
+  if (ImGui::IsItemDeactivatedAfterEdit())
+  {
+    for (int i = 0; i < 3; ++i)
+    {
+      if (isfinite(positionTemp[i]))
+        m_position[i] = positionTemp[i];
+    }
+
     vcProject_UpdateNodeGeometryFromCartesian(m_pProject, m_pNode, pProgramState->geozone, udPGT_Point, &m_position, 1);
-  changed |= ImGui::IsItemDeactivatedAfterEdit();
+  }
 
   if (ImGui::InputScalarN(udTempStr("%s##FilterRotation%zu", vcString::Get("sceneFilterRotation"), *pItemID), ImGuiDataType_Double, &m_headingPitch.x, 2))
   {


### PR DESCRIPTION
Fixes [AB#2236](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2236)

This PR was also to fix [AB#2241](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2241). It indeed fixes the immediate issue of entering an `inf` (max 9s), but large values become `inf`/`nan` anyway once put through the lat/long conversions. This is a more difficult problem and I'm not actually sure what to do here.