### PR TITLE
Markdown Description/Hyperlink display

### DIFF
--- a/src/scene/vcPOI.cpp
+++ b/src/scene/vcPOI.cpp
@@ -887,13 +887,7 @@ void vcPOI::HandleSceneEmbeddedUI(vcState *pProgramState)
     ImGui::Unindent();
   }
 
-  if (m_hyperlink[0] != '\0' && ImGui::Button(udTempStr("%s '%s'", vcString::Get("scenePOILabelOpenHyperlink"), m_hyperlink)))
-  {
-    if (udStrEndsWithi(m_hyperlink, ".png") || udStrEndsWithi(m_hyperlink, ".jpg"))
-      pProgramState->pLoadImage = udStrdup(m_hyperlink);
-    else
-      vcWebFile_OpenBrowser(m_hyperlink);
-  }
+  vcIGSW_Markdown(pProgramState, udTempStr("%s\n[%s](%s)", m_description, m_hyperlink, m_hyperlink));
 }
 
 void vcPOI::HandleContextMenu(vcState *pProgramState)


### PR DESCRIPTION
- Working with hyperlink displayed below description
- Turn Markdown description into a markdown
- Fixes [AB#2397](https://dev.azure.com/euclideon/57c3bd2a-8f94-4578-b195-2e4fa9d8f295/_workitems/edit/2397)