### PR TITLE
Remove "Add Node here" from "Add Other" context menu

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2323,18 +2323,6 @@ void vcMain_ShowSceneExplorerWindow(vcState *pProgramState)
   vcMenuBarButton(pProgramState->pUITexture, vcString::Get("sceneExplorerAddOther"), vcB_Invalid, vcMBBI_AddOther, vcMBBG_SameGroup);
   if (ImGui::BeginPopupContextItem(vcString::Get("sceneExplorerAddOther"), 0))
   {
-    if (pProgramState->sceneExplorer.selectedItems.size() == 1)
-    {
-      const vcSceneItemRef &item = pProgramState->sceneExplorer.selectedItems[0];
-      if (item.pItem->itemtype == udPNT_PointOfInterest)
-      {
-        vcPOI* pPOI = (vcPOI*)item.pItem->pUserData;
-
-        if (ImGui::MenuItem(vcString::Get("scenePOIAddPoint")))
-          pPOI->AddPoint(pProgramState, pProgramState->pActiveViewport->worldAnchorPoint);
-      }
-    }
-
     if (ImGui::MenuItem(vcString::Get("sceneExplorerAddFeed"), nullptr, nullptr))
     {
       udProjectNode *pNode = nullptr;


### PR DESCRIPTION
- Removed "Add Node here" option from "Add other" menu
- Fixes [AB#1968](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/1968)