### PR TITLE
Project Save No Modal

### DIFF
--- a/src/vcProject.cpp
+++ b/src/vcProject.cpp
@@ -503,9 +503,12 @@ bool vcProject_SaveAs(vcState *pProgramState, const char *pPath, bool allowOverr
   else
     projectError.resultCode = udR_WriteFailure;
 
-  vcError_AddError(pProgramState, projectError);
+  if (projectError.resultCode != udR_Success)
+  {
+    pProgramState->errorItems.PushBack(projectError);
+    vcModals_OpenModal(pProgramState, vcMT_ProjectChange);
+  }
 
-  vcModals_OpenModal(pProgramState, vcMT_ProjectChange);
   vcProject_UpdateProjectHistory(pProgramState, exportFilename.GetPath(), false);
 
   return (projectError.resultCode == udR_Success);


### PR DESCRIPTION
- Uses the ProjectChange Modal instead of the normal Error modal if there was an error on Project Save
- Fixes [AB#2331](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2331)