### PR TITLE
Project Save/Load Default SRID

### DIFF
--- a/builds/assets/lang/enAU.json
+++ b/builds/assets/lang/enAU.json
@@ -367,6 +367,7 @@
   "menuProjectNone": "No server projects",
   "menuProjectSettingsTitle": "Project Settings",
   "menuProjectName": "Project Name",
+  "menuProjectDefaultSRID": "Project Default SRID",
   "menuProjectInfo": "Project Info",
   "menuProjectSlideshow": "Show viewpoints as slideshow",
   "menuFileName": "File Name",

--- a/src/scene/vcFolder.cpp
+++ b/src/scene/vcFolder.cpp
@@ -84,12 +84,23 @@ void vcFolder::AddToScene(vcState *pProgramState, vcRenderData *pRenderData)
         continue;
       }
 
-      if (pSceneItem->m_loadStatus == vcSLS_Loaded && pProgramState->sceneExplorer.movetoUUIDWhenPossible[0] != '\0' && udStrEqual(pProgramState->sceneExplorer.movetoUUIDWhenPossible, pNode->UUID))
+      if (pSceneItem->m_loadStatus == vcSLS_Loaded)
       {
-        udWorkerPool_AddTask(pProgramState->pWorkerPool, nullptr, nullptr, false, [pProgramState, pSceneItem](void*) {
-          vcProject_UseProjectionFromItem(pProgramState, pSceneItem);
-          memset(pProgramState->sceneExplorer.movetoUUIDWhenPossible, 0, sizeof(pProgramState->sceneExplorer.movetoUUIDWhenPossible));
-        });
+        if (pProgramState->sceneExplorer.movetoUUIDWhenPossible[0] != '\0' && udStrEqual(pProgramState->sceneExplorer.movetoUUIDWhenPossible, pNode->UUID))
+        {
+          udWorkerPool_AddTask(pProgramState->pWorkerPool, nullptr, nullptr, false, [pProgramState, pSceneItem](void *) {
+            vcProject_UseProjectionFromItem(pProgramState, pSceneItem);
+            memset(pProgramState->sceneExplorer.movetoUUIDWhenPossible, 0, sizeof(pProgramState->sceneExplorer.movetoUUIDWhenPossible));
+            });
+        }
+
+        if (pProgramState->sceneExplorer.movetoUUIDWithoutProjectionWhenPossible[0] != '\0' && udStrEqual(pProgramState->sceneExplorer.movetoUUIDWithoutProjectionWhenPossible, pNode->UUID))
+        {
+          udWorkerPool_AddTask(pProgramState->pWorkerPool, nullptr, nullptr, false, [pProgramState, pSceneItem](void *) {
+            pSceneItem->SetCameraPosition(pProgramState);
+            memset(pProgramState->sceneExplorer.movetoUUIDWithoutProjectionWhenPossible, 0, sizeof(pProgramState->sceneExplorer.movetoUUIDWithoutProjectionWhenPossible));
+            });
+        }
       }
     }
     else

--- a/src/vcModals.cpp
+++ b/src/vcModals.cpp
@@ -1178,10 +1178,13 @@ void vcModals_DrawProjectSettings(vcState *pProgramState)
 
     ImGui::InputText(vcString::Get("menuProjectName"), pProgramState->modelPath, udLengthOf(pProgramState->modelPath));
 
+    if (ImGui::InputInt(vcString::Get("menuProjectDefaultSRID"), &pProgramState->activeProject.recommendedSRID))
+      udProjectNode_SetMetadataInt(pProgramState->activeProject.pRoot, "defaultcrs", pProgramState->activeProject.recommendedSRID);
+
     ImGui::Columns(2);
 
     ImVec2 size = ImGui::GetWindowSize();
-    ImGui::InputTextMultiline(vcString::Get("menuProjectInfo"), information, udLengthOf(information), ImVec2(0, size.y - 117));
+    ImGui::InputTextMultiline(vcString::Get("menuProjectInfo"), information, udLengthOf(information), ImVec2(0, size.y - 142));
 
     ImGui::NextColumn();
 

--- a/src/vcProject.cpp
+++ b/src/vcProject.cpp
@@ -207,7 +207,13 @@ bool vcProject_ExtractCameraRecursive(vcState *pProgramState, udProjectNode *pPa
         pProgramState->pViewports[viewportIndex].camera.headingPitch = headingPitch;
       }
 
+      // unset
+      memset(pProgramState->sceneExplorer.movetoUUIDWithoutProjectionWhenPossible, 0, sizeof(pProgramState->sceneExplorer.movetoUUIDWithoutProjectionWhenPossible));
       return true;
