### PR TITLE
Flythrough Browser Export Disable

### DIFF
--- a/src/scene/vcFlythrough.cpp
+++ b/src/scene/vcFlythrough.cpp
@@ -299,7 +299,8 @@ void vcFlythrough::HandleSceneEmbeddedUI(vcState *pProgramState)
       m_state = vcFTS_Playing;
       m_timePosition = 0.0;
     }
-    
+
+#if VC_HASCONVERT
     if (ImGui::BeginMenu(vcString::Get("flythroughExport"), m_flightPoints.length > 0))
     {
       if (ImGui::BeginCombo(vcString::Get("flythroughResolution"), vcString::Get(vcScreenshotResolutionNameKeys[m_selectedResolutionIndex])))
@@ -353,7 +354,7 @@ void vcFlythrough::HandleSceneEmbeddedUI(vcState *pProgramState)
 
       ImGui::EndMenu();
     }
-
+#endif // VC_HASCONVERT
     break;
   case vcFTS_Playing:
     if (ImGui::Button(vcString::Get("flythroughPlayStop")))


### PR DESCRIPTION
- Disabled Exporting Flythrough points if unable to convert as well
- Fixes [AB#2219](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2219)