### PR TITLE
Converting tiff now supports a lot more of the tif spec

### DIFF
--- a/src/vcTiffConvert.cpp
+++ b/src/vcTiffConvert.cpp
@@ -473,7 +473,7 @@ static udError vcTiffImageReaderReadPixel_Tile(vcTiffConvertData *pConvertData, 
   pixelCoords.x = double(pConvertData->tile.currentPixel % pConvertData->tile.tileDimensions.x) * pConvertData->pointResolution;
   pixelCoords.y = double(pConvertData->tile.currentPixel / pConvertData->tile.tileDimensions.x) * pConvertData->pointResolution;
   pixelCoords.z = 0.0;
-  tileOrigin = {(double)pConvertData->tile.currentTileCoords.x * pConvertData->tile.tileDimensions.x, (double)pConvertData->tile.currentTileCoords.y * pConvertData->tile.tileDimensions.y};
+  tileOrigin = {(double)pConvertData->tile.currentTileCoords.x * pConvertData->tile.tileDimensions.x, (double)pConvertData->tile.currentTileCoords.y * pConvertData->tile.tileDimensions.y, 0.0};
   tileOrigin *= pConvertData->pointResolution;
 
   pPixelData->point = pConvertData->origin + tileOrigin + pixelCoords;
@@ -719,7 +719,7 @@ udError TiffConvert_ReadFloat(struct udConvertCustomItem *pConvertInput, struct 
   udError result;
   udError pixReadRes;
   vcTiffPixelData pixelData = {};
-  uint32_t colour;
+  uint32_t colour = 0xFFFF00FF;
   vcTiffConvertData *pData = nullptr;
 
   if (pConvertInput == nullptr || pBuffer == nullptr)

--- a/src/vcTiffConvert.cpp
+++ b/src/vcTiffConvert.cpp
@@ -53,6 +53,22 @@ struct vcTiffConvertData;
 typedef void(*vcTiffImageReaderDestroyFn)(vcTiffConvertData *pData);
 typedef udError(*vcTiffImageReaderReadPixelFn)(vcTiffConvertData *pData, vcTiffPixelData *pPixelData);
 
+struct TileData
+{
+  uint8_t *pRaster;
+  uint64_t currentPixel;
+  udVector2<uint32> tileDimensions;
+  udVector2<uint32_t> currentTileCoords;
+  uint64_t nTilePixels; // Can be less then the size of a tile
+};
+
+struct ScanLineData
+{
+  uint8_t *pRaster;
+  uint64_t currentPixel;
+  uint32 row;
+};
+
 struct vcTiffConvertData
 {
   TIFF *pTif;
@@ -64,21 +80,8 @@ struct vcTiffConvertData
 
   union
   {
-    struct TileData
-    {
-      uint8_t *pRaster;
-      uint64_t currentPixel;
-      udVector2<uint32> tileDimensions;
-      udVector2<uint32_t> currentTileCoords;
-      uint64_t nTilePixels; // Can be less then the size of a tile
-    } tile;
-    struct StripData {} strip; // TODO
-    struct ScanLineData
-    {
-      uint8_t *pRaster;
-      uint64_t currentPixel;
-      uint32 row;
-    } scanLine;
+    TileData tile;
+    ScanLineData scanLine;
   };
 
   uint32_t pointsWritten;

--- a/src/vcTiffConvert.cpp
+++ b/src/vcTiffConvert.cpp
@@ -10,146 +10,76 @@
 #include "udMath.h"
 #include "tiffio.h"
 
-// A class to read image data from a particular directory within a tiff file.
-class TiffPixelReader
+// There could be an arbitrary number of samples, but currently we only support 4: red, green, blue, alpha
+#define MAX_SAMPLES 4
+
+enum vcTiffPhotometric
 {
-public:
-
-  TiffPixelReader()
-    : m_pTiff(nullptr)
-    , m_pointResolution(0.01)
-    , m_origin{}
-    , m_convertFlags(udCCIF_None)
-  {
-
-  }
-
-  virtual ~TiffPixelReader()
-  {
-
-  }
-
-  udError Init(TIFF *pTiff)
-  {
-    m_pTiff = pTiff;
-    return OnInit();
-  }
-
-  virtual void ShutDown()
-  {
-    OnShutDown();
-  }
-
-  // Returns:
-  //    udE_Success: next pixel set
-  //    udE_NotFound: no more pixels to be found
-  //    udE_*: An error has occured
-  virtual udError GetNextPixel(udDouble3 *pCoords, uint32_t *pPixel) = 0;
-
-  void SetConvertDefaults(udDouble3 const & origin, double pointResolution, enum udConvertCustomItemFlags flags)
-  {
-    m_origin = origin;
-    m_pointResolution = pointResolution;
-    m_convertFlags = flags;
-  }
-
-protected:
-
-  virtual udError OnInit() = 0;
-  virtual void OnShutDown() = 0;
-
-  TIFF *m_pTiff;
-  double m_pointResolution;
-  udDouble3 m_origin;
-  udConvertCustomItemFlags m_convertFlags;
+  vcTP_GreyScale_WhiteIsZero = 0,
+  vcTP_GreyScale_BlackIsZero = 1,
+  vcTP_RGB                   = 2,
+  vcTP_ColourPalatte         = 3,
 };
 
-// TODO add TiffScanLineReader, TiffStripReader, TiffTIleReader.
-// And perhaps within these, objects to read the different types of data formats.
-
-class TiffFullImageReader : public TiffPixelReader
+struct vcTiffSampleData
 {
-public:
-
-  TiffFullImageReader()
-    : TiffPixelReader()
-    , m_pRaster(nullptr)
-    , m_currentPixel(0)
-    , m_imageDimensions{}
+  union
   {
-
-  }
-
-  ~TiffFullImageReader()
-  {
-    OnShutDown();
-  }
-
-  udError GetNextPixel(udDouble3 *pCoords, uint32_t *pPixel) override
-  {
-    udError result;
-    size_t pixelCount = (size_t)m_imageDimensions.x * m_imageDimensions.y;
-    uint64_t x;
-    uint64_t y;
-
-    if (pCoords == nullptr || pPixel == nullptr)
-      UD_ERROR_SET(udE_InvalidParameter);
-
-    ++m_currentPixel;
-
-    UD_ERROR_IF(m_currentPixel == pixelCount, udE_NotFound);
-
-    x = m_currentPixel % m_imageDimensions.x;
-    y = m_currentPixel / m_imageDimensions.x;
-
-    *pCoords = m_origin + udDouble3::create((double)x * m_pointResolution, (double)y * m_pointResolution, 0.0);
-    *pPixel = m_pRaster[m_currentPixel];
-
-    result = udE_Success;
-  epilogue:
-    return result;
-  }
-
-private:
-
-
-  udError OnInit() override
-  {
-    udError result;
-    size_t pixelCount;
-
-    m_currentPixel = 0;
-
-    UD_ERROR_IF(TIFFGetField(m_pTiff, TIFFTAG_IMAGEWIDTH, &m_imageDimensions.x) != 1, udE_ReadFailure);
-    UD_ERROR_IF(TIFFGetField(m_pTiff, TIFFTAG_IMAGELENGTH, &m_imageDimensions.y) != 1, udE_ReadFailure);
-
-    pixelCount = (size_t)m_imageDimensions.x * m_imageDimensions.y;
-    m_pRaster = (uint32 *)_TIFFmalloc(pixelCount * sizeof(uint32));
-    UD_ERROR_NULL(m_pRaster, udE_MemoryAllocationFailure);
-
-    UD_ERROR_IF(TIFFReadRGBAImageOriented(m_pTiff, m_imageDimensions.x, m_imageDimensions.y, m_pRaster, ORIENTATION_BOTLEFT, 0) == 0, udE_ReadFailure);
-
-    result = udE_Success;
-  epilogue:
-    return result;
-  }
-
-  void OnShutDown() override
-  {
-    _TIFFfree(m_pRaster);
-    m_pRaster = nullptr;
-    m_currentPixel = 0;
-  }
-
-  uint32 *m_pRaster;
-  uint64_t m_currentPixel;
-  udVector2<uint32> m_imageDimensions;
+    int64_t   t_int64[MAX_SAMPLES];  // Used to store 1, 2, 4, 8, 16, 32 and 64-bit int samples
+    uint64_t  t_uint64[MAX_SAMPLES]; // Used to store 1, 2, 4, 8, 16, 32 and 64-bit uint samples
+    double    t_double[MAX_SAMPLES]; // float32 values are promoted to doubles
+  };
 };
+
+struct vcTiffPixelData
+{
+  udDouble3 point;
+  vcTiffSampleData sample;
+};
+
+struct vcTiffImageFormat
+{
+  int32 imageDepth;
+  uint16 bitsPerSample;
+  uint16 sampleFormat;
+  uint16 samplesPerPixel;
+  uint16 photometric;
+  uint16 planarconfig;
+  uint16 **ppColourPalette; // Stored RRR...GGG...BBB..., number of colours == 2 ^ bitsPerSample, also samplesPerPixel MUST = 1
+};
+
+struct vcTiffConvertData;
+
+typedef void(*vcTiffImageReaderDestroyFn)(vcTiffConvertData *pData);
+typedef udError(*vcTiffImageReaderReadPixelFn)(vcTiffConvertData *pData, vcTiffPixelData *pPixelData);
 
 struct vcTiffConvertData
 {
-  TIFF *pTiff;
-  TiffPixelReader *pReader;
+  TIFF *pTif;
+  vcTiffImageReaderDestroyFn pDestroy;
+  vcTiffImageReaderReadPixelFn pRead;
+
+  vcTiffImageFormat format;
+  udVector2<uint32> imageDimensions;
+
+  union
+  {
+    struct TileData
+    {
+      uint8_t *pRaster;
+      uint64_t currentPixel;
+      udVector2<uint32> tileDimensions;
+      udVector2<uint32_t> currentTileCoords;
+      uint64_t nTilePixels; // Can be less then the size of a tile
+    } tile;
+    struct StripData {} strip; // TODO
+    struct ScanLineData
+    {
+      uint8_t *pRaster;
+      uint64_t currentPixel;
+      uint32 row;
+    } scanLine;
+  };
 
   uint32_t pointsWritten;
   uint32_t everyNth;
@@ -161,6 +91,508 @@ struct vcTiffConvertData
   uint32_t directoryCount;
   uint64_t pointsProcessed;
 };
+
+static void vcTiff_PackSamples(uint8_t *pBuf, uint8_t *pSampleBuf, uint32_t sampleCount, uint32_t sampleBitWidth, uint32_t samplesPerPixel, uint32_t sample)
+{
+  if (sampleBitWidth < 8)
+  {
+    UDASSERT(false, "TODO!");
+  }
+  else
+  {
+    for (size_t i = 0; i < sampleCount; ++i)
+    {
+      uint8_t *pDest = pBuf + sample + i * ((size_t)samplesPerPixel + sampleBitWidth / CHAR_BIT);
+      uint8_t *pSrc = pSampleBuf + i * sampleBitWidth / CHAR_BIT;
+      memcpy(pDest, pSrc, sampleBitWidth);
+    }
+  }
+}
+
+static uint32_t vcTiff_To8BitSample(double x)
+{
+  return uint32_t(udClamp(x, 0.0, 1.0) * 255.);
+}
+
+static uint32_t vcTiff_To8BitSample(uint64_t value, uint32_t nBits)
+{
+  if (nBits < 8)
+    return uint32_t(255ull * value / ((1ull << nBits) - 1));
+  if (nBits > 8)
+    return uint32_t(value >> (nBits - 8));
+  return (uint32_t)value;
+}
+
+static uint32_t vcTiff_To8BitSamplei(int64_t value, int32_t nBits)
+{
+  if (value < 0)
+    return 0;
+
+  if (nBits < 8)
+    return uint32_t(255ll * value / ((1ll << nBits) - 1));
+  if (nBits > 8)
+    return uint32_t(value >> (nBits - 8));
+  return (uint32_t)value;
+}
+
+static udError vcTiff_SampleDataToColour(vcTiffImageFormat const & format, vcTiffSampleData const & data, uint32_t *pColour)
+{
+  udError result;
+
+  if (pColour == nullptr)
+    UD_ERROR_SET(udE_InvalidParameter);
+
+  // We photometric is defined as colour map, we must have a colourmap loaded!
+  UD_ERROR_IF((format.ppColourPalette != nullptr) == (format.photometric == 2), udE_InvalidConfiguration);
+
+  switch (format.sampleFormat)
+  {
+    case SAMPLEFORMAT_INT:
+    {
+      if (format.photometric == vcTP_GreyScale_WhiteIsZero) // Assume data.samplesPerPixel == 1
+      {
+        uint32_t grey = 255 - vcTiff_To8BitSamplei(data.t_int64[0], format.bitsPerSample);
+        *pColour = 0xFF000000 | (grey) | (grey << 8) | (grey << 16);
+      }
+      else if (format.photometric == vcTP_GreyScale_BlackIsZero) // Assume data.samplesPerPixel == 1
+      {
+        uint32_t grey = vcTiff_To8BitSamplei(data.t_int64[0], format.bitsPerSample);
+        *pColour = 0xFF000000 | (grey) | (grey << 8) | (grey << 16);
+      }
+      else if (format.photometric == vcTP_RGB) // Assume data.samplesPerPixel == 3
+      {
+        uint32_t red = vcTiff_To8BitSamplei(data.t_int64[0], format.bitsPerSample);
+        uint32_t green = vcTiff_To8BitSamplei(data.t_int64[1], format.bitsPerSample);
+        uint32_t blue = vcTiff_To8BitSamplei(data.t_int64[2], format.bitsPerSample);
+        *pColour = 0xFF000000 | (red) | (green << 8) | (blue << 16);
+      }
+      else if (format.photometric == vcTP_ColourPalatte) // Assume data.samplesPerPixel == 1
+      {
+        uint32_t nColours = (1ul << format.bitsPerSample);
+        uint32_t index = uint32_t(data.t_int64[0]);
+        uint32_t red = (*format.ppColourPalette[index] >> 8);
+        uint32_t green = (*format.ppColourPalette[index] >> 8) + sizeof(uint16) * nColours;
+        uint32_t blue = (*format.ppColourPalette[index] >> 8) + sizeof(uint16) * nColours * 2;
+        *pColour = 0xFF000000 | (red) | (green << 8) | (blue << 16);
+      }
+      else if (format.samplesPerPixel == 4) // rgba
+      {
+        uint32_t red = vcTiff_To8BitSamplei(data.t_int64[0], format.bitsPerSample);
+        uint32_t green = vcTiff_To8BitSamplei(data.t_int64[1], format.bitsPerSample);
+        uint32_t blue = vcTiff_To8BitSamplei(data.t_int64[2], format.bitsPerSample);
+        uint32_t alpha = vcTiff_To8BitSamplei(data.t_int64[3], format.bitsPerSample);
+        *pColour = (red) | (green << 8) | (blue << 16) | (alpha << 24);
+      }
+      else
+      {
+        UD_ERROR_SET(udE_InvalidConfiguration);
+      }
+      break;
+    }
+    case SAMPLEFORMAT_UINT:
+    {
+      if (format.photometric == vcTP_GreyScale_WhiteIsZero) // Assume format.samplesPerPixel == 1
+      {
+        uint32_t grey = 255 - vcTiff_To8BitSample(data.t_uint64[0], format.bitsPerSample);
+        *pColour = 0xFF000000 | (grey) | (grey << 8) | (grey << 16);
+      }
+      else if (format.photometric == vcTP_GreyScale_BlackIsZero) // Assume format.samplesPerPixel == 1
+      {
+        uint32_t grey = vcTiff_To8BitSample(data.t_uint64[0], format.bitsPerSample);
+        *pColour = 0xFF000000 | (grey) | (grey << 8) | (grey << 16);
+      }
+      else if (format.photometric == vcTP_RGB) // Assume format.samplesPerPixel == 3
+      {
+        uint32_t red = vcTiff_To8BitSample(data.t_uint64[0], format.bitsPerSample);
+        uint32_t green = vcTiff_To8BitSample(data.t_uint64[1], format.bitsPerSample);
+        uint32_t blue = vcTiff_To8BitSample(data.t_uint64[2], format.bitsPerSample);
+        *pColour = 0xFF000000 | (red) | (green << 8) | (blue << 16);
+      }
+      else if (format.photometric == vcTP_ColourPalatte) // Assume format.samplesPerPixel == 1
+      {
+        uint32_t nColours = (1ul << format.bitsPerSample);
+        uint32_t index = uint32_t(data.t_uint64[0]);
+        uint32_t red = (*format.ppColourPalette[index] >> 8);
+        uint32_t green = (*format.ppColourPalette[index] >> 8) + sizeof(uint16) * nColours;
+        uint32_t blue = (*format.ppColourPalette[index] >> 8) + sizeof(uint16) * nColours * 2;
+        *pColour = 0xFF000000 | (red) | (green << 8) | (blue << 16);
+      }
+      else if (format.samplesPerPixel == 4) // rgba
+      {
+        uint32_t red = vcTiff_To8BitSample(data.t_uint64[0], format.bitsPerSample);
+        uint32_t green = vcTiff_To8BitSample(data.t_uint64[1], format.bitsPerSample);
+        uint32_t blue = vcTiff_To8BitSample(data.t_uint64[2], format.bitsPerSample);
+        uint32_t alpha = vcTiff_To8BitSample(data.t_uint64[3], format.bitsPerSample);
+        *pColour = (red) | (green << 8) | (blue << 16) | (alpha << 24);
+      }
+      else
+      {
+        UD_ERROR_SET(udE_InvalidConfiguration);
+      }
+      break;
+    }
+    case SAMPLEFORMAT_IEEEFP:
+    {
+      if (format.photometric == vcTP_GreyScale_WhiteIsZero) // Assume data.samplesPerPixel == 1
+      {
+        uint32_t grey = 255 - vcTiff_To8BitSample(data.t_double[0]);
+        *pColour = 0xFF000000 | (grey) | (grey << 8) | (grey << 16);
+      }
+      else if (format.photometric == vcTP_GreyScale_BlackIsZero) // Assume data.samplesPerPixel == 1
+      {
+        uint32_t grey = vcTiff_To8BitSample(data.t_double[0]);
+        *pColour = 0xFF000000 | (grey) | (grey << 8) | (grey << 16);
+      }
+      else if (format.photometric == vcTP_RGB) // Assume data.samplesPerPixel == 3
+      {
+        uint32_t red = vcTiff_To8BitSample(data.t_double[0]);
+        uint32_t green = vcTiff_To8BitSample(data.t_double[1]);
+        uint32_t blue = vcTiff_To8BitSample(data.t_double[2]);
+        *pColour = 0xFF000000 | (red) | (green << 8) | (blue << 16);
+      }
+      else if (format.photometric == vcTP_ColourPalatte) // Assume data.samplesPerPixel == 1
+      {
+        // Makes no sense to have a colour palette indexed by a double
+        UD_ERROR_SET(udE_InvalidConfiguration);
+      }
+      else if (format.samplesPerPixel == 4) // rgba
+      {
+        uint32_t red = vcTiff_To8BitSample(data.t_double[0]);
+        uint32_t green = vcTiff_To8BitSample(data.t_double[1]);
+        uint32_t blue = vcTiff_To8BitSample(data.t_double[2]);
+        uint32_t alpha = vcTiff_To8BitSample(data.t_double[3]);
+        *pColour = (red) | (green << 8) | (blue << 16) | (alpha << 24);
+      }
+      else
+      {
+        UD_ERROR_SET(udE_InvalidConfiguration);
+      }
+      break;
+    }
+  }
+
+  result = udE_Success;
+epilogue:
+  return result;
+}
+
+static udError vcTiff_DecodeSample(void * pBuf, uint64_t pixelIndex, vcTiffImageFormat const & format, uint32_t sampleIndex, vcTiffSampleData *pSample)
+{
+  udError result;
+
+  if (pBuf == nullptr || pSample == nullptr)
+    UD_ERROR_SET(udE_InvalidParameter);
+
+  if (format.bitsPerSample == 1)
+  {
+    // A 1-bit int or float makes no sense
+    UD_ERROR_IF(format.sampleFormat != SAMPLEFORMAT_UINT, udE_InvalidConfiguration);
+    uint64_t bitIndex = pixelIndex *format.samplesPerPixel + sampleIndex;
+    uint8_t byte = ((uint8_t *)pBuf)[bitIndex / 8];
+    uint64_t value = uint64_t(byte & (1 << (bitIndex % 8))) == 0 ? 0 : 1;
+    pSample->t_uint64[sampleIndex] = value;
+  }
+  else if (format.bitsPerSample == 2)
+  {
+    // Currently samples less than 8 bits must be uint
+    UD_ERROR_IF(format.sampleFormat != SAMPLEFORMAT_UINT, udE_InvalidConfiguration);
+    uint64_t bitIndex = pixelIndex * format.samplesPerPixel + sampleIndex;
+    uint8_t byte = ((uint8_t *)pBuf)[bitIndex / 4];
+    uint32_t shft = (bitIndex % 4) * 2;
+    uint64_t value = uint64_t((byte >> shft) & 0x3);
+    pSample->t_uint64[sampleIndex] = value;
+  }
+  else if (format.bitsPerSample == 4)
+  {
+    // Currently samples less than 8 bits must be uint
+    UD_ERROR_IF(format.sampleFormat != SAMPLEFORMAT_UINT, udE_InvalidConfiguration);
+    uint64_t bitIndex = pixelIndex * format.samplesPerPixel + sampleIndex;
+    uint8_t byte = ((uint8_t *)pBuf)[bitIndex / 2];
+    uint32_t shft = (bitIndex % 2) * 4;
+    uint64_t value = uint64_t((byte >> shft) & 0xF);
+    pSample->t_uint64[sampleIndex] = value;
+  }
+  else if (format.bitsPerSample == 8)
+  {
+    // Currently do not support 8-bit floats
+    uint64_t ind = pixelIndex * format.samplesPerPixel + sampleIndex;
+    if (format.sampleFormat == SAMPLEFORMAT_INT)
+      pSample->t_int64[sampleIndex] = ((int8_t *)(pBuf))[ind];
+    else if (format.sampleFormat == SAMPLEFORMAT_UINT)
+      pSample->t_uint64[sampleIndex] = ((uint8_t *)(pBuf))[ind];
+    else
+      UD_ERROR_SET(udE_InvalidConfiguration);
+  }
+  else if (format.bitsPerSample == 16)
+  {
+    // Currently do not support 16-bit floats
+    uint64_t ind = pixelIndex * format.samplesPerPixel + sampleIndex;
+    if (format.sampleFormat == SAMPLEFORMAT_INT)
+      pSample->t_int64[sampleIndex] = ((int16_t *)(pBuf))[ind];
+    else if (format.sampleFormat == SAMPLEFORMAT_UINT)
+      pSample->t_uint64[sampleIndex] = ((uint16_t *)(pBuf))[ind];
+    else
+      UD_ERROR_SET(udE_InvalidConfiguration);
+  }
+  else if (format.bitsPerSample == 32)
+  {
+    uint64_t ind = pixelIndex * format.samplesPerPixel + sampleIndex;
+    if (format.sampleFormat == SAMPLEFORMAT_INT)
+      pSample->t_int64[sampleIndex] = ((int32_t *)(pBuf))[ind];
+    else if (format.sampleFormat == SAMPLEFORMAT_UINT)
+      pSample->t_uint64[sampleIndex] = ((uint32_t *)(pBuf))[ind];
+    else if (format.sampleFormat == SAMPLEFORMAT_IEEEFP)
+      pSample->t_double[sampleIndex] = (double)((float *)(pBuf))[ind];
+    else
+      UD_ERROR_SET(udE_InvalidConfiguration);
+  }
+  else if (format.bitsPerSample == 64)
+  {
+    uint64_t ind = pixelIndex * format.samplesPerPixel + sampleIndex;
+    if (format.sampleFormat == SAMPLEFORMAT_INT)
+      pSample->t_int64[sampleIndex] = ((int64_t *)(pBuf))[ind];
+    else if (format.sampleFormat == SAMPLEFORMAT_UINT)
+      pSample->t_uint64[sampleIndex] = ((uint64_t *)(pBuf))[ind];
+    else if (format.sampleFormat == SAMPLEFORMAT_IEEEFP)
+      pSample->t_double[sampleIndex] = ((double *)(pBuf))[ind];
+    else
+      UD_ERROR_SET(udE_InvalidConfiguration);
+  }
+
+  result = udE_Success;
+epilogue:
+  return result;
+}
+
+static udError vcTiff_LoadTile(vcTiffConvertData *pData, uint32_t x, uint32_t y)
+{
+  udError result;
+  uint8_t *pBuf = nullptr;
+  uint32_t px, py;
+
+  UD_ERROR_NULL(pData, udE_InvalidParameter);
+
+  px = x * pData->tile.tileDimensions.x;
+  py = y * pData->tile.tileDimensions.y;
+
+  pData->tile.currentPixel = 0;
+  pData->tile.currentTileCoords = {x, y};
+
+  if (pData->format.planarconfig == PLANARCONFIG_CONTIG)
+  {
+    if (pData->tile.pRaster == nullptr)
+    {
+      pData->tile.pRaster = (uint8_t *)_TIFFmalloc(TIFFTileSize(pData->pTif));
+      UD_ERROR_NULL(pData->tile.pRaster, udE_MemoryAllocationFailure);
+    }
+    UD_ERROR_IF(TIFFReadTile(pData->pTif, pData->tile.pRaster, px, py, 0, 0) == 0, udE_ReadFailure);
+  }
+  else
+  {
+    if (pData->tile.pRaster == nullptr)
+    {
+      pData->tile.pRaster = (uint8_t *)_TIFFmalloc(TIFFTileSize(pData->pTif) * udMin(pData->format.samplesPerPixel, MAX_SAMPLES));
+      UD_ERROR_NULL(pData->tile.pRaster, udE_MemoryAllocationFailure);
+    }
+
+    size_t pixelCount = (size_t)pData->tile.tileDimensions.x * pData->tile.tileDimensions.y;
+    pBuf = (uint8 *)_TIFFmalloc(TIFFTileSize(pData->pTif)); // TODO could allocated this once per image
+    UD_ERROR_NULL(pBuf, udE_MemoryAllocationFailure);
+
+    for (uint16 i = 0; i < udMin(pData->format.samplesPerPixel, MAX_SAMPLES); ++i)
+    {
+      UD_ERROR_IF(TIFFReadTile(pData->pTif, pBuf, px, py, 0, i) == 0, udE_ReadFailure);
+      vcTiff_PackSamples(pData->tile.pRaster, pBuf, (uint32_t)pixelCount, pData->format.bitsPerSample, pData->format.samplesPerPixel, i);
+    }
+  }
+
+  result = udE_Success;
+epilogue:
+  _TIFFfree(pBuf);
+  return result;
+}
+
+static udError vcTiffImageReaderInit_Tile(vcTiffConvertData *pData)
+{
+  udError result;
+
+  if (pData == nullptr)
+    UD_ERROR_SET(udE_InvalidParameter);
+
+  pData->tile = {};
+
+  UD_ERROR_IF(TIFFGetField(pData->pTif, TIFFTAG_IMAGEWIDTH, &pData->imageDimensions.x) != 1, udE_ReadFailure);
+  UD_ERROR_IF(TIFFGetField(pData->pTif, TIFFTAG_IMAGELENGTH, &pData->imageDimensions.y) != 1, udE_ReadFailure);
+  UD_ERROR_IF(TIFFGetField(pData->pTif, TIFFTAG_TILEWIDTH, &pData->tile.tileDimensions.x) != 1, udE_ReadFailure);
+  UD_ERROR_IF(TIFFGetField(pData->pTif, TIFFTAG_TILELENGTH, &pData->tile.tileDimensions.y) != 1, udE_ReadFailure);
+
+  UD_ERROR_CHECK(vcTiff_LoadTile(pData, 0, 0));
+
+  result = udE_Success;
+epilogue:
+  return result;
+}
+
+static void vcTiffImageReaderDestroy_Tile(vcTiffConvertData *pData)
+{
+  if (pData == nullptr)
+    return;
+
+  _TIFFfree(pData->tile.pRaster);
+  pData->tile.pRaster = nullptr;
+}
+
+static udError vcTiffImageReaderReadPixel_Tile(vcTiffConvertData *pConvertData, vcTiffPixelData *pPixelData)
+{
+  udError result;
+  udDouble3 tileOrigin;
+  udDouble3 pixelCoords;
+  uint64_t tilePixelCount = (uint64_t)pConvertData->tile.tileDimensions.x * pConvertData->tile.tileDimensions.y;
+
+  if (pConvertData == nullptr || pPixelData == nullptr)
+    UD_ERROR_SET(udE_InvalidParameter);
+
+  if (pConvertData->tile.currentPixel >= tilePixelCount) // finished this tile
+  {
+    pConvertData->tile.currentPixel = 0;
+    pConvertData->tile.currentTileCoords.x++;
+    if (pConvertData->tile.currentTileCoords.x * pConvertData->tile.tileDimensions.x >= pConvertData->imageDimensions.x)
+    {
+      pConvertData->tile.currentTileCoords.x = 0;
+      pConvertData->tile.currentTileCoords.y++;
+
+      if (pConvertData->tile.currentTileCoords.y * pConvertData->tile.tileDimensions.y >= pConvertData->imageDimensions.y)
+        UD_ERROR_SET(udE_NotFound);
+    }
+    UD_ERROR_CHECK(vcTiff_LoadTile(pConvertData, pConvertData->tile.currentTileCoords.x, pConvertData->tile.currentTileCoords.y));
+  }
+  
+  pixelCoords.x = double(pConvertData->tile.currentPixel % pConvertData->tile.tileDimensions.x) * pConvertData->pointResolution;
+  pixelCoords.y = double(pConvertData->tile.currentPixel / pConvertData->tile.tileDimensions.x) * pConvertData->pointResolution;
+  pixelCoords.z = 0.0;
+  tileOrigin = {(double)pConvertData->tile.currentTileCoords.x * pConvertData->tile.tileDimensions.x, (double)pConvertData->tile.currentTileCoords.y * pConvertData->tile.tileDimensions.y};
+  tileOrigin *= pConvertData->pointResolution;
+
+  pPixelData->point = pConvertData->origin + tileOrigin + pixelCoords;
+
+  for (uint32_t i = 0; i < udMin(pConvertData->format.samplesPerPixel, MAX_SAMPLES); ++i)
+    UD_ERROR_CHECK(vcTiff_DecodeSample(pConvertData->tile.pRaster, pConvertData->tile.currentPixel, pConvertData->format, i, &pPixelData->sample));
+
+  ++pConvertData->tile.currentPixel;
+
+  result = udE_Success;
+epilogue:
+  return result;
+}
+
+static udError vcTiff_LoadScanLine(vcTiffConvertData *pData, uint32_t row)
+{
+  udError result;
+  uint8_t *pBuf = nullptr;
+
+  UD_ERROR_NULL(pData, udE_InvalidParameter);
+
+  pData->scanLine.currentPixel = 0;
+  pData->scanLine.row = row;
+
+  UD_ERROR_IF(pData->scanLine.row == pData->imageDimensions.y, udE_NotFound);
+
+  if (pData->format.planarconfig == PLANARCONFIG_CONTIG)
+  {
+    if (pData->scanLine.pRaster == nullptr)
+    {
+      pData->scanLine.pRaster = (uint8 *)_TIFFmalloc(TIFFScanlineSize(pData->pTif));
+      UD_ERROR_NULL(pData->scanLine.pRaster, udE_MemoryAllocationFailure);
+    }
+
+    UD_ERROR_IF(TIFFReadScanline(pData->pTif, pData->scanLine.pRaster, pData->scanLine.row) == 0, udE_ReadFailure);
+  }
+  else
+  {
+    if (pData->scanLine.pRaster == nullptr)
+    {
+      pData->scanLine.pRaster = (uint8 *)_TIFFmalloc(TIFFScanlineSize(pData->pTif) * udMin(pData->format.samplesPerPixel, MAX_SAMPLES));
+      UD_ERROR_NULL(pData->scanLine.pRaster, udE_MemoryAllocationFailure);
+    }
+
+    pBuf = (uint8 *)_TIFFmalloc(TIFFScanlineSize(pData->pTif));
+    UD_ERROR_NULL(pBuf, udE_MemoryAllocationFailure);
+
+    for (uint16 i = 0; i < pData->format.samplesPerPixel; ++i)
+    {
+      UD_ERROR_IF(TIFFReadScanline(pData->pTif, pBuf, pData->scanLine.row, i) == 0, udE_ReadFailure);
+      vcTiff_PackSamples(pData->scanLine.pRaster, pBuf, pData->imageDimensions.x, pData->format.bitsPerSample, pData->format.samplesPerPixel, i);
+    }
+  }
+
+  result = udE_Success;
+epilogue:
+  _TIFFfree(pBuf);
+  return result;
+}
+
+static udError vcTiffImageReaderInit_ScanLine(vcTiffConvertData *pData)
+{
+  udError result;
+  
+  UD_ERROR_NULL(pData, udE_InvalidParameter);
+
+  pData->scanLine.currentPixel = 0;
+
+  UD_ERROR_IF(TIFFGetField(pData->pTif, TIFFTAG_IMAGEWIDTH, &pData->imageDimensions.x) != 1, udE_ReadFailure);
+  UD_ERROR_IF(TIFFGetField(pData->pTif, TIFFTAG_IMAGELENGTH, &pData->imageDimensions.y) != 1, udE_ReadFailure);
+
+  UD_ERROR_CHECK(vcTiff_LoadScanLine(pData, 0));
+
+  result = udE_Success;
+epilogue:
+  /*if (result != udE_Success && pData != nullptr)
+  {
+    _TIFFfree(pData->scanLine.pRaster);
+    pData->scanLine.pRaster = nullptr;
+  }*/
+
+  return result;
+}
+
+static void vcTiffImageReaderDestroy_ScanLine(vcTiffConvertData *pData)
+{
+  if (pData == nullptr)
+    return;
+
+  _TIFFfree(pData->scanLine.pRaster);
+  pData->scanLine.pRaster = nullptr;
+}
+
+static udError vcTiffImageReaderReadPixel_ScanLine(vcTiffConvertData *pConvertData, vcTiffPixelData *pPixelData)
+{
+  udError result;
+  uint64_t x;
+  uint64_t y;
+
+  if (pConvertData == nullptr || pPixelData == nullptr)
+    UD_ERROR_SET(udE_InvalidParameter);
+
+  if (pConvertData->scanLine.currentPixel == pConvertData->imageDimensions.x)
+  {
+    UD_ERROR_IF(pConvertData->scanLine.row == pConvertData->imageDimensions.y, udE_NotFound);
+    UD_ERROR_CHECK(vcTiff_LoadScanLine(pConvertData, pConvertData->scanLine.row + 1));
+  }
+
+  x = pConvertData->scanLine.currentPixel;
+  y = pConvertData->scanLine.row;
+
+  pPixelData->point = pConvertData->origin + udDouble3::create((double)x * pConvertData->pointResolution, (double)y * pConvertData->pointResolution, 0.0);
+
+  for (uint32_t i = 0; i < udMin(pConvertData->format.samplesPerPixel, MAX_SAMPLES); ++i)
+    UD_ERROR_CHECK(vcTiff_DecodeSample(pConvertData->scanLine.pRaster, pConvertData->scanLine.currentPixel, pConvertData->format, i, &pPixelData->sample));
+
+  ++pConvertData->scanLine.currentPixel;
+
+  result = udE_Success;
+epilogue:
+  return result;
+}
 
 udError vcTiff_GetDirctoryCount(const char *pFileName, uint32_t *pDirectoryCount)
 {
@@ -191,21 +623,23 @@ static udError vcTiff_InitReader(vcTiffConvertData *pData)
 
   UD_ERROR_NULL(pData, udE_InvalidParameter);
 
-  delete pData->pReader;
-  pData->pReader = nullptr;
+  pData->pDestroy = nullptr;
+  pData->pRead = nullptr;
 
-  // TODO Has Image?
+  // Is tile image?
+  if (vcTiffImageReaderInit_Tile(pData) == udE_Success)
+  {
+    pData->pDestroy = vcTiffImageReaderDestroy_Tile;
+    pData->pRead = vcTiffImageReaderReadPixel_Tile;
+  }
+  else
+  {
+    UD_ERROR_CHECK(vcTiffImageReaderInit_ScanLine(pData));
+    pData->pDestroy = vcTiffImageReaderDestroy_ScanLine;
+    pData->pRead = vcTiffImageReaderReadPixel_ScanLine;
+  }
 
-  // TODO Is tile image?
-
-  // TODO Is scanline image?
-
-  // TODO Is strip image?
-
-  // Otherwise just try to load the whole image.
-  pData->pReader = new TiffFullImageReader();
-  pData->pReader->SetConvertDefaults(pData->origin, pData->pointResolution, pData->convertFlags);
-  UD_ERROR_CHECK(pData->pReader->Init(pData->pTiff));
+  // TODO Strip image (but currently should load as scanline)
 
   result = udE_Success;
 epilogue:
@@ -219,12 +653,14 @@ static udError vcTiff_LoadNextDirectory(vcTiffConvertData *pData)
   if (pData == nullptr)
     UD_ERROR_SET(udE_InvalidParameter);
 
-  delete pData->pReader;
-  pData->pReader = nullptr;
+  if (pData->pDestroy != nullptr)
+    pData->pDestroy(pData);
 
-  pData->currentDirectory++;
+  pData->pDestroy = nullptr;
+  pData->pRead = nullptr;
+  ++pData->currentDirectory;
 
-  UD_ERROR_IF(TIFFReadDirectory(pData->pTiff) == 0, udE_NotFound);
+  UD_ERROR_IF(TIFFReadDirectory(pData->pTif) == 0, udE_NotFound);
   UD_ERROR_CHECK(vcTiff_InitReader(pData));
 
   result = udE_Success;
@@ -232,20 +668,41 @@ epilogue:
   return result;
 }
 
+// TODO we should be able to add the point estimate here...
 udError TiffConvert_Open(struct udConvertCustomItem *pConvertInput, uint32_t everyNth, const double origin[3], double pointResolution, enum udConvertCustomItemFlags flags)
 {
   udError result = udE_Failure;
   vcTiffConvertData *pData = (vcTiffConvertData *)pConvertInput->pData;
+  uint32 imageDepth;
 
   UD_ERROR_CHECK(vcTiff_GetDirctoryCount(pConvertInput->pName, &pData->directoryCount));
 
-  pData->pTiff = TIFFOpen(pConvertInput->pName, "r");
-  UD_ERROR_NULL(pData->pTiff, udE_OpenFailure);
+  pData->pTif = TIFFOpen(pConvertInput->pName, "r");
+  UD_ERROR_NULL(pData->pTif, udE_OpenFailure);
 
   pData->pointResolution = pointResolution;
   pData->origin = {origin[0], origin[1], origin[2]};
   pData->everyNth = everyNth;
   pData->convertFlags = flags;
+
+  // TODO check for and deal with image depth; saved as (format.imageDepth)
+  // TODO retrieve colour map
+  UD_ERROR_IF(TIFFGetField(pData->pTif, TIFFTAG_BITSPERSAMPLE, &pData->format.bitsPerSample) != 1, udE_ReadFailure);
+  if (TIFFGetField(pData->pTif, TIFFTAG_SAMPLEFORMAT, &pData->format.sampleFormat) != 1)
+    pData->format.sampleFormat = SAMPLEFORMAT_UINT; // Just assume unsigned int
+
+  if (TIFFGetField(pData->pTif, TIFFTAG_IMAGEDEPTH, &imageDepth) != 1)
+    pData->format.imageDepth = uint32(imageDepth);
+  else
+    pData->format.imageDepth = -1;
+
+  UD_ERROR_IF(TIFFGetField(pData->pTif, TIFFTAG_SAMPLESPERPIXEL, &pData->format.samplesPerPixel) != 1, udE_ReadFailure);
+  UD_ERROR_IF(TIFFGetField(pData->pTif, TIFFTAG_PHOTOMETRIC, &pData->format.photometric) != 1, udE_ReadFailure);    // Will a tif always have this tag?
+
+  if (pData->format.photometric == PHOTOMETRIC_PALETTE)
+    UD_ERROR_IF(TIFFGetField(pData->pTif, TIFFTAG_COLORMAP, &pData->format.ppColourPalette) != 1, udE_InvalidConfiguration);
+
+  UD_ERROR_IF(TIFFGetField(pData->pTif, TIFFTAG_PLANARCONFIG, &pData->format.planarconfig) != 1, udE_ReadFailure);  // Will a tif always have this tag?
 
   UD_ERROR_CHECK(vcTiff_InitReader(pData));
 
@@ -258,9 +715,9 @@ udError TiffConvert_ReadFloat(struct udConvertCustomItem *pConvertInput, struct 
 {
   udError result;
   udError pixReadRes;
+  vcTiffPixelData pixelData = {};
+  uint32_t colour;
   vcTiffConvertData *pData = nullptr;
-  udDouble3 point = {};
-  uint32_t colour = 0;
 
   if (pConvertInput == nullptr || pBuffer == nullptr)
     UD_ERROR_SET(udE_InvalidParameter);
@@ -268,17 +725,17 @@ udError TiffConvert_ReadFloat(struct udConvertCustomItem *pConvertInput, struct 
   pData = (vcTiffConvertData *)pConvertInput->pData;
   pBuffer->pointCount = 0;
 
-  UD_ERROR_NULL(pData->pReader, udE_Success); // No reader = all done
+  UD_ERROR_NULL(pData->pRead, udE_Success); // No reader = all done
 
   while (true)
   {
-    if (pData->pReader == nullptr)
-      pixReadRes = udE_NotFound; // This would suggest 
+    if (pData->pRead == nullptr)
+      pixReadRes = udE_NotFound;
 
     if (pBuffer->pointCount == pBuffer->pointsAllocated)
       break;
 
-    pixReadRes = pData->pReader->GetNextPixel(&point, &colour);
+    pixReadRes = pData->pRead(pData, &pixelData);
 
     if (pixReadRes == udE_Success)
     {
@@ -287,13 +744,15 @@ udError TiffConvert_ReadFloat(struct udConvertCustomItem *pConvertInput, struct 
       if (pData->everyNth != 0 && pData->pointsProcessed % pData->everyNth != 0)
         continue;
 
-      pBuffer->pAttributes[pBuffer->pointCount * pBuffer->attributeStride + 0] = (colour & 0xFF);
-      pBuffer->pAttributes[pBuffer->pointCount * pBuffer->attributeStride + 1] = ((colour >> 8) & 0xFF);
-      pBuffer->pAttributes[pBuffer->pointCount * pBuffer->attributeStride + 2] = ((colour >> 16) & 0xFF);
+      UD_ERROR_CHECK(vcTiff_SampleDataToColour(pData->format, pixelData.sample, &colour));
 
-      pBuffer->pPositions[pBuffer->pointCount * 3 + 0] = point[0];
-      pBuffer->pPositions[pBuffer->pointCount * 3 + 1] = point[1];
-      pBuffer->pPositions[pBuffer->pointCount * 3 + 2] = point[2];
+      pBuffer->pAttributes[pBuffer->pointCount * pBuffer->attributeStride + 0] = uint8_t((colour >> 16) & 0xFF);
+      pBuffer->pAttributes[pBuffer->pointCount * pBuffer->attributeStride + 1] = uint8_t((colour >> 8)  & 0xFF);
+      pBuffer->pAttributes[pBuffer->pointCount * pBuffer->attributeStride + 2] = uint8_t((colour >> 0)  & 0xFF);
+
+      pBuffer->pPositions[pBuffer->pointCount * 3 + 0] = pixelData.point[0];
+      pBuffer->pPositions[pBuffer->pointCount * 3 + 1] = pixelData.point[1];
+      pBuffer->pPositions[pBuffer->pointCount * 3 + 2] = pixelData.point[2];
 
       ++pBuffer->pointCount;
     }
@@ -322,7 +781,7 @@ udError TiffConvert_ReadFloat(struct udConvertCustomItem *pConvertInput, struct 
 
   result = udE_Success;
 epilogue:
-  return udE_Success;
+  return result;
 }
 
 void TiffConvert_Destroy(struct udConvertCustomItem *pConvertInput)
@@ -331,10 +790,11 @@ void TiffConvert_Destroy(struct udConvertCustomItem *pConvertInput)
   udAttributeSet_Destroy(&pConvertInput->attributes);
   udFree(pConvertInput->pName);
 
-  delete pData->pReader;
-  if (pData->pTiff != nullptr)
-    TIFFClose(pData->pTiff);
-  memset(pData, 0, sizeof(vcTiffConvertData));
+  if (pData->pDestroy)
+    pData->pDestroy(pData);
+
+  if (pData->pTif != nullptr)
+    TIFFClose(pData->pTif);
 
   udFree(pData);
 }
@@ -343,33 +803,35 @@ void TiffConvert_Close(struct udConvertCustomItem *pConvertInput)
 {
   vcTiffConvertData *pData = (vcTiffConvertData *)pConvertInput->pData;
 
-  delete pData->pReader;
-  if (pData->pTiff != nullptr)
-    TIFFClose(pData->pTiff);
+  if (pData->pDestroy)
+    pData->pDestroy(pData);
+
+  if (pData->pTif != nullptr)
+    TIFFClose(pData->pTif);
+
   memset(pData, 0, sizeof(vcTiffConvertData));
 }
 
 udError vcTiff_AddItem(udConvertContext *pConvertContext, const char *pFilename)
 {
-  // Setup the custom item
-  udConvertCustomItem *pItem = udAllocType(udConvertCustomItem, 1, udAF_Zero);
+  udConvertCustomItem item = {};
   vcTiffConvertData *pData = udAllocType(vcTiffConvertData, 1, udAF_Zero);
 
-  pItem->pOpen = TiffConvert_Open;
-  pItem->pReadPointsFloat = TiffConvert_ReadFloat;
-  pItem->pDestroy = TiffConvert_Destroy;
-  pItem->pClose = TiffConvert_Close;
+  item.pOpen = TiffConvert_Open;
+  item.pReadPointsFloat = TiffConvert_ReadFloat;
+  item.pDestroy = TiffConvert_Destroy;
+  item.pClose = TiffConvert_Close;
 
-  pItem->pData = pData;
+  item.pData = pData;
 
-  pItem->pName = udStrdup(pFilename);
-  pItem->boundsKnown = false;
-  pItem->pointCount = -1;
-  pItem->pointCountIsEstimate = false;
+  item.pName = udStrdup(pFilename);
+  item.boundsKnown = false;
+  item.pointCount = -1;
+  item.pointCountIsEstimate = false;
 
-  pItem->sourceResolution = 0;
-  udAttributeSet_Create(&pItem->attributes, udSAC_ARGB, 0);
+  item.sourceResolution = 0;
+  udAttributeSet_Create(&item.attributes, udSAC_ARGB, 0);
 
   // Do the actual conversion
-  return udConvert_AddCustomItem(pConvertContext, pItem);
+  return udConvert_AddCustomItem(pConvertContext, &item);
 }


### PR DESCRIPTION
Fixes [AB#2334](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2334) 

Supports a lot more of the tiff spec, but does not yet support geotiff. Currently supports:
 - pulling all images from all internal directories
 - general image loading
 - optimised loading tiled image data
 - 1, 2, 4, 8, 16, 32 and 64-bit uint samples (pixel channels)
 - 2, 4, 8, 16, 32 and 64-bit int samples
 - 32 and 64-bit float samples
 - up to 4 samples per pixel
 - Grey scale images 
 - RGB images
 - Palettized images
 - Samples stored contiguous or separately 
