### PR TITLE
Wait on streamer for flythough exports and screenshots

### DIFF
--- a/src/vcRender.cpp
+++ b/src/vcRender.cpp
@@ -1776,7 +1776,11 @@ udResult vcRender_RenderUD(vcState *pProgramState, vcRenderContext *pRenderConte
 
   renderOptions.pFilter = renderData.pQueryFilter;
   renderOptions.pointMode = (udRenderContextPointMode)pProgramState->settings.presentation.pointMode;
-  renderOptions.flags = (udRenderContextFlags)(udRCF_LogarithmicDepth | udRCF_ManualStreamerUpdate);
+
+  if (pProgramState->exportVideo || pProgramState->settings.screenshot.taking)
+    renderOptions.flags = (udRenderContextFlags)(udRCF_LogarithmicDepth | udRCF_BlockingStreaming);
+  else
+    renderOptions.flags = (udRenderContextFlags)(udRCF_LogarithmicDepth | udRCF_ManualStreamerUpdate);
 
   udError result = udRenderContext_Render(pRenderContext->udRenderContext.pRenderer, pRenderTarget, pModels, numVisibleModels, &renderOptions);
 


### PR DESCRIPTION
Fixes [AB#2224](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2224)

This improves output quite a bit, but could still use some refinement. Also this does not solve where map tiles (or anything else that needs to stream in) haven't loaded in during a screenshot. Perhaps that should be a different PR.