### PR TITLE
Hide classification colours

### DIFF
--- a/src/vcSettingsUI.cpp
+++ b/src/vcSettingsUI.cpp
@@ -855,7 +855,9 @@ void vcSettingsUI_BasicMapSettings(vcState *pProgramState, bool alwaysShowOption
 void vcSettingsUI_SceneVisualizationSettings(vcState *pProgramState)
 {
   vcSettingsUI_VisualizationSettings(&pProgramState->settings.visualization);
-  vcSettingsUI_CustomClassificationColours(pProgramState, &pProgramState->settings.visualization);
+
+  if (pProgramState->settings.visualization.mode == vcVM_Classification)
+    vcSettingsUI_CustomClassificationColours(pProgramState, &pProgramState->settings.visualization);
 
   const char *lensNameArray[] = {
     vcString::Get("settingsViewportCameraLensCustom"),


### PR DESCRIPTION
- Hide Classification Colours when not in Classification mode
- Fixes [AB#2262](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2262)