### PR TITLE
Copying zone even when zone in nongeolocated

### DIFF
--- a/src/scene/vcModel.cpp
+++ b/src/scene/vcModel.cpp
@@ -377,13 +377,13 @@ void vcModel::ChangeProjection(const udGeoZone &newZone)
 
   m_changeZones = false;
 
-  if (newZone.srid == 0)
-    return;
-
-  if (m_pCurrentZone != nullptr)
-    m_sceneMatrix = udGeoZone_TransformMatrix(m_sceneMatrix, *m_pCurrentZone, newZone);
-  else if (m_pPreferredProjection != nullptr)
-    m_sceneMatrix = udGeoZone_TransformMatrix(m_baseMatrix, *m_pPreferredProjection, newZone);
+  if (newZone.srid != 0)
+  {
+    if (m_pCurrentZone != nullptr)
+      m_sceneMatrix = udGeoZone_TransformMatrix(m_sceneMatrix, *m_pCurrentZone, newZone);
+    else if (m_pPreferredProjection != nullptr)
+      m_sceneMatrix = udGeoZone_TransformMatrix(m_baseMatrix, *m_pPreferredProjection, newZone);
+  }
 
   if (m_pCurrentZone == nullptr)
     m_pCurrentZone = udAllocType(udGeoZone, 1, udAF_None);


### PR DESCRIPTION
Fixes [AB#1841](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1841)

Strictly speaking, the steps to repo this item is actually not a bug. You can't export a model that has been moved from its default transform. However, the user should have been able to select `Reset All` in non geolocated space and then export. This was not happening as `Resetting` did not reset the model to the default matrix. This PR should fix that.