### PR TITLE
Fixed crash on Login error

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2991,10 +2991,7 @@ void vcMain_ShowLoginWindow(vcState *pProgramState)
     {
       ImGui::TextUnformatted(vcString::Get(loginStatusKeys[pProgramState->loginStatus]));
 
-      const bool isErrorStatus = udStrBeginsWith(loginStatusKeys[pProgramState->loginStatus], "loginError");
-
-      if (isErrorStatus)
-        ImGui::PopStyleColor();
+      udStrBeginsWith(loginStatusKeys[pProgramState->loginStatus], "loginError");
 
       // Tool for support to get reasons for failures, requires Alt & Ctrl
       if (pProgramState->logoutReason != udE_Success && io.KeyAlt && io.KeyCtrl)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2989,7 +2989,15 @@ void vcMain_ShowLoginWindow(vcState *pProgramState)
   {
     if (ImGui::Begin("loginTitle", nullptr, ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoSavedSettings))
     {
+      const bool isErrorStatus = udStrBeginsWith(loginStatusKeys[pProgramState->loginStatus], "loginError");
+
+      if (isErrorStatus)
+        ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0, 0.0, 0.0, 1.0));
+
       ImGui::TextUnformatted(vcString::Get(loginStatusKeys[pProgramState->loginStatus]));
+
+      if (isErrorStatus)
+        ImGui::PopStyleColor();
 
       // Tool for support to get reasons for failures, requires Alt & Ctrl
       if (pProgramState->logoutReason != udE_Success && io.KeyAlt && io.KeyCtrl)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2991,8 +2991,6 @@ void vcMain_ShowLoginWindow(vcState *pProgramState)
     {
       ImGui::TextUnformatted(vcString::Get(loginStatusKeys[pProgramState->loginStatus]));
 
-      udStrBeginsWith(loginStatusKeys[pProgramState->loginStatus], "loginError");
-
       // Tool for support to get reasons for failures, requires Alt & Ctrl
       if (pProgramState->logoutReason != udE_Success && io.KeyAlt && io.KeyCtrl)
       {


### PR DESCRIPTION
popStyleColor() crashes because there is no pushStyleColor() before so the .back on the vector crashes.
Fixes [AB#2354](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2354)