+    }
+    else if (pNode->itemtype == udPNT_PointCloud)
+    {
+      udStrcpy(pProgramState->sceneExplorer.movetoUUIDWithoutProjectionWhenPossible, pNode->UUID);
     }
 
     if (vcProject_ExtractCameraRecursive(pProgramState, pNode))

--- a/src/vcProject.cpp
+++ b/src/vcProject.cpp
@@ -207,13 +207,7 @@ bool vcProject_ExtractCameraRecursive(vcState *pProgramState, udProjectNode *pPa
         pProgramState->pViewports[viewportIndex].camera.headingPitch = headingPitch;
       }
 
-      // unset
-      memset(pProgramState->sceneExplorer.movetoUUIDWhenPossible, 0, sizeof(pProgramState->sceneExplorer.movetoUUIDWhenPossible));
       return true;
-    }
-    else if (pNode->itemtype == udPNT_PointCloud)
-    {
-      udStrcpy(pProgramState->sceneExplorer.movetoUUIDWhenPossible, pNode->UUID);
     }
 
     if (vcProject_ExtractCameraRecursive(pProgramState, pNode))
@@ -300,8 +294,8 @@ bool vcProject_LoadFromServer(vcState *pProgramState, const char *pProjectID)
     if (projectZone > 0 && udGeoZone_SetFromSRID(&pProgramState->activeProject.baseZone, projectZone) != udR_Success)
       udGeoZone_SetFromSRID(&pProgramState->activeProject.baseZone, vcPSZ_StandardGeoJSON);
 
-    int32_t recommendedSRID = -1;
-    if (udProjectNode_GetMetadataInt(pProgramState->activeProject.pRoot, "defaultcrs", &recommendedSRID, pProgramState->activeProject.baseZone.srid) == udE_Success && recommendedSRID >= 0 && ((udGeoZone_SetFromSRID(&zone, recommendedSRID) == udR_Success) || recommendedSRID == 0))
+    pProgramState->activeProject.recommendedSRID = -1;
+    if (udProjectNode_GetMetadataInt(pProgramState->activeProject.pRoot, "defaultcrs", &pProgramState->activeProject.recommendedSRID, pProgramState->activeProject.baseZone.srid) == udE_Success && pProgramState->activeProject.recommendedSRID >= 0 && ((udGeoZone_SetFromSRID(&zone, pProgramState->activeProject.recommendedSRID) == udR_Success) || pProgramState->activeProject.recommendedSRID == 0))
       vcGIS_ChangeSpace(&pProgramState->geozone, zone);
 
     const char *pInfo = nullptr;
@@ -362,8 +356,8 @@ bool vcProject_LoadFromURI(vcState *pProgramState, const char *pFilename)
     if (projectZone > 0 && udGeoZone_SetFromSRID(&pProgramState->activeProject.baseZone, projectZone) != udR_Success)
       udGeoZone_SetFromSRID(&pProgramState->activeProject.baseZone, vcPSZ_StandardGeoJSON);
 
-    int32_t recommendedSRID = -1;
-    if (udProjectNode_GetMetadataInt(pProgramState->activeProject.pRoot, "defaultcrs", &recommendedSRID, pProgramState->activeProject.baseZone.srid) == udE_Success && recommendedSRID >= 0 && ((udGeoZone_SetFromSRID(&zone, recommendedSRID) == udR_Success) || recommendedSRID == 0))
+    pProgramState->activeProject.recommendedSRID = -1;
+    if (udProjectNode_GetMetadataInt(pProgramState->activeProject.pRoot, "defaultcrs", &pProgramState->activeProject.recommendedSRID, pProgramState->activeProject.baseZone.srid) == udE_Success && pProgramState->activeProject.recommendedSRID >= 0 && ((udGeoZone_SetFromSRID(&zone, pProgramState->activeProject.recommendedSRID) == udR_Success) || pProgramState->activeProject.recommendedSRID == 0))
       vcGIS_ChangeSpace(&pProgramState->geozone, zone);
 
     const char *pInfo = nullptr;

--- a/src/vcProject.h
+++ b/src/vcProject.h
@@ -22,6 +22,8 @@ struct vcProject
 
   bool slideshow;
   udProjectNode *pSlideshowViewpoint;
+
+  int32_t recommendedSRID;
 };
 
 enum vcProjectStandardZones

--- a/src/vcState.h
+++ b/src/vcState.h
@@ -254,6 +254,7 @@ struct vcState
   {
     char selectUUIDWhenPossible[37];
     char movetoUUIDWhenPossible[37];
+    char movetoUUIDWithoutProjectionWhenPossible[37];
 
     vcSceneItemRef insertItem;
     vcSceneItemRef clickedItem;


### PR DESCRIPTION
- Added ability to set the loading SRID
- Made it so that on loading a project you don't go to a models SRID, but instead go to the models position using the default SRID
- Fixes [AB#2244](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2244)