### PR TITLE
Flythrough Remove Camera Detach UI

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1383,7 +1383,7 @@ void vcRenderSceneUI(vcState *pProgramState, const ImVec2 &windowPos, const ImVe
     ImGui::End();
   }
 
-  if (pProgramState->pActiveViewport->cameraInput.pAttachedToSceneItem != nullptr)
+  if (pProgramState->pActiveViewport->cameraInput.pAttachedToSceneItem != nullptr && !udStrEqual(pProgramState->pActiveViewport->cameraInput.pAttachedToSceneItem->m_pNode->itemtypeStr, "FlyPath"))
   {
     ImGui::SetNextWindowPos(ImVec2(windowPos.x + windowSize.x, windowPos.y), ImGuiCond_Always, ImVec2(1.f, 0.f));
     ImGui::SetNextWindowSizeConstraints(ImVec2(200, 0), ImVec2(FLT_MAX, FLT_MAX)); // Set minimum width to include the header


### PR DESCRIPTION
- Removed "Detach Camera UI" for when a flythrough is controlling a camera
- Fixes [AB#2185](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2185)
