### PR TITLE
Filter Shape Name Change

### DIFF
--- a/src/scene/vcQueryNode.cpp
+++ b/src/scene/vcQueryNode.cpp
@@ -149,20 +149,6 @@ void vcQueryNode::HandleSceneExplorerUI(vcState *pProgramState, size_t *pItemID)
 {
   bool changed = false;
 
-  const char *filterShapeNames[] = { vcString::Get("sceneFilterShapeBox"), vcString::Get("sceneFilterShapeCylinder"), vcString::Get("sceneFilterShapeSphere") };
-  int shape = m_shape;
-  if (ImGui::Combo(udTempStr("%s##FilterShape%zu", vcString::Get("sceneFilterShape"), *pItemID), &shape, filterShapeNames, (int)udLengthOf(filterShapeNames)))
-  {
-    // Change name if is still default
-    const char *defaultShapeNames[] = { vcString::Get("sceneExplorerFilterBoxDefaultName"), vcString::Get("sceneExplorerFilterCylinderDefaultName"), vcString::Get("sceneExplorerFilterSphereDefaultName") };
-    if (udStrEqual(m_pNode->pName, defaultShapeNames[m_shape]))
-      udProjectNode_SetName(pProgramState->activeProject.pProject, m_pNode, defaultShapeNames[shape]);
-    
-    changed = true;
-    m_shape = (vcQueryNodeFilterShape)shape;
-    udProjectNode_SetMetadataString(m_pNode, "shape", GetNodeShape(m_shape));
-  }
-
   ImGui::InputScalarN(udTempStr("%s##FilterPosition%zu", vcString::Get("sceneFilterPosition"), *pItemID), ImGuiDataType_Double, &m_center.x, 3);
   changed |= ImGui::IsItemDeactivatedAfterEdit();
 

--- a/src/scene/vcQueryNode.cpp
+++ b/src/scene/vcQueryNode.cpp
@@ -12,18 +12,6 @@
 #include "imgui.h"
 #include "imgui_ex/vcImGuiSimpleWidgets.h"
 
-static const char *GetNodeShape(vcQueryNodeFilterShape shape)
-{
-  if (shape == vcQNFS_Box)
-    return "box";
-  else if (shape == vcQNFS_Sphere)
-    return "sphere";
-  else if (shape == vcQNFS_Cylinder)
-    return "cylinder";
-  else
-    return "";
-}
-
 vcQueryNode::vcQueryNode(vcProject *pProject, udProjectNode *pNode, vcState *pProgramState) :
   vcSceneItem(pProject, pNode, pProgramState),
   m_shape(vcQNFS_Box),

--- a/src/scene/vcQueryNode.cpp
+++ b/src/scene/vcQueryNode.cpp
@@ -153,6 +153,11 @@ void vcQueryNode::HandleSceneExplorerUI(vcState *pProgramState, size_t *pItemID)
   int shape = m_shape;
   if (ImGui::Combo(udTempStr("%s##FilterShape%zu", vcString::Get("sceneFilterShape"), *pItemID), &shape, filterShapeNames, (int)udLengthOf(filterShapeNames)))
   {
+    // Change name if is still default
+    const char *defaultShapeNames[] = { vcString::Get("sceneExplorerFilterBoxDefaultName"), vcString::Get("sceneExplorerFilterCylinderDefaultName"), vcString::Get("sceneExplorerFilterSphereDefaultName") };
+    if (udStrEqual(m_pNode->pName, defaultShapeNames[m_shape]))
+      udProjectNode_SetName(pProgramState->activeProject.pProject, m_pNode, defaultShapeNames[shape]);
+    
     changed = true;
     m_shape = (vcQueryNodeFilterShape)shape;
     udProjectNode_SetMetadataString(m_pNode, "shape", GetNodeShape(m_shape));


### PR DESCRIPTION
- Filters change names to the appropriate default shape name if their shape changes and their name is still default
- Fixes [AB#2386](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2386)