### PR TITLE
Map Mode Right Click fix

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2649,7 +2649,7 @@ void vcMain_RenderSceneWindow(vcState *pProgramState)
       renderData.pins.Deinit();
 
       // Handle context menu
-      if (!isFixedOrthographicViewport && (wasViewportContextMenuOpenLastFrame == -1 || wasViewportContextMenuOpenLastFrame == viewportIndex))
+      if ((wasViewportContextMenuOpenLastFrame == -1 || wasViewportContextMenuOpenLastFrame == viewportIndex))
       {
         if ((io.MouseDragMaxDistanceSqr[1] < (io.MouseDragThreshold * io.MouseDragThreshold) && ImGui::BeginPopupContextItem("SceneContext")))
         {


### PR DESCRIPTION
- Allow Right-click context menu when in mapmode
- Fixes [AB#2151](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2151)