### PR TITLE
Gizmo Camera bug Fix

### DIFF
--- a/src/vcCamera.cpp
+++ b/src/vcCamera.cpp
@@ -508,7 +508,7 @@ void vcCamera_HandleSceneInput(vcState *pProgramState, vcViewport *pViewport, in
       }
     }
   }
-  pViewport->cameraInput.gizmoCapturedMouse = pViewport->cameraInput.gizmoCapturedMouse || (pViewport->gizmo.operation != 0 && vcGizmo_IsHovered(pViewport->gizmo.pContext, pViewport->gizmo.direction) && (isBtnClicked[0] || isBtnClicked[1] || isBtnClicked[2]));
+  pViewport->cameraInput.gizmoCapturedMouse = pViewport->cameraInput.gizmoCapturedMouse || (pViewport->gizmo.operation != 0 && !pProgramState->sceneExplorer.selectedItems.empty() && vcGizmo_IsHovered(pViewport->gizmo.pContext, pViewport->gizmo.direction) && (isBtnClicked[0] || isBtnClicked[1] || isBtnClicked[2]));
   if (pViewport->cameraInput.gizmoCapturedMouse)
   {
     // was the gizmo just released?


### PR DESCRIPTION
- Fixed a bug where deleting a model while hovering the gizmo disabled the camera
- Fixes [AB#2309](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2309)
