### PR TITLE
Tile Renderer Forced Update on Geozone Change

### DIFF
--- a/src/rendering/vcTileRenderer.cpp
+++ b/src/rendering/vcTileRenderer.cpp
@@ -1199,7 +1199,7 @@ void vcTileRenderer_Update(vcTileRenderer *pTileRenderer, const double deltaTime
   vcQuadTree_UpdateView(&pTileRenderer->quadTree, pCamera, viewInfo.viewProjectionMatrix);
 
   pTileRenderer->generateTreeUpdateTimer += pTileRenderer->frameDeltaTime;
-  if (pTileRenderer->generateTreeUpdateTimer >= QuadTreeUpdateFrequencySec)
+  if (pTileRenderer->generateTreeUpdateTimer >= QuadTreeUpdateFrequencySec || pTileRenderer->quadTree.geozone.srid != pGeozone->srid)
   {
     pTileRenderer->generateTreeUpdateTimer = 0.0;
 


### PR DESCRIPTION
- Forced an update for TileRenderer->quadTree when the geozone is changed
- Fixes [AB#2284](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2284)