### PR TITLE
Optimization for SHP file loading

### DIFF
--- a/src/vcSHP.cpp
+++ b/src/vcSHP.cpp
@@ -151,7 +151,7 @@ udResult vcSHP_LoadShpRecord(vcSHP *pSHP, uint8_t **ppReadPosition, vcSHPType de
 
   record.Init();
   
-  UD_ERROR_IF(*pLeftLength < sizeof(int32_t) * 2, udR_ReadFailure);
+  UD_ERROR_IF(*pLeftLength < int32_t(sizeof(int32_t) * 2), udR_ReadFailure);
   memcpy(id, *ppReadPosition, sizeof(int32_t));
   memcpy(length, *ppReadPosition + sizeof(int32_t), sizeof(int32_t));
 

--- a/src/vcSHP.cpp
+++ b/src/vcSHP.cpp
@@ -349,7 +349,6 @@ udResult vcSHP_LoadShpFile(vcSHP *pSHP, const char *pFilename)
     UD_ERROR_CHECK(udFile_Read(pFile, cache0, totalRecordLength));
 
     pReadPosition = cache0;
-    printf("total %d bytes has been read \n", totalRecordLength);
 
     while (leftLength > 0)
     {
@@ -366,8 +365,6 @@ udResult vcSHP_LoadShpFile(vcSHP *pSHP, const char *pFilename)
     int32_t leftLength = 0;
     uint8_t *lastCache = nullptr;
     int32_t lastCacheSize = 0;
-
-    printf("total %d bytes to read \n", totalRecordLength);
 
     while (bytesToRead > 0)
     {
@@ -402,7 +399,6 @@ udResult vcSHP_LoadShpFile(vcSHP *pSHP, const char *pFilename)
       //read some bytes
       UD_ERROR_CHECK(udFile_Read(pFile, *ppCurrentCache + leftLength, cacheSize-leftLength));
       bytesToRead -= (cacheSize - leftLength);
-      printf("%d bytes has been read, left %d\n", (cacheSize - leftLength), bytesToRead);
 
       //read cache to records
       pReadPosition = *ppCurrentCache;


### PR DESCRIPTION
To read 100M content or a record larger than 100M at a time, instead of reading records one by one. This change is for loading files from URL.
And the data structure also has been reorganized to make the code more concise.
[AB#2270](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2270).