### PR TITLE
Check NOT success before opening error modal

### DIFF
--- a/src/vcError.cpp
+++ b/src/vcError.cpp
@@ -4,6 +4,9 @@
 
 void vcError_AddError(vcState *pProgramState, const ErrorItem &error)
 {
-  pProgramState->errorItems.PushBack(error);
-  vcModals_OpenModal(pProgramState, vcMT_ErrorInformation);
+  if (error.resultCode != udR_Success)
+  {
+    pProgramState->errorItems.PushBack(error);
+    vcModals_OpenModal(pProgramState, vcMT_ErrorInformation);
+  }
 }


### PR DESCRIPTION
- vcError_adderror function only opens the error modal if the error resultCode is NOT udr_success
- Fixes [AB#2331](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2331